### PR TITLE
Style change in Cello block name

### DIFF
--- a/src/Cello/mesh_Index.cpp
+++ b/src/Cello/mesh_Index.cpp
@@ -440,10 +440,14 @@ std::string Index::bit_string(int max_level,int rank, const int nb3[3]) const
 
   for (int axis=0; axis<rank; axis++) {
 
-    for (int i=nb3[axis]-1; i>=0; i--) {
-      int shift = (level >= 0) ? i : i-level;
-      int bit = (a_[axis].array & ( 1 << shift));
-      bits = bits + (bit?"1":"0");
+    if(nb3[axis]-1 < 0){
+      bits = bits + "0";
+    } else{
+      for (int i=nb3[axis]-1; i>=0; i--) {
+        int shift = (level >= 0) ? i : i-level;
+        int bit = (a_[axis].array & ( 1 << shift));
+        bits = bits + (bit?"1":"0");
+      }
     }
 
     for (int i=0; i<max_level; i++) {


### PR DESCRIPTION
Changes style in the instance of running with only a single root-grid block (e.g. `root_block = [1,1,1]`). This is likely never going to happen in any real run since that means running on a single core, but could be possible if doing development tests (as I am doing).

Previously the root grid block name in this case would be   B___, but this changes the name to B0_0_0, which I feel is a bit more consistent with how the naming convention works when there are more than one root blocks, and is more consistent with the refined levels when there is only one root block.

Additionally, this fixes an issue with the Enzo-P frontend in yt, which looks specifically for the B?_?_? naming convention. Sims with `root_block = [1,1,1]` would fail to be recognized because of this. 

In addition, the comments in the yt frontend indicated to me that B___ blocks are assumed to be at a negative refinement level. I'm not too sure of what this actually means on the Enzo-E side of things though, but if this is the case then this also fixes confusion there.

Let me know if this change is worthwhile. Or if there should just be some modifications to the yt front-end to catch this edge case.


