### PR TITLE
Fixed a bug that had prevented the use of the grackle cooling timestep.

### DIFF
--- a/input/method_grackle.in
+++ b/input/method_grackle.in
@@ -142,7 +142,8 @@
       list = [ "grackle", "null"];
 
      grackle {
-        courant = 0.40;
+        courant = 0.40; # meaningless unless use_cooling_timestep = true;
+
         data_file = "CloudyData_UVB=HM2012_shielded.h5";
 
         with_radiative_cooling = 1;
@@ -152,11 +153,15 @@
         self_shielding_method  = 3;  # 0 - 3 (0 or 3 recommended)
 
         HydrogenFractionByMass = 0.73;
+
+        # set this to true to limit the maximum timestep to the product of the
+        # minimum cooling/heating time and courant.
+        use_cooling_timestep = false; # default is false
      }
 
-     # use this to limit maximum timestep if
-     # Grackle crashes due to max iteration limit - this is not
-     # needed generally in a real simulation as hydro timestep will
+     # use this to limit maximum timestep if grackle::use_cooling_timestep is
+     # set to false and Grackle crashes due to max iteration limit - this is
+     # not needed generally in a real simulation as hydro timestep will
      # be small (usually)
      null { dt = 100.0; }
 

--- a/src/Enzo/enzo_EnzoMethodGrackle.hpp
+++ b/src/Enzo/enzo_EnzoMethodGrackle.hpp
@@ -93,7 +93,7 @@ public: // interface
   { return "grackle"; }
 
   /// Compute maximum timestep for this method
-  virtual double timestep ( Block * block) throw();
+  virtual double timestep ( Block * block) const throw();
 
 #ifdef CONFIG_USE_GRACKLE
 


### PR DESCRIPTION
The main issue was that `EnzoMethodGrackle`'s `timestep` instance method, declared in `src/Enzo/enzo_EnzoMethodGrackle.hpp` and implemented in `src/Enzo/enzo_EnzoMethodGrackle.cpp`, was not const-qualified. In contrast, the virtual method declared in the `Method` super-class (the one Cello uses to compute the timestep) is const-qualified. As a result, the old implementation had been providing an unused overload of the `timestep` method. When Cello was calling the `timestep` method of an instance of `EnzoMethodGrackle`, the default implementation provided for `Method::timestep` was used, which simply returned `std::numeric_limits<double>::max()`.

This bugfix can be tested by adding setting the Method::grackle::use_cooling_timestep parameter to true in `input/method_grackle.in`. Prior to this commit, changing this value will have no effect on the number of cycles that the simulation will run for. When the changes from this commit are included and the parameter is set to true, then the simulation will run for many,many more cycles.