### PR TITLE
Fixed bugs related to compiling enzo-e without grackle

### DIFF
--- a/SConstruct
+++ b/SConstruct
@@ -277,6 +277,7 @@ python_lt_27 = 0
 sys.path.append("./config");
 
 flags_arch_cpp = ''
+flags_arch_fortran = ''
 flags_config = ''
 flags_cxx = ''
 flags_cc = ''
@@ -495,7 +496,7 @@ cflags   = cflags + ' ' + flags_cc
 cflags   = cflags + ' ' + flags_config
 cflags   = cflags + ' ' + flags_cc_charm
 
-fortranflags = flags_arch
+fortranflags = flags_arch + ' ' + flags_arch_fortran
 fortranflags = fortranflags + ' ' + flags_fc
 fortranflags = fortranflags + ' ' + flags_config
 fortranflags = fortranflags + ' ' + flags_fc_charm

--- a/config/linux_gnu.py
+++ b/config/linux_gnu.py
@@ -18,6 +18,9 @@ flags_arch = '-Wall -O3 -g -ffast-math -funroll-loops -fPIC'
 #flags_link_charm = '-memory paranoid'
 #flags_link_charm = '-fprofile-arcs' # gcov
 
+#optional fortran flag
+flags_arch_fortran = '-ffixed-line-length-132'
+
 cc  = 'gcc '
 f90 = 'gfortran'
 

--- a/src/Enzo/_enzo.hpp
+++ b/src/Enzo/_enzo.hpp
@@ -209,11 +209,7 @@ extern "C" {
 
 #include "enzo_EnzoInitialCollapse.hpp"
 #include "enzo_EnzoInitialCosmology.hpp"
-
-#ifdef CONFIG_USE_GRACKLE
-  #include "enzo_EnzoInitialGrackleTest.hpp"
-#endif
-
+#include "enzo_EnzoInitialGrackleTest.hpp"
 #include "enzo_EnzoInitialImplosion2.hpp"
 #include "enzo_EnzoInitialMusic.hpp"
 #include "enzo_EnzoInitialPm.hpp"

--- a/src/Enzo/enzo_EnzoConfig.cpp
+++ b/src/Enzo/enzo_EnzoConfig.cpp
@@ -119,8 +119,8 @@ EnzoConfig::EnzoConfig() throw ()
   // EnzoMethodTurbulence
   method_turbulence_edot(0.0),
   method_turbulence_mach_number(0.0),
-#ifdef CONFIG_USE_GRACKLE
   method_grackle_use_grackle(false),
+#ifdef CONFIG_USE_GRACKLE
   method_grackle_chemistry(),
   method_grackle_use_cooling_timestep(false),
   method_grackle_radiation_redshift(-1.0),
@@ -323,8 +323,8 @@ void EnzoConfig::pup (PUP::er &p)
   p | units_length;
   p | units_time;
 
-#ifdef CONFIG_USE_GRACKLE
   p  | method_grackle_use_grackle;
+#ifdef CONFIG_USE_GRACKLE
   p  | method_grackle_use_cooling_timestep;
   p  | method_grackle_radiation_redshift;
 
@@ -794,12 +794,12 @@ void EnzoConfig::read(Parameters * p) throw()
   // GRACKLE 3.0
   //======================================================================
 
+  this->method_grackle_use_grackle = false;
 #ifdef CONFIG_USE_GRACKLE
 
 
   /// Grackle parameters
 
-  this->method_grackle_use_grackle = false;
   for (size_t i=0; i<method_list.size(); i++) {
     if (method_list[i] == "grackle") method_grackle_use_grackle=true;
   }

--- a/src/Enzo/enzo_EnzoConfig.hpp
+++ b/src/Enzo/enzo_EnzoConfig.hpp
@@ -206,8 +206,8 @@ public: // interface
       method_turbulence_edot(0.0),
       method_turbulence_mach_number(0.0),
       // EnzoMethodGrackle
-#ifdef CONFIG_USE_GRACKLE
       method_grackle_use_grackle(false),
+#ifdef CONFIG_USE_GRACKLE
       method_grackle_chemistry(),
       method_grackle_use_cooling_timestep(false),
       method_grackle_radiation_redshift(-1.0),
@@ -394,6 +394,14 @@ public: // attributes
   double                     method_turbulence_edot;
   double                     method_turbulence_mach_number;
 
+  /// EnzoMethodGrackle
+  bool                       method_grackle_use_grackle;
+#ifdef CONFIG_USE_GRACKLE
+  chemistry_data *           method_grackle_chemistry;
+  bool                       method_grackle_use_cooling_timestep;
+  double                     method_grackle_radiation_redshift;
+#endif /* CONFIG_USE_GRACKLE */
+
   /// EnzoMethodGravity
   double                     method_gravity_grav_const;
   std::string                method_gravity_solver;
@@ -454,14 +462,6 @@ public: // attributes
 
   /// Stop at specified redshift for cosmology
   double                     stopping_redshift;
-
-
-#ifdef CONFIG_USE_GRACKLE
-  bool             method_grackle_use_grackle;
-  chemistry_data * method_grackle_chemistry;
-  bool             method_grackle_use_cooling_timestep;
-  double           method_grackle_radiation_redshift;
-#endif /* CONFIG_USE_GRACKLE */
 
 };
 

--- a/src/Enzo/enzo_EnzoMethodGrackle.cpp
+++ b/src/Enzo/enzo_EnzoMethodGrackle.cpp
@@ -647,6 +647,6 @@ void EnzoMethodGrackle::ResetEnergies ( EnzoBlock * enzo_block) throw()
 
   return;
 }
-#endif CONFIG_USE_GRACKLE
+#endif //CONFIG_USE_GRACKLE
 
 //======================================================================


### PR DESCRIPTION
Made changes to allow for compilation without grackle installation. 

Also made a minor tweak to the SConstruct file and config/linux_gnu.py to address a problem with compiling the fortran files.