### PR TITLE
Tweak to .gitignore and adding wraparound to documentation

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -19,3 +19,13 @@ errors.org
 warnings.org
 test/CHARM_BUILD
 test/CHARM_VERSION
+
+# ignore directories used for building branches
+build-*/Cello/*
+build-*/Enzo/*
+build-*/External/*
+build-*/SConscript
+
+# ignore the binaries
+bin/enzo-p
+bin/enzo-p.prev

--- a/doc/source/_static/theme_overrides.css
+++ b/doc/source/_static/theme_overrides.css
@@ -1,0 +1,15 @@
+/* taken from https://github.com/readthedocs/sphinx_rtd_theme/issues/117
+ * - override table width restrictions */
+@media screen and (min-width: 767px) {
+
+  .wy-table-responsive table td {
+    /* !important prevents the common CSS stylesheets from
+       overriding this as on RTD they are loaded after this stylesheet */
+    white-space: normal !important;
+  }
+
+  .wy-table-responsive {
+    overflow: visible !important;
+  }
+
+}

--- a/doc/source/conf.py
+++ b/doc/source/conf.py
@@ -260,3 +260,13 @@ epub_copyright = u'2019, James Bordner'
 
 # Example configuration for intersphinx: refer to the Python standard library.
 intersphinx_mapping = {'http://docs.python.org/': None}
+
+# taken from https://github.com/readthedocs/sphinx_rtd_theme/issues/117
+# to solve the issue related to the tables not wrapping
+html_static_path = ['_static']
+
+html_context = {
+    'css_files': [
+        '_static/theme_overrides.css',  # overrides for wide tables in RTD theme
+        ],
+    }


### PR DESCRIPTION
I modified the .gitignore file to ignore directories and binaries created during the build process.

I also modified the document generation files to enable text wrap-around in documentation. Prior to this change, tables are stretched out such that text in a given cell sits on a single line. This isn't a problem for the current documentation, but it becomes problematic in the new documentation included in Pull Request #9.

To provide an example, here is how a table is currently rendered:
![old_version](https://user-images.githubusercontent.com/28722054/74390886-8483fc00-4dd0-11ea-8ff5-c6f1fe780751.jpg)
And here is how a table is rendered after the change:
![with_wraparound](https://user-images.githubusercontent.com/28722054/74390904-949bdb80-4dd0-11ea-9bc6-393a9f513fb3.jpg)

