### PR TITLE
Updated Stampede Build Files

### DIFF
--- a/config/_common_search_paths.py
+++ b/config/_common_search_paths.py
@@ -1,28 +1,26 @@
 import os
 
+def _check_dirs(search_paths):
+        for search_path in search_paths:
+                if os.path.isdir(search_path):
+                        return path
+        return None
+
 def charm_path_search(home):
 	# function that searches for charm_path in locations common across
 	# multiple architectures
 	charm_path = os.getenv('CHARM_HOME')
 
 	if (charm_path is None) and (home is not None):
-		if os.path.isdir(home + '/Charm/charm'):
-			charm_path = home + '/Charm/charm'
-		elif os.path.isdir(home + '/charm'):
-			charm_path = home + '/charm'
-		elif os.path.isdir(home + '/local/charm'):
-			charm_path = home + '/local/charm'
-		elif os.path.isdir(home + '/src/charm'):
-			charm_path = home + '/src/charm'
-		elif os.path.isdir(home + '/source/charm'):
-			charm_path = home + '/source/charm'
+                temp = ['Charm/charm', 'charm', 'local/charm', 'src/charm',
+                        'source/charm']
+                paths = [os.path.join(home, elem) for elem in temp]
+                charm_path = _check_dirs(paths)
 	if charm_path is None:
-		if os.path.isdir('/usr/local/charm'):
-			charm_path = '/usr/local/charm'
-		elif os.path.isdir('/opt/charm'):
-			charm_path = '/opt/charm'
-		else:
-			raise Exception('Charm++ was not found.	 Try setting the CHARM_HOME environment variable.')
+                charm_path = _check_dirs(['/usr/local/charm', '/opt/charm'])
+                if charm_path is None:
+			raise Exception('Charm++ was not found.	Try setting '
+                                        'the CHARM_HOME environment variable.')
 	return charm_path
 
 def grackle_path_search(home):
@@ -30,21 +28,11 @@ def grackle_path_search(home):
 	# multiple architectures
 	grackle_path = os.getenv('GRACKLE_HOME')
 	if (grackle_path is None) and (home is not None):
-		if os.path.isdir(home + '/Grackle/src/clib'):
-			grackle_path = home + '/Grackle/src/clib'
-		elif os.path.isdir(home + '/grackle/src/clib'):
-			grackle_path = home + '/grackle/src/clib'
-		elif os.path.isdir(home + '/local/grackle/src/clib'):
-			grackle_path = home + '/local/grackle/src/clib'
-		elif os.path.isdir(home + '/src/grackle/src/clib'):
-			grackle_path = home + '/src/grackle/src/clib'
-		elif os.path.isdir(home + '/source/grackle/src/clib'):
-			grackle_path = home + '/source/grackle/src/clib'
-		elif os.path.isdir(home + '/Software/Grackle/src/clib'):
-			grackle_path = home + '/Software/Grackle/src/clib'
+                temp = ['Grackle', 'grackle', 'local/grackle',
+                        'src/grackle', 'source/grackle', 'Software/Grackle']
+                paths = [os.path.join(home, elem, 'src/clib') for elem in temp]
+                grackle_path = _check_dirs(paths)
 	if grackle_path is None:
-		if os.path.isdir('/usr/local/grackle/src/clib'):
-			grackle_path = '/usr/local/grackle/src/clib'
-		elif os.path.isdir('/opt/grackle/src/clib'):
-			grackle_path = '/opt/grackle/src/clib'
+                grackle_path = _check_dirs(['/usr/local/grackle/src/clib',
+                                            '/opt/grackle/src/clib'])
 	return grackle_path

--- a/config/_common_search_paths.py
+++ b/config/_common_search_paths.py
@@ -1,0 +1,50 @@
+import os
+
+def charm_path_search(home):
+	# function that searches for charm_path in locations common across
+	# multiple architectures
+	charm_path = os.getenv('CHARM_HOME')
+
+	if (charm_path is None) and (home is not None):
+		if os.path.isdir(home + '/Charm/charm'):
+			charm_path = home + '/Charm/charm'
+		elif os.path.isdir(home + '/charm'):
+			charm_path = home + '/charm'
+		elif os.path.isdir(home + '/local/charm'):
+			charm_path = home + '/local/charm'
+		elif os.path.isdir(home + '/src/charm'):
+			charm_path = home + '/src/charm'
+		elif os.path.isdir(home + '/source/charm'):
+			charm_path = home + '/source/charm'
+	if charm_path is None:
+		if os.path.isdir('/usr/local/charm'):
+			charm_path = '/usr/local/charm'
+		elif os.path.isdir('/opt/charm'):
+			charm_path = '/opt/charm'
+		else:
+			raise Exception('Charm++ was not found.	 Try setting the CHARM_HOME environment variable.')
+	return charm_path
+
+def grackle_path_search(home):
+	# function that searches for grackle_path in locations common across
+	# multiple architectures
+	grackle_path = os.getenv('GRACKLE_HOME')
+	if (grackle_path is None) and (home is not None):
+		if os.path.isdir(home + '/Grackle/src/clib'):
+			grackle_path = home + '/Grackle/src/clib'
+		elif os.path.isdir(home + '/grackle/src/clib'):
+			grackle_path = home + '/grackle/src/clib'
+		elif os.path.isdir(home + '/local/grackle/src/clib'):
+			grackle_path = home + '/local/grackle/src/clib'
+		elif os.path.isdir(home + '/src/grackle/src/clib'):
+			grackle_path = home + '/src/grackle/src/clib'
+		elif os.path.isdir(home + '/source/grackle/src/clib'):
+			grackle_path = home + '/source/grackle/src/clib'
+		elif os.path.isdir(home + '/Software/Grackle/src/clib'):
+			grackle_path = home + '/Software/Grackle/src/clib'
+	if grackle_path is None:
+		if os.path.isdir('/usr/local/grackle/src/clib'):
+			grackle_path = '/usr/local/grackle/src/clib'
+		elif os.path.isdir('/opt/grackle/src/clib'):
+			grackle_path = '/opt/grackle/src/clib'
+	return grackle_path

--- a/config/linux_gnu.py
+++ b/config/linux_gnu.py
@@ -1,5 +1,6 @@
 
 import os
+from _common_search_paths import charm_path_search, grackle_path_search
 
 is_arch_valid = 1
 
@@ -32,30 +33,10 @@ libs_fortran    = ['gfortran']
 
 home = os.getenv('HOME')
 
-charm_path = os.getenv('CHARM_HOME')
-
 # use Charm++ with randomized message queues for debugging and stress-testing
 # charm_path = home + '/Charm/charm.random'
 
-if charm_path is None:
-	if home is not None:
-		if os.path.isdir(home + '/Charm/charm'):
-			charm_path = home + '/Charm/charm'
-		elif os.path.isdir(home + '/charm'):
-			charm_path = home + '/charm'
-		elif os.path.isdir(home + '/local/charm'):
-			charm_path = home + '/local/charm'
-		elif os.path.isdir(home + '/src/charm'):
-			charm_path = home + '/src/charm'
-		elif os.path.isdir(home + '/source/charm'):
-			charm_path = home + '/source/charm'
-	if charm_path is None:
-		if os.path.isdir('/usr/local/charm'):
-			charm_path = '/usr/local/charm'
-		elif os.path.isdir('/opt/charm'):
-			charm_path = '/opt/charm'
-		else:
-			raise Exception('Charm++ was not found.  Try setting the CHARM_HOME environment variable.')
+charm_path = charm_path_search(home)
 
 # use_papi = 1
 # papi_inc = os.getenv('PAPI_INC', '/usr/include')
@@ -84,23 +65,4 @@ png_path = os.getenv('LIBPNG_HOME', '/lib/x86_64-linux-gnu')
 boost_inc = os.getenv('BOOST_INC', '/usr/include/boost')
 boost_lib = os.getenv('BOOST_LIB', '/usr/lib/x86_64-linux-gnu')
 
-grackle_path = os.getenv('GRACKLE_HOME')
-if grackle_path is None:
-	if home is not None:
-		if os.path.isdir(home + '/Grackle/src/clib'):
-			grackle_path = home + '/Grackle/src/clib'
-		elif os.path.isdir(home + '/grackle/src/clib'):
-			grackle_path = home + '/grackle/src/clib'
-		elif os.path.isdir(home + '/local/grackle/src/clib'):
-			charm_path = home + '/local/grackle/src/clib'
-		elif os.path.isdir(home + '/src/grackle/src/clib'):
-			grackle_path = home + '/src/grackle/src/clib'
-		elif os.path.isdir(home + '/source/grackle/src/clib'):
-			grackle_path = home + '/source/grackle/src/clib'
-		elif os.path.isdir(home + '/Software/Grackle/src/clib'):
-			grackle_path = home + '/Software/Grackle/src/clib'
-	if grackle_path is None:
-		if os.path.isdir('/usr/local/grackle/src/clib'):
-			grackle_path = '/usr/local/grackle/src/clib'
-		elif os.path.isdir('/opt/grackle/src/clib'):
-			grackle_path = '/opt/grackle/src/clib'
+grackle_path = grackle_path_search(home)

--- a/config/linux_intel.py
+++ b/config/linux_intel.py
@@ -1,5 +1,6 @@
 
 import os
+from _common_search_paths import charm_path_search, grackle_path_search
 
 is_arch_valid = 1
 
@@ -24,27 +25,7 @@ libs_fortran    = ['ifcore', 'ifport']
 
 home = os.getenv('HOME')
 
-charm_path = os.getenv('CHARM_HOME')
-
-if charm_path is None:
-	if home is not None:
-		if os.path.isdir(home + '/Charm/charm'):
-			charm_path = home + '/Charm/charm'
-		elif os.path.isdir(home + '/charm'):
-			charm_path = home + '/charm'
-		elif os.path.isdir(home + '/local/charm'):
-			charm_path = home + '/local/charm'
-		elif os.path.isdir(home + '/src/charm'):
-			charm_path = home + '/src/charm'
-		elif os.path.isdir(home + '/source/charm'):
-			charm_path = home + '/source/charm'
-	if charm_path is None:
-		if os.path.isdir('/usr/local/charm'):
-			charm_path = '/usr/local/charm'
-		elif os.path.isdir('/opt/charm'):
-			charm_path = '/opt/charm'
-		else:
-			raise Exception('Charm++ was not found.  Try setting the CHARM_HOME environment variable.')
+charm_path = charm_path_search(home)
 
 use_papi=0
 papi_inc = '/usr/local/include'
@@ -72,23 +53,4 @@ png_path = os.getenv('LIBPNG_HOME')
 if png_path is None:
 	png_path     = '/lib/x86_64-linux-gnu'
 
-grackle_path = os.getenv('GRACKLE_HOME')
-if grackle_path is None:
-	if home is not None:
-		if os.path.isdir(home + '/Grackle/src/clib'):
-			grackle_path = home + '/Grackle/src/clib'
-		elif os.path.isdir(home + '/grackle/src/clib'):
-			grackle_path = home + '/grackle/src/clib'
-		elif os.path.isdir(home + '/local/grackle/src/clib'):
-			charm_path = home + '/local/grackle/src/clib'
-		elif os.path.isdir(home + '/src/grackle/src/clib'):
-			grackle_path = home + '/src/grackle/src/clib'
-		elif os.path.isdir(home + '/source/grackle/src/clib'):
-			grackle_path = home + '/source/grackle/src/clib'
-		elif os.path.isdir(home + '/Software/Grackle/src/clib'):
-			grackle_path = home + '/Software/Grackle/src/clib'
-	if grackle_path is None:
-		if os.path.isdir('/usr/local/grackle/src/clib'):
-			grackle_path = '/usr/local/grackle/src/clib'
-		elif os.path.isdir('/opt/grackle/src/clib'):
-			grackle_path = '/opt/grackle/src/clib'
+grackle_path_search = grackle_path_search(home)

--- a/config/stampede_gnu.py
+++ b/config/stampede_gnu.py
@@ -1,5 +1,5 @@
 import os
-
+from _common_search_paths import charm_path_search, grackle_path_search
 is_arch_valid = 1
 
 #python_lt_27 = 1
@@ -7,6 +7,9 @@ is_arch_valid = 1
 flags_arch = '-O3 -Wall -g'
 #flags_arch = '-Wall -g'
 flags_link  = '-rdynamic'
+
+#optional fortran flag
+flags_arch_fortran = '-ffixed-line-length-132'
 
 cc   = 'gcc'
 f90  = 'gfortran'
@@ -21,9 +24,14 @@ libs_fortran    = ['gfortran']
 
 home = os.environ['HOME']
 
-hdf5_path    = os.environ['HDF5HOME']
-hdf5_inc = hdf5_path + '/include'
-hdf5_lib = hdf5_path + '/lib'
+hdf5_path = os.getenv('HDF5HOME',None)
+if hdf5_path is not None:
+	hdf5_inc = hdf5_path + '/include'
+	hdf5_lib = hdf5_path + '/lib'
+else:
+	# the following environment variables are set by the hdf5 module
+	hdf5_inc = os.environ['TACC_HDF5_INC']
+	hdf5_lib = os.environ['TACC_HDF5_LIB']
 
 boost_path = os.environ['BOOST_ROOT']
 boost_inc = boost_path + '/include'
@@ -39,9 +47,22 @@ boost_lib = boost_path + '/lib'
 #
 #--------------------------------------------------
 
-charm_path   = home + '/Charm/682/gnu/omni/charm'
-papi_inc = home + '/include'
-papi_lib = home + '/lib'
+if os.path.isdir(home + '/Charm/682/gnu/omni/charm'):
+	charm_path = home + '/Charm/682/gnu/omni/charm'
+else:
+	charm_path = charm_path_search(home)
+
+if ((os.getenv("TACC_PAPI_LIB", None) is not None) and
+    (os.getenv("TACC_PAPI_INC", None) is not None)):
+	papi_inc = os.environ["TACC_PAPI_INC"]
+	papi_lin = os.environ["TACC_PAPI_LIB"]
+else:
+	papi_inc = home + '/include'
+	papi_lib = home + '/lib'
 
 png_path     = '/usr/lib64'
-grackle_path = home + '/public/Grackle/src/clib'
+
+if os.path.isdir(home + '/public/Grackle/src/clib'):
+	grackle_path = home + '/public/Grackle/src/clib'
+else:
+	grackle_path = grackle_path_search(home)

--- a/config/stampede_intel.py
+++ b/config/stampede_intel.py
@@ -1,11 +1,20 @@
 import os
+from _common_search_paths import charm_path_search, grackle_path_search
 
 is_arch_valid = 1
 
-#python_lt_27 = 1
+#vec_flags = '-xCORE-AVX2 '   # mimimum instructions supported by all nodes
+#vec_flags = '-xCORE-AVX512 ' # only supports SKX login & compute nodes
+#vec_flags = '-xMIC-AVX512 '  # only supports KNL compute nodes
+# As recommended by the stampede user-guide the following builds a "fat"
+# binary including code paths for both SKX and KNL that is selected at
+# execution. It's more flexible, but has (~20%) longer compile times and
+# produces larger binaries and (which may be slightly slower than targetting
+# one architecture.
+vec_flags = '-xCORE-AVX2 -axCORE-AVX512,MIC-AVX512 '
 
-flags_arch = '-Ofast -g -Wall'
-flags_link  = '-rdynamic'
+flags_arch = vec_flags + '-Ofast -g -Wall'
+flags_link = '-rdynamic'
 
 cc   = 'icc'
 f90  = 'ifort'
@@ -19,10 +28,16 @@ libs_fortran    = ['irc', 'imf','ifcore','ifport','stdc++','intlc','svml']
 
 home = os.environ['HOME']
 
-hdf5_path    = os.environ['HDF5HOME']
-hdf5_inc = hdf5_path + '/include'
-hdf5_lib = hdf5_path + '/lib'
+hdf5_path = os.getenv('HDF5HOME',None)
+if hdf5_path is not None:
+	hdf5_inc = hdf5_path + '/include'
+	hdf5_lib = hdf5_path + '/lib'
+else:
+	# the following environment variables are set by the hdf5 module
+	hdf5_inc = os.environ['TACC_HDF5_INC']
+	hdf5_lib = os.environ['TACC_HDF5_LIB']
 
+# the BOOST_ROOT environment variable is defined by the the boost module
 boost_path = os.environ['BOOST_ROOT']
 boost_inc = boost_path + '/include'
 boost_lib = boost_path + '/lib'
@@ -37,9 +52,22 @@ boost_lib = boost_path + '/lib'
 #
 #--------------------------------------------------
 
-charm_path   = home + '/Charm/682/intel/omni/charm'
-papi_inc = home + '/include'
-papi_lib = home + '/lib'
+if os.path.isdir(home + '/Charm/682/intel/omni/charm'):
+	charm_path = home + '/Charm/682/intel/omni/charm'
+else:
+	charm_path = charm_path_search(home)
+
+if ((os.getenv("TACC_PAPI_LIB", None) is not None) and
+    (os.getenv("TACC_PAPI_INC", None) is not None)):
+	papi_inc = os.environ["TACC_PAPI_INC"]
+	papi_lin = os.environ["TACC_PAPI_LIB"]
+else:
+	papi_inc = home + '/include'
+	papi_lib = home + '/lib'
 
 png_path     = '/usr/lib64'
-grackle_path = home + '/public/Grackle/src/clib'
+
+if os.path.isdir(home + '/public/Grackle/src/clib'):
+	grackle_path = home + '/public/Grackle/src/clib'
+else:
+	grackle_path = grackle_path_search(home)


### PR DESCRIPTION
I updated the configuration files (`stampede_gnu.py` and `stampede_intel.py`) for building Enzo-E on Stampede2 and I have confirmed that Enzo-E is successfully compiled using both compilers. Additionally, I factored out the duplicate code used to search for the ``charm_path`` and ``grackle_path``, from the ``linux_gnu.py`` and ``linux_intel.py`` configuration files into dedicated functions in ``_common_search_paths.py`` (these functions are now used in all four of these configuration files).

I just wanted to note that when building on stampede2, using either compiler, Scons raises an error (detailed in Issue #28 ). This error arises at the very end of the installation and doesn't seem to have any actual effect.