### PR TITLE
Particle IO Bugfix

### DIFF
--- a/src/Cello/io_OutputData.cpp
+++ b/src/Cello/io_OutputData.cpp
@@ -309,7 +309,7 @@ void OutputData::write_particle_data
       // write the batch to disk
       file_->data_write(buffer);
       
-      if (mb > 0) file_->mem_close();
+      file_->mem_close();
     }
 
     // check that the number of particles equals the number written
@@ -320,7 +320,7 @@ void OutputData::write_particle_data
 	     np == i0);
 
     // close the attribute dataset
-    if (np > 0) file_->data_close();
+    file_->data_close();
   }
 
 }


### PR DESCRIPTION
Bugfix in particle output when number of particles is zero. The associated groups in the HDF5 output file would still be created in this instance, but not closed properly. This caused a lock on the output file after IO was over unless the simulation completed with a clean exit. If not, the output data was corrupted.

One other solution is to not create the groups in the first place if the number of particles is zero, but this would lead to inconsistencies in data format if a simulation starts without particles but forms some later on. I prefer creating the (empty) groups if user requests particle output but there happen to be no particles. 