### PR TITLE
Grackle bugfix

### DIFF
--- a/SConstruct
+++ b/SConstruct
@@ -295,7 +295,6 @@ elif (arch == "gordon_intel"): from gordon_intel import *
 elif (arch == "gordon_pgi"):   from gordon_pgi   import *
 elif (arch == "comet_gnu"):    from comet_gnu    import *
 elif (arch == "linux_gnu"):    from linux_gnu    import *
-elif (arch == "linux_illium"): from linux_illium import *
 elif (arch == "linux_intel"):  from linux_intel  import *
 elif (arch == "linux_yt"):     from linux_yt     import *
 elif (arch == "linux_gprof"):  from linux_gprof  import *

--- a/src/Enzo/enzo_EnzoMethodGrackle.cpp
+++ b/src/Enzo/enzo_EnzoMethodGrackle.cpp
@@ -17,7 +17,8 @@ EnzoMethodGrackle::EnzoMethodGrackle
   const double physics_cosmology_initial_redshift,
   const double time
 )
-  : Method()
+  : Method(),
+    grackle_units_(), grackle_chemistry_data_defined_(false)
 {
 #ifdef CONFIG_USE_GRACKLE
 
@@ -156,12 +157,12 @@ void EnzoMethodGrackle::compute ( Block * block) throw()
 
     this->compute_(enzo_block);
 
-    enzo_block->compute_done();
-
     if (simulation)
       simulation->performance()->stop_region(perf_grackle,__FILE__,__LINE__);
   #endif
   }
+
+  block->compute_done();
 
   return;
 


### PR DESCRIPTION
Fixing bug that cause simulation to hang using Grackle method in AMR runs. compute_done now properly called.