### PR TITLE
Face-Centered Field IO Bugfix

### DIFF
--- a/src/Cello/data_FieldFace.hpp
+++ b/src/Cello/data_FieldFace.hpp
@@ -146,11 +146,13 @@ public: // interface
 
   /// Compute loop limits for copy, load, or store if accumulate == false
   void loop_limits
-  (int i3[3], int n3[3], const int m3[3], const int g3[3], int refresh_type);
+  (int i3[3], int n3[3], const int m3[3], const int g3[3], const int c3[3],
+   int refresh_type);
 
   /// Compute loop limits for copy, load, or store if accumulate == true
   void loop_limits_accumulate
-  (int i3[3], int n3[3], const int m3[3], const int g3[3], int refresh_type);
+  (int i3[3], int n3[3], const int m3[3], const int g3[3], const int c3[3],
+   int refresh_type);
 
   //--------------------------------------------------
 

--- a/src/Cello/io_IoFieldData.cpp
+++ b/src/Cello/io_IoFieldData.cpp
@@ -83,11 +83,14 @@ void IoFieldData::field_array
 
   field_descr->ghost_depth(field_index_,&ngx,&ngy,&ngz);
 
+  int cx=0,cy=0,cz=0;
+  field_descr->centering(field_index_,&cx,&cy,&cz);
+
   if (field_data_->ghosts_allocated()) {
 
-    if (nxd) (*nxd) = nbx + 2*ngx;
-    if (nyd) (*nyd) = nby + 2*ngy;
-    if (nzd) (*nzd) = nbz + 2*ngz;
+    if (nxd) (*nxd) = nbx + 2*ngx + cx;
+    if (nyd) (*nyd) = nby + 2*ngy + cy;
+    if (nzd) (*nzd) = nbz + 2*ngz + cz;
 
     // Exclude ghosts when writing
 
@@ -97,19 +100,19 @@ void IoFieldData::field_array
 
     // Include ghosts when writing
 
-     if (nx) (*nx) = nbx + 2*ngx;
-     if (ny) (*ny) = nby + 2*ngy;
-     if (nz) (*nz) = nbz + 2*ngz;
+     if (nx) (*nx) = nbx + 2*ngx + cx;
+     if (ny) (*ny) = nby + 2*ngy + cy;
+     if (nz) (*nz) = nbz + 2*ngz + cz;
 
   } else {
 
-    if (nxd) (*nxd) = nbx;
-    if (nyd) (*nyd) = nby;
-    if (nzd) (*nzd) = nbz;
+    if (nxd) (*nxd) = nbx + cx;
+    if (nyd) (*nyd) = nby + cy;
+    if (nzd) (*nzd) = nbz + cz;
 
-    if (nx) (*nx) = nbx;
-    if (ny) (*ny) = nby;
-    if (nz) (*nz) = nbz;
+    if (nx) (*nx) = nbx + cx;
+    if (ny) (*ny) = nby + cy;
+    if (nz) (*nz) = nbz + cz;
 
   }
 }


### PR DESCRIPTION
Addresses the bug in saving face-centered fields to HDF5 files that caused the data to be clipped. This occurred because the IoFieldData::field_array method (which retrieved field data and its iteration limits for copying the data to the hdf5 file) determines the iteration limits by calling FieldData::size and it never checked the field's centering (which effectively assumes that all fields are face-centered).

The bugfix now has IoFieldData::field_array check field centering and adjusts the iteration limits accordingly.