### PR TITLE
Enable CI testing with circleci

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,0 +1,101 @@
+version: 2.1
+
+commands:
+  set-env:
+    description: "Set environment variables."
+    steps:
+      - run: |
+          echo 'export LD_LIBRARY_PATH=$HOME/local/lib:$LD_LIBRARY_PATH' >> $BASH_ENV
+          echo 'export CELLO_ARCH=linux_gnu' >> $BASH_ENV
+          echo 'export CELLO_PREC=double' >> $BASH_ENV
+          echo 'export HDF5_INC=/usr/include/hdf5/serial' >> $BASH_ENV
+          echo 'export HDF5_LIB=/usr/lib/x86_64-linux-gnu' >> $BASH_ENV
+          echo 'export CHARM_HOME=$HOME/local/charm-6.9.0' >> $BASH_ENV
+          echo 'export GRACKLE_HOME=$HOME/local' >> $BASH_ENV
+          # tag the tip so we can go back to it
+          git tag tip
+
+  install-dependencies:
+    description: "Install dependencies."
+    steps:
+      - run: |
+          source $BASH_ENV
+          sudo apt-get update
+          sudo apt-get install -y bc csh libhdf5-serial-dev gfortran libtool-bin libpapi-dev libpng-dev libboost-all-dev
+          # apt-get installs hdf5 libraries with _serial
+          sudo ln -s /usr/lib/x86_64-linux-gnu/libhdf5_serial.so /usr/lib/x86_64-linux-gnu/libhdf5.so
+          # Install charm++
+          mkdir -p $HOME/local
+          if [ ! -f $HOME/local/charm-6.9.0/bin/charmrun ]; then
+            cd $HOME/local
+            wget http://charm.cs.illinois.edu/distrib/charm-6.9.0.tar.gz
+            tar xvfz charm-6.9.0.tar.gz
+            rm charm-6.9.0.tar.gz
+            cd charm-6.9.0
+            ./build charm++ netlrts-linux-x86_64 -j4 --with-production
+          fi
+
+  install-grackle:
+    description: "Install grackle."
+    steps:
+      - run: |
+          git clone -b master https://github.com/grackle-project/grackle $HOME/grackle
+          cd $HOME/grackle
+          ./configure
+          cd src/clib
+          make machine-linux-gnu
+          make
+          make install
+
+  build-and-test:
+    description: "Compile enzo-e and run tests."
+    parameters:
+      tag:
+        type: string
+        default: tip
+      skipfile:
+        type: string
+        default: ""
+    steps:
+      - run: |
+          source $BASH_ENV
+          if [ ! -f << parameters.skipfile >> ]; then
+            git checkout << parameters.tag >>
+            make
+          fi
+
+jobs:
+  test-suite:
+    docker:
+      - image: circleci/python:3.7.2
+
+    working_directory: ~/enzo-e
+
+    steps:
+      - checkout
+      - set-env
+
+      - restore_cache:
+          name: "Restore dependencies cache."
+          key: dependencies-v1
+
+      - install-dependencies
+
+      - save_cache:
+          name: "Save dependencies cache"
+          key: dependencies-v1
+          paths:
+            - ~/local
+
+      - install-grackle
+
+      - build-and-test:
+          tag: tip
+          skipfile: notafile
+
+workflows:
+   version: 2
+
+   tests:
+     jobs:
+       - test-suite

--- a/build.sh
+++ b/build.sh
@@ -222,7 +222,6 @@ d=`date "+%H:%M:%S"`
 
 rm -f test/STATUS
 
-
-
-
-
+if [ ! -e $target ]; then
+   exit 1
+fi

--- a/config/linux_gnu.py
+++ b/config/linux_gnu.py
@@ -54,9 +54,9 @@ if charm_path is None:
 		else:
 			raise Exception('Charm++ was not found.  Try setting the CHARM_HOME environment variable.')
 
-use_papi=1                
-papi_inc = '/usr/include'
-papi_lib = '/usr/lib'
+use_papi = 1
+papi_inc = os.getenv('PAPI_INC', '/usr/include')
+papi_lib = os.getenv('PAPI_LIB', '/usr/lib')
 
 hdf5_inc = os.getenv('HDF5_INC')
 if hdf5_inc is None:

--- a/config/linux_gnu.py
+++ b/config/linux_gnu.py
@@ -24,7 +24,7 @@ f90 = 'gfortran'
 flags_prec_single = ''
 flags_prec_double = '-fdefault-real-8 -fdefault-double-8'
 
-libpath_fortran = '.'
+libpath_fortran = '/usr/lib/x86_64-linux-gnu'
 libs_fortran    = ['gfortran']
 
 home = os.getenv('HOME')
@@ -76,9 +76,10 @@ if hdf5_lib is None:
 	else:
 		raise Exception('HDF5 lib file was not found.  Try setting the HDF5_LIB environment variable such that $HDF5_LIB/libhdf5.a exists.')
 
-png_path = os.getenv('LIBPNG_HOME')
-if png_path is None:
-	png_path     = '/lib/x86_64-linux-gnu'
+png_path = os.getenv('LIBPNG_HOME', '/lib/x86_64-linux-gnu')
+
+boost_inc = os.getenv('BOOST_INC', '/usr/include/boost')
+boost_lib = os.getenv('BOOST_LIB', '/usr/lib/x86_64-linux-gnu')
 
 grackle_path = os.getenv('GRACKLE_HOME')
 if grackle_path is None:


### PR DESCRIPTION
This provides some initial testing with the CircleCI service. Currently, this will only compile the code, but we can add the testing bit later.

I also added the ability to set PAPI paths to the linux_gnu makefile and simplified a couple things.