### PR TITLE
Threadsafe Grackle Changes

### DIFF
--- a/src/Cello/problem_Problem.cpp
+++ b/src/Cello/problem_Problem.cpp
@@ -783,6 +783,16 @@ Physics * Problem::physics (std::string type) const throw()
 
 //----------------------------------------------------------------------
 
+Method * Problem::method (std::string name) const throw()
+{
+  for (size_t i=0; i<method_list_.size(); i++) {
+    if (method_list_[i]->name() == name) return method_list_[i];
+  }
+  return NULL;
+}
+
+//----------------------------------------------------------------------
+
 Compute * Problem::create_compute
   ( std::string name,
     Config * config ) throw ()

--- a/src/Cello/problem_Problem.hpp
+++ b/src/Cello/problem_Problem.hpp
@@ -131,6 +131,9 @@ public: // interface
   Method * method(size_t i) const throw() 
   { return (i < method_list_.size()) ? method_list_[i] : NULL; }
 
+  /// Return the named method object if present
+  Method * method (std::string name) const throw();
+
   /// Return the prolong object
   Prolong * prolong() const throw()  { return prolong_; }
 

--- a/src/Enzo/enzo.cpp
+++ b/src/Enzo/enzo.cpp
@@ -22,6 +22,12 @@ namespace enzo {
     return (EnzoPhysicsCosmology *) problem()->physics("cosmology");
   }
 
+  const EnzoMethodGrackle * grackle_method()
+  {
+    if (!enzo::config()->method_grackle_use_grackle) {return NULL;}
+    return (const EnzoMethodGrackle *) problem()->method("grackle");
+  }
+
   EnzoUnits * units()
   {
     return (EnzoUnits *) problem()->units();

--- a/src/Enzo/enzo.hpp
+++ b/src/Enzo/enzo.hpp
@@ -58,6 +58,7 @@ namespace enzo {
   EnzoProblem * problem();
   EnzoSimulation * simulation();
   EnzoPhysicsCosmology * cosmology();
+  const EnzoMethodGrackle * grackle_method();
   EnzoUnits * units();
   const EnzoConfig * config();
   CProxy_EnzoBlock block_array();

--- a/src/Enzo/enzo_EnzoComputeCoolingTime.cpp
+++ b/src/Enzo/enzo_EnzoComputeCoolingTime.cpp
@@ -69,45 +69,12 @@ void EnzoComputeCoolingTime::compute_(Block * block,
                                       grackle_field_data * grackle_fields /* NULL */
                                     )
 {
-  EnzoBlock * enzo_block = enzo::block(block);
-
-  Field field = enzo_block->data()->field();
-
-  const int in = cello::index_static();
-  const EnzoConfig * enzo_config = enzo::config();
-
-
   ASSERT("EnzoComputeCoolingTime::compute_()",
          "Grackle must be enabled in order to compute the cooling time",
-         enzo_config->method_grackle_use_grackle );
-
-  code_units grackle_units_;
-  grackle_field_data grackle_fields_;
-
-  // setup grackle units if they are not already provided
-  if (!grackle_units){
-    grackle_units = &grackle_units_;
-    EnzoMethodGrackle::setup_grackle_units(enzo_block, grackle_units, i_hist_);
-  }
-
-  // if grackle fields are not provided, define them
-  bool delete_grackle_fields = false;
-  if (!grackle_fields){
-    grackle_fields  = &grackle_fields_;
-    EnzoMethodGrackle::setup_grackle_fields(enzo_block, grackle_fields, i_hist_);
-    delete_grackle_fields = true;
-  }
-
-  // temperature is returned in units of K
-  if (calculate_cooling_time(&grackle_units_, &grackle_fields_, ct) == ENZO_FAIL){
-    ERROR("EnzoComputeCoolingTime::compute_()",
-          "Error in call to Grackle's compute_temperature routine.\n");
-  }
-
-  if (delete_grackle_fields){
-    EnzoMethodGrackle::delete_grackle_fields(grackle_fields);
-  }
-  return;
+         enzo::config()->method_grackle_use_grackle );
+  const EnzoMethodGrackle* grackle_method = enzo::grackle_method();
+  grackle_method->calculate_cooling_time(block, ct, grackle_units,
+					 grackle_fields, i_hist_);
 }
 
 #endif

--- a/src/Enzo/enzo_EnzoComputePressure.cpp
+++ b/src/Enzo/enzo_EnzoComputePressure.cpp
@@ -87,36 +87,9 @@ void EnzoComputePressure::compute_(Block * block,
 
   if (enzo::config()->method_grackle_use_grackle){
 #ifdef CONFIG_USE_GRACKLE
-    code_units grackle_units_;
-    grackle_field_data grackle_fields_;
-
-    // setup grackle units if they are not already provided
-    if (!grackle_units){
-      grackle_units = &grackle_units_;
-      EnzoMethodGrackle::setup_grackle_units(enzo_block, grackle_units, i_hist_);
-    }
-
-    // if grackle fields are not provided, define them
-    bool delete_grackle_fields = false;
-    if (!grackle_fields){
-      grackle_fields  = &grackle_fields_;
-  		// NOTE: Add option here to pass history index to setup to
-		//       allow for computation of old baryon fields ....
-		//       this way we can facilitate computation of
-		//       interpolated (in time) fields
-      EnzoMethodGrackle::setup_grackle_fields(enzo_block, grackle_fields, i_hist_);
-      delete_grackle_fields = true;
-    }
-
-    // Compute pressure in Grackle
-    if (calculate_pressure(grackle_units, grackle_fields, p) == ENZO_FAIL){
- 		  ERROR("EnzoComputePressure::compute_()",
-	          "Error in call to Grackle's calculate_pressure routine.\n");
-    }
-
-    if (delete_grackle_fields){
-      EnzoMethodGrackle::delete_grackle_fields(grackle_fields);
-    }
+    const EnzoMethodGrackle* grackle_method = enzo::grackle_method();
+    grackle_method->calculate_pressure(block, p, grackle_units,
+				       grackle_fields, i_hist_);
 #else
     ERROR("EnzoComputePressure::compute_()",
           "Attempting to compute pressure with method Grackle " 

--- a/src/Enzo/enzo_EnzoComputeTemperature.cpp
+++ b/src/Enzo/enzo_EnzoComputeTemperature.cpp
@@ -94,35 +94,9 @@ void EnzoComputeTemperature::compute_(Block * block,
   if (enzo::config()->method_grackle_use_grackle){
 
 #ifdef CONFIG_USE_GRACKLE
-    code_units grackle_units_;
-    grackle_field_data grackle_fields_;
-
-    // setup grackle units if they are not already provided
-    if (!grackle_units){
-      grackle_units = &grackle_units_;
-      EnzoMethodGrackle::setup_grackle_units(enzo_block, grackle_units, i_hist_);
-    }
-
-    // if grackle fields are not provided, define them
-    bool delete_grackle_fields = false;
-    if (!grackle_fields){
-      grackle_fields  = &grackle_fields_;
-      EnzoMethodGrackle::setup_grackle_fields(enzo_block, grackle_fields, i_hist_);
-      delete_grackle_fields = true;
-    }
-
-    // Note: compute pressure is handled internally in Grackle.
-    //       Do not need to recompute this here
-
-    // temperature is returned in units of K
-    if (calculate_temperature(grackle_units, grackle_fields, t) == ENZO_FAIL){
-      ERROR("EnzoComputeTemperature::compute_()",
-            "Error in call to Grackle's compute_temperature routine.\n");
-    }
-
-    if (delete_grackle_fields){
-      EnzoMethodGrackle::delete_grackle_fields(grackle_fields);
-    }
+    const EnzoMethodGrackle* grackle_method = enzo::grackle_method();
+    grackle_method->calculate_temperature(block, t, grackle_units,
+					  grackle_fields, i_hist_);
 #else
     ERROR("EnzoComputeTemperature::compute_()",
           "Attempting to compute temperature with method Grackle "

--- a/src/Enzo/enzo_EnzoConfig.cpp
+++ b/src/Enzo/enzo_EnzoConfig.cpp
@@ -168,8 +168,10 @@ EnzoConfig::EnzoConfig() throw ()
 EnzoConfig::~EnzoConfig() throw ()
 {
 #ifdef CONFIG_USE_GRACKLE
-  delete[] method_grackle_chemistry->grackle_data_file;
-  delete method_grackle_chemistry;
+  if (method_grackle_chemistry){
+    delete[] method_grackle_chemistry->grackle_data_file;
+    delete method_grackle_chemistry;
+  }
 #endif // CONFIG_USE_GRACKLE
 }
 

--- a/src/Enzo/enzo_EnzoConfig.cpp
+++ b/src/Enzo/enzo_EnzoConfig.cpp
@@ -168,6 +168,7 @@ EnzoConfig::EnzoConfig() throw ()
 EnzoConfig::~EnzoConfig() throw ()
 {
 #ifdef CONFIG_USE_GRACKLE
+  free(method_grackle_chemistry->grackle_data_file);
   delete method_grackle_chemistry;
 #endif // CONFIG_USE_GRACKLE
 }
@@ -340,10 +341,7 @@ void EnzoConfig::pup (PUP::er &p)
       method_grackle_chemistry->use_grackle = method_grackle_use_grackle;
 
       if(method_grackle_chemistry->use_grackle){
-        if (set_default_chemistry_parameters(method_grackle_chemistry) == ENZO_FAIL){
-          ERROR("EnzoMethodConfig::pup()",
-                "Error in Grackle set_default_chemistry_parameters");
-        }
+        *method_grackle_chemistry = _set_default_chemistry_parameters();
       }
     }
   }
@@ -808,17 +806,13 @@ void EnzoConfig::read(Parameters * p) throw()
   if (method_grackle_use_grackle) {
 
     method_grackle_chemistry = new chemistry_data;
-
-    if (set_default_chemistry_parameters(method_grackle_chemistry) == ENZO_FAIL) {
-      ERROR("EnzoMethodGrackle::EnzoMethodGrackle()",
-      "Error in set_default_chemistry_parameters");
-    }
+    *method_grackle_chemistry = _set_default_chemistry_parameters();
 
     /* this must be set AFTER default values are set */
     method_grackle_chemistry->use_grackle = method_grackle_use_grackle;
 
     // Copy over parameters from Enzo-P to Grackle
-    grackle_data->Gamma = field_gamma;
+    method_grackle_chemistry->Gamma = field_gamma;
 
     //
     method_grackle_use_cooling_timestep = p->value_logical
@@ -829,118 +823,118 @@ void EnzoConfig::read(Parameters * p) throw()
       ("Method:grackle:radiation_redshift", -1.0);
 
     // Set Grackle parameters from parameter file
-    grackle_data->with_radiative_cooling = p->value_integer
+    method_grackle_chemistry->with_radiative_cooling = p->value_integer
       ("Method:grackle:with_radiative_cooling",
-        grackle_data->with_radiative_cooling);
+        method_grackle_chemistry->with_radiative_cooling);
 
-    grackle_data->primordial_chemistry = p->value_integer
+    method_grackle_chemistry->primordial_chemistry = p->value_integer
       ("Method:grackle:primordial_chemistry",
-        grackle_data->primordial_chemistry);
+        method_grackle_chemistry->primordial_chemistry);
 
-    grackle_data->metal_cooling = p->value_integer
+    method_grackle_chemistry->metal_cooling = p->value_integer
       ("Method:grackle:metal_cooling",
-        grackle_data->metal_cooling);
+        method_grackle_chemistry->metal_cooling);
 
-    grackle_data->h2_on_dust = p->value_integer
+    method_grackle_chemistry->h2_on_dust = p->value_integer
       ("Method:grackle:h2_on_dust",
-        grackle_data->h2_on_dust);
+        method_grackle_chemistry->h2_on_dust);
 
-    grackle_data->three_body_rate = p->value_integer
+    method_grackle_chemistry->three_body_rate = p->value_integer
       ("Method:grackle:three_body_rate",
-        grackle_data->three_body_rate);
+        method_grackle_chemistry->three_body_rate);
 
-    grackle_data->cmb_temperature_floor = p->value_integer
+    method_grackle_chemistry->cmb_temperature_floor = p->value_integer
       ("Method:grackle:cmb_temperature_floor",
-        grackle_data->cmb_temperature_floor);
+        method_grackle_chemistry->cmb_temperature_floor);
 
-    grackle_data->grackle_data_file = strdup(p->value_string
+    method_grackle_chemistry->grackle_data_file = strdup(p->value_string
       ("Method:grackle:data_file",
-        grackle_data->grackle_data_file).c_str());
+        method_grackle_chemistry->grackle_data_file).c_str());
 
-    grackle_data->cie_cooling = p->value_integer
+    method_grackle_chemistry->cie_cooling = p->value_integer
       ("Method:grackle:cie_cooling",
-        grackle_data->cie_cooling);
+        method_grackle_chemistry->cie_cooling);
 
-    grackle_data->h2_optical_depth_approximation = p->value_integer
+    method_grackle_chemistry->h2_optical_depth_approximation = p->value_integer
       ("Method:grackle:h2_optical_depth_approximation",
-        grackle_data->h2_optical_depth_approximation);
+        method_grackle_chemistry->h2_optical_depth_approximation);
 
-    grackle_data->photoelectric_heating = p->value_integer
+    method_grackle_chemistry->photoelectric_heating = p->value_integer
       ("Method:grackle:photoelectric_heating",
-        grackle_data->photoelectric_heating);
+        method_grackle_chemistry->photoelectric_heating);
 
-    grackle_data->photoelectric_heating_rate = p->value_float
+    method_grackle_chemistry->photoelectric_heating_rate = p->value_float
       ("Method:grackle:photoelectric_heating_rate",
-        grackle_data->photoelectric_heating_rate);
+        method_grackle_chemistry->photoelectric_heating_rate);
 
-    grackle_data->CaseBRecombination = p->value_integer
+    method_grackle_chemistry->CaseBRecombination = p->value_integer
       ("Method:grackle:CaseBRecombination",
-       grackle_data->CaseBRecombination);
+       method_grackle_chemistry->CaseBRecombination);
 
-    grackle_data->UVbackground = p->value_integer
+    method_grackle_chemistry->UVbackground = p->value_integer
       ("Method:grackle:UVbackground",
-        grackle_data->UVbackground);
+        method_grackle_chemistry->UVbackground);
 
-    grackle_data->use_volumetric_heating_rate = p->value_integer
+    method_grackle_chemistry->use_volumetric_heating_rate = p->value_integer
       ("Method:grackle:use_volumetric_heating_rate",
-      grackle_data->use_volumetric_heating_rate);
+      method_grackle_chemistry->use_volumetric_heating_rate);
 
-    grackle_data->use_specific_heating_rate = p->value_integer
+    method_grackle_chemistry->use_specific_heating_rate = p->value_integer
       ("Method:grackle:use_specific_heating_rate",
-       grackle_data->use_specific_heating_rate);
+       method_grackle_chemistry->use_specific_heating_rate);
 
-    grackle_data->self_shielding_method = p->value_integer
+    method_grackle_chemistry->self_shielding_method = p->value_integer
       ("Method:grackle:self_shielding_method",
-       grackle_data->self_shielding_method);
+       method_grackle_chemistry->self_shielding_method);
 
-    grackle_data->H2_self_shielding = p->value_integer
+    method_grackle_chemistry->H2_self_shielding = p->value_integer
       ("Method:grackle:H2_self_shielding",
-       grackle_data->H2_self_shielding);
+       method_grackle_chemistry->H2_self_shielding);
 
-    grackle_data->HydrogenFractionByMass = p->value_float
+    method_grackle_chemistry->HydrogenFractionByMass = p->value_float
       ("Method:grackle:HydrogenFractionByMass",
-        grackle_data->HydrogenFractionByMass);
+        method_grackle_chemistry->HydrogenFractionByMass);
 
-    grackle_data->DeuteriumToHydrogenRatio = p->value_float
+    method_grackle_chemistry->DeuteriumToHydrogenRatio = p->value_float
       ("Method:grackle:DeuteriumToHydrogenRatio",
-       grackle_data->DeuteriumToHydrogenRatio);
+       method_grackle_chemistry->DeuteriumToHydrogenRatio);
 
-    grackle_data->SolarMetalFractionByMass = p->value_float
+    method_grackle_chemistry->SolarMetalFractionByMass = p->value_float
       ("Method:grackle:SolarMetalFractionByMass",
-       grackle_data->SolarMetalFractionByMass);
+       method_grackle_chemistry->SolarMetalFractionByMass);
 
-    grackle_data->Compton_xray_heating = p->value_integer
+    method_grackle_chemistry->Compton_xray_heating = p->value_integer
       ("Method:grackle:Compton_xray_heating",
-       grackle_data->Compton_xray_heating);
+       method_grackle_chemistry->Compton_xray_heating);
 
-    grackle_data->LWbackground_sawtooth_suppression = p->value_integer
+    method_grackle_chemistry->LWbackground_sawtooth_suppression = p->value_integer
       ("Method:grackle:LWbackground_sawtooth_suppression",
-       grackle_data->LWbackground_sawtooth_suppression);
+       method_grackle_chemistry->LWbackground_sawtooth_suppression);
 
-    grackle_data->LWbackground_intensity = p->value_float
+    method_grackle_chemistry->LWbackground_intensity = p->value_float
       ("Method:grackle:LWbackground_intensity",
-       grackle_data->LWbackground_intensity);
+       method_grackle_chemistry->LWbackground_intensity);
 
-    grackle_data->UVbackground_redshift_on = p->value_float
+    method_grackle_chemistry->UVbackground_redshift_on = p->value_float
       ("Method:grackle:UVbackground_redshift_on",
-       grackle_data->UVbackground_redshift_on);
+       method_grackle_chemistry->UVbackground_redshift_on);
 
-    grackle_data->UVbackground_redshift_off = p->value_float
+    method_grackle_chemistry->UVbackground_redshift_off = p->value_float
       ("Method:grackle:UVbackground_redshift_off",
-       grackle_data->UVbackground_redshift_off);
+       method_grackle_chemistry->UVbackground_redshift_off);
 
-    grackle_data->UVbackground_redshift_fullon = p->value_float
+    method_grackle_chemistry->UVbackground_redshift_fullon = p->value_float
       ("Method:grackle:UVbackground_redshift_fullon",
-        grackle_data->UVbackground_redshift_fullon);
+        method_grackle_chemistry->UVbackground_redshift_fullon);
 
-    grackle_data->UVbackground_redshift_drop = p->value_float
+    method_grackle_chemistry->UVbackground_redshift_drop = p->value_float
      ("Method:grackle:UVbackground_redshift_drop",
-      grackle_data->UVbackground_redshift_drop);
+      method_grackle_chemistry->UVbackground_redshift_drop);
 
     // When radiative transfer is eventually included, make
     // sure to set the below parameter to match the Enzo-P
     // parameter for turning RT on / off:
-    //   grackle_data->use_radiative_transfer = ENZO_P_PARAMETER_NAME;
+    //   method_grackle_chemistry->use_radiative_transfer = ENZO_P_PARAMETER_NAME;
 
   }
 #endif /* CONFIG_USE_GRACKLE */

--- a/src/Enzo/enzo_EnzoConfig.hpp
+++ b/src/Enzo/enzo_EnzoConfig.hpp
@@ -25,7 +25,8 @@ inline void operator|(PUP::er &p, chemistry_data &c){
  p | c.metal_cooling;
  p | c.UVbackground;
 
- int length = (c.grackle_data_file == NULL) ? 0 : strlen(c.grackle_data_file);
+ bool skip_strlen = (p.isUnpacking() || c.grackle_data_file == NULL);
+ int length = (skip_strlen) ? 0 : strlen(c.grackle_data_file);
  p | length;
  if (length > 0){
    if (p.isUnpacking()){

--- a/src/Enzo/enzo_EnzoInitialGrackleTest.cpp
+++ b/src/Enzo/enzo_EnzoInitialGrackleTest.cpp
@@ -115,8 +115,10 @@ void EnzoInitialGrackleTest::enforce_block
                                    enzo_config->initial_grackle_test_minimum_metallicity)/
                                    double(nz);
 
-
   double tiny_number = 1e-10;
+
+  chemistry_data * grackle_chemistry =
+    enzo::config()->method_grackle_chemistry;
 
   for (int iz=0; iz<nz+gz; iz++){ // Metallicity
     for (int iy=0; iy<ny+gy; iy++) { // Temperature
@@ -125,31 +127,31 @@ void EnzoInitialGrackleTest::enforce_block
 
         grackle_fields_.density[i] = cello::mass_hydrogen *
                      pow(10.0, ((H_n_slope * (ix-gx)) + log10(enzo_config->initial_grackle_test_minimum_H_number_density)))/
-                     grackle_data->HydrogenFractionByMass / enzo_units->density();
+                     grackle_chemistry->HydrogenFractionByMass / enzo_units->density();
 
         // solar metallicity
         grackle_fields_.metal_density[i] = pow(10.0,((metallicity_slope * (iz-gz)) +
                                           log10(enzo_config->initial_grackle_test_minimum_metallicity))) *
-                                          grackle_data->SolarMetalFractionByMass * grackle_fields_.density[i];
+                                          grackle_chemistry->SolarMetalFractionByMass * grackle_fields_.density[i];
         grackle_fields_.x_velocity[i] = 0.0;
         grackle_fields_.y_velocity[i] = 0.0;
         grackle_fields_.z_velocity[i] = 0.0;
 
-        if (grackle_data->primordial_chemistry > 0){
-            grackle_fields_.HI_density[i]    = grackle_fields_.density[i] * grackle_data->HydrogenFractionByMass;
+        if (grackle_chemistry->primordial_chemistry > 0){
+            grackle_fields_.HI_density[i]    = grackle_fields_.density[i] * grackle_chemistry->HydrogenFractionByMass;
             grackle_fields_.HII_density[i]   = grackle_fields_.density[i] * tiny_number;
-            grackle_fields_.HeI_density[i]   = grackle_fields_.density[i] * (1.0 - grackle_data->HydrogenFractionByMass);
+            grackle_fields_.HeI_density[i]   = grackle_fields_.density[i] * (1.0 - grackle_chemistry->HydrogenFractionByMass);
             grackle_fields_.HeII_density[i]  = grackle_fields_.density[i] * tiny_number;
             grackle_fields_.HeIII_density[i] = grackle_fields_.density[i] * tiny_number;
             grackle_fields_.e_density[i]     = grackle_fields_.density[i] * tiny_number;
         }
-        if (grackle_data->primordial_chemistry > 1){
+        if (grackle_chemistry->primordial_chemistry > 1){
           grackle_fields_.HM_density[i]    = grackle_fields_.density[i] * tiny_number;
           grackle_fields_.H2I_density[i]   = grackle_fields_.density[i] * tiny_number;
           grackle_fields_.H2II_density[i]  = grackle_fields_.density[i] * tiny_number;
         }
-        if (grackle_data->primordial_chemistry > 2){
-            grackle_fields_.DI_density[i]    = grackle_fields_.density[i] * grackle_data->DeuteriumToHydrogenRatio;
+        if (grackle_chemistry->primordial_chemistry > 2){
+            grackle_fields_.DI_density[i]    = grackle_fields_.density[i] * grackle_chemistry->DeuteriumToHydrogenRatio;
             grackle_fields_.DII_density[i]   = grackle_fields_.density[i] * tiny_number;
             grackle_fields_.HDI_density[i]   = grackle_fields_.density[i] * tiny_number;
         }
@@ -167,7 +169,7 @@ void EnzoInitialGrackleTest::enforce_block
         int i = INDEX(ix,iy,iz,ngx,ngy);
 
         /* calculate mu if following species */
-        if (grackle_data->primordial_chemistry > 0){
+        if (grackle_chemistry->primordial_chemistry > 0){
 
           mu = grackle_fields_.e_density[i] + grackle_fields_.HI_density[i] +
                       grackle_fields_.HII_density[i] +
@@ -175,12 +177,12 @@ void EnzoInitialGrackleTest::enforce_block
                        grackle_fields_.HeII_density[i] +
                        grackle_fields_.HeIII_density[i])*0.25;
 
-          if (grackle_data->primordial_chemistry > 1){
+          if (grackle_chemistry->primordial_chemistry > 1){
 
             mu += grackle_fields_.HM_density[i] + (grackle_fields_.H2I_density[i] +
                    grackle_fields_.H2II_density[i])*0.5;
           }
-          if (grackle_data->primordial_chemistry > 2){
+          if (grackle_chemistry->primordial_chemistry > 2){
             mu += (grackle_fields_.DI_density[i] + grackle_fields_.DII_density[i])*0.5 +
                    grackle_fields_.HDI_density[i]/3.0;
           }

--- a/src/Enzo/enzo_EnzoMethodGrackle.cpp
+++ b/src/Enzo/enzo_EnzoMethodGrackle.cpp
@@ -18,7 +18,9 @@ EnzoMethodGrackle::EnzoMethodGrackle
   const double time
 )
   : Method(),
-    grackle_units_(), grackle_chemistry_data_defined_(false)
+    grackle_units_(),
+    grackle_rates_(),
+    time_grackle_data_initialized_(ENZO_FLOAT_UNDEFINED)
 {
 #ifdef CONFIG_USE_GRACKLE
 
@@ -33,7 +35,10 @@ EnzoMethodGrackle::EnzoMethodGrackle
   std::vector<std::string> fields_to_define;
   std::vector<std::string> colour_fields;
 
-  if (grackle_data->metal_cooling > 0){
+  chemistry_data * grackle_chemistry =
+    enzo::config()->method_grackle_chemistry;
+
+  if (grackle_chemistry->metal_cooling > 0){
     std::string metal_name = "metal_density";
 
     if (! (field_descr->is_field(metal_name))){
@@ -43,7 +48,7 @@ EnzoMethodGrackle::EnzoMethodGrackle
   }
 
   // Define primordial chemistry fields
-  if (grackle_data->primordial_chemistry > 0){
+  if (grackle_chemistry->primordial_chemistry > 0){
     std::string pc1_fields[6] = {"HI_density","HII_density",
                                   "HeI_density","HeII_density","HeIII_density",
                                   "e_density"};
@@ -56,7 +61,7 @@ EnzoMethodGrackle::EnzoMethodGrackle
       colour_fields.push_back( pc1_fields[ifield] );
     }
 
-    if(grackle_data->primordial_chemistry > 1){
+    if(grackle_chemistry->primordial_chemistry > 1){
 
       std::string pc2_fields[3] = {"HM_density", "H2I_density", "H2II_density"};
       numfields = 3;
@@ -68,7 +73,7 @@ EnzoMethodGrackle::EnzoMethodGrackle
         colour_fields.push_back( pc2_fields[ifield] );
       }
 
-      if(grackle_data->primordial_chemistry > 2){
+      if(grackle_chemistry->primordial_chemistry > 2){
         std::string pc3_fields[3] = {"DI_density", "DII_density", "HDI_density"};
         numfields = 3;
 
@@ -86,13 +91,13 @@ EnzoMethodGrackle::EnzoMethodGrackle
 
   } // endif primordial chemistry is on
 
-  if (grackle_data->use_specific_heating_rate){
+  if (grackle_chemistry->use_specific_heating_rate){
     if ( !(field_descr->is_field("specific_heating_rate"))){
       fields_to_define.push_back("specific_heating_rate");
     }
   }
 
-  if (grackle_data->use_volumetric_heating_rate){
+  if (grackle_chemistry->use_volumetric_heating_rate){
     if ( !(field_descr->is_field("volumetric_heating_rate"))){
       fields_to_define.push_back("volumetric_heating_rate");
     }
@@ -125,7 +130,7 @@ EnzoMethodGrackle::EnzoMethodGrackle
   refresh(ir)->add_all_fields();
 
   /// Define Grackle's internal data structures
-  grackle_chemistry_data_defined_ = false;
+  time_grackle_data_initialized_ = ENZO_FLOAT_UNDEFINED;
   this->initialize_grackle_chemistry_data(time);
 
 #endif /* CONFIG_USE_GRACKLE */
@@ -153,8 +158,6 @@ void EnzoMethodGrackle::compute ( Block * block) throw()
     if (simulation)
       simulation->performance()->start_region(perf_grackle,__FILE__,__LINE__);
 
-    this->initialize_grackle_chemistry_data(block->time());
-
     this->compute_(enzo_block);
 
     if (simulation)
@@ -170,13 +173,18 @@ void EnzoMethodGrackle::compute ( Block * block) throw()
 
 #ifdef CONFIG_USE_GRACKLE
 
-void EnzoMethodGrackle::initialize_grackle_chemistry_data(
-                                                   const double& current_time)
+void EnzoMethodGrackle::initialize_grackle_chemistry_data(double current_time)
 {
 
   /* Define Grackle's chemistry data if not yet defined */
 
-  if (this->grackle_chemistry_data_defined_) return;
+  if (this->time_grackle_data_initialized_ == current_time) return;
+
+  if (this->time_grackle_data_initialized_ != ENZO_FLOAT_UNDEFINED){
+    // deallocate previously the allocated allocated grackle_rates_ (doesn't
+    // actually affect the chemistry_data pointer)
+    deallocate_grackle_rates_();
+  }
 
   EnzoUnits * enzo_units = enzo::units();
   const EnzoConfig * enzo_config = enzo::config();
@@ -210,14 +218,15 @@ void EnzoMethodGrackle::initialize_grackle_chemistry_data(
 
   // Initialize grackle units and data
   TRACE("Calling initialize_chemistry_data from EnzoMethodGrackle::EnzoMethodGrackle()");
-  if (initialize_chemistry_data(&grackle_units_) == ENZO_FAIL) {
-    ERROR("EnzoConfig::EnzoConfig()",
-    "Error in initialize_chemistry_data");
+  
+  if (_initialize_chemistry_data(enzo_config->method_grackle_chemistry,
+				 &grackle_rates_, &grackle_units_)
+      == ENZO_FAIL) {
+    ERROR("EnzoMethodGrackle::initialize_grackle_chemistry_data",
+    "Error in _initialize_chemistry_data");
   }
 
-  // This value should not be PUPed to ensure Grackle's data is always
-  // defined locally on each processor (see enzo_EnzoMethodGrackle.hpp)
-  this->grackle_chemistry_data_defined_ = true;
+  this->time_grackle_data_initialized_ = current_time;
 
   return;
 }
@@ -392,28 +401,31 @@ void EnzoMethodGrackle::update_grackle_density_fields(
 
   double tiny_number = 1.0E-10;
 
+  chemistry_data * grackle_chemistry =
+    enzo::config()->method_grackle_chemistry;
+
   for (int iz = 0; iz<ngz; iz++){
     for (int iy=0; iy<ngy; iy++){
       for (int ix=0; ix<ngx; ix++){
         int i = INDEX(ix,iy,iz,ngx,ngy);
 
-        if(grackle_data->primordial_chemistry > 0){
-          grackle_fields_->HI_density[i]   = grackle_fields_->density[i] * grackle_data->HydrogenFractionByMass;
+        if(grackle_chemistry->primordial_chemistry > 0){
+          grackle_fields_->HI_density[i]   = grackle_fields_->density[i] * grackle_chemistry->HydrogenFractionByMass;
           grackle_fields_->HII_density[i]   = grackle_fields_->density[i] * tiny_number;
-          grackle_fields_->HeI_density[i]   = grackle_fields_->density[i] * (1.0 - grackle_data->HydrogenFractionByMass);
+          grackle_fields_->HeI_density[i]   = grackle_fields_->density[i] * (1.0 - grackle_chemistry->HydrogenFractionByMass);
           grackle_fields_->HeII_density[i]  = grackle_fields_->density[i] * tiny_number;
           grackle_fields_->HeIII_density[i] = grackle_fields_->density[i] * tiny_number;
           grackle_fields_->e_density[i]     = grackle_fields_->density[i] * tiny_number;
         }
 
-        if (grackle_data->primordial_chemistry > 1){
+        if (grackle_chemistry->primordial_chemistry > 1){
           grackle_fields_->HM_density[i]    = grackle_fields_->density[i] * tiny_number;
           grackle_fields_->H2I_density[i]   = grackle_fields_->density[i] * tiny_number;
           grackle_fields_->H2II_density[i]  = grackle_fields_->density[i] * tiny_number;
         }
 
-        if (grackle_data->primordial_chemistry > 2){
-          grackle_fields_->DI_density[i]    = grackle_fields_->density[i] * grackle_data->DeuteriumToHydrogenRatio;
+        if (grackle_chemistry->primordial_chemistry > 2){
+          grackle_fields_->DI_density[i]    = grackle_fields_->density[i] * grackle_chemistry->DeuteriumToHydrogenRatio;
           grackle_fields_->DII_density[i]   = grackle_fields_->density[i] * tiny_number;
           grackle_fields_->HDI_density[i]   = grackle_fields_->density[i] * tiny_number;
         }
@@ -453,11 +465,16 @@ void EnzoMethodGrackle::compute_ ( EnzoBlock * enzo_block) throw()
   setup_grackle_units(enzo_block, &this->grackle_units_);
   setup_grackle_fields(enzo_block, &grackle_fields_);
 
+  chemistry_data * grackle_chemistry =
+    enzo::config()->method_grackle_chemistry;
+
   // Solve chemistry
   double dt = enzo_block->dt;
-  if (solve_chemistry(&grackle_units_, &grackle_fields_, dt) == ENZO_FAIL) {
+  if (local_solve_chemistry(grackle_chemistry, &grackle_rates_,
+			    &grackle_units_, &grackle_fields_, dt)
+      == ENZO_FAIL) {
     ERROR("EnzoMethodGrackle::compute()",
-    "Error in solve_chemistry.\n");
+    "Error in local_solve_chemistry.\n");
   }
 
   /* Correct total energy for changes in internal energy */
@@ -513,18 +530,7 @@ double EnzoMethodGrackle::timestep ( Block * block ) const throw()
       delete_cooling_time = true;
     }
 
-    // the grackle_units_ member can't be used here since this method MUST be
-    // const-qualified (i.e. the values of member variables can't be changed)
-    code_units temp_grackle_units;
-    grackle_field_data grackle_fields_;
-
-    setup_grackle_units(enzo_block,  &temp_grackle_units);
-    setup_grackle_fields(enzo_block, &grackle_fields_);
-
-    if (calculate_cooling_time(&temp_grackle_units, &grackle_fields_, cooling_time) == ENZO_FAIL) {
-      ERROR("EnzoMethodGrackle::compute()",
-      "Error in calculate_cooling_time.\n");
-    }
+    calculate_cooling_time(block, cooling_time, NULL, NULL, 0);
 
     // make sure to exclude the ghost zone. Because there is no refresh before
     // this method is called (at least during the very first cycle) - this can
@@ -541,10 +547,6 @@ double EnzoMethodGrackle::timestep ( Block * block ) const throw()
     if (delete_cooling_time){
       delete [] cooling_time;
     }
-
-    delete_grackle_fields(&grackle_fields_);
-
-
   }
 #endif
 
@@ -559,8 +561,11 @@ void EnzoMethodGrackle::ResetEnergies ( EnzoBlock * enzo_block) throw()
    const EnzoConfig * enzo_config = enzo::config();
    EnzoUnits * enzo_units = enzo::units();
 
+   chemistry_data * grackle_chemistry =
+    enzo::config()->method_grackle_chemistry;
+
    /* Only need to do this if tracking chemistry */
-   if (grackle_data->primordial_chemistry < 1)
+   if (grackle_chemistry->primordial_chemistry < 1)
      return;
 
    Field field = enzo_block->data()->field();
@@ -640,11 +645,11 @@ void EnzoMethodGrackle::ResetEnergies ( EnzoBlock * enzo_block) throw()
          enzo_float mu = e_density[i] + HI_density[i] + HII_density[i] +
             (HeI_density[i] + HeII_density[i] + HeIII_density[i])*0.25;
 
-         if (grackle_data->primordial_chemistry > 1){
+         if (grackle_chemistry->primordial_chemistry > 1){
            mu += HM_density[i] + 0.5 * (H2I_density[i] + H2II_density[i]);
          }
 
-         if (grackle_data->primordial_chemistry > 2){
+         if (grackle_chemistry->primordial_chemistry > 2){
            mu += (DI_density[i] + DII_density[i])*0.5 + HDI_density[i]/3.0;
          }
 
@@ -661,6 +666,76 @@ void EnzoMethodGrackle::ResetEnergies ( EnzoBlock * enzo_block) throw()
 
   return;
 }
+
+//----------------------------------------------------------------------
+
+void EnzoMethodGrackle::compute_local_property_
+(Block * block, enzo_float* values, code_units* grackle_units,
+ grackle_field_data* grackle_fields, int i_hist,
+ grackle_local_property_func func, std::string func_name) const throw()
+{
+  EnzoBlock * enzo_block = enzo::block(block);
+  const EnzoConfig * enzo_config = enzo::config();
+
+  code_units cur_grackle_units_;
+  grackle_field_data cur_grackle_fields_;
+
+  // setup grackle units if they are not already provided
+  if (!grackle_units){
+    grackle_units = &cur_grackle_units_;
+    EnzoMethodGrackle::setup_grackle_units(enzo_block, grackle_units, i_hist);
+  }
+
+  // if grackle fields are not provided, define them
+  bool delete_grackle_fields = false;
+  if (!grackle_fields){
+    grackle_fields  = &cur_grackle_fields_;
+    EnzoMethodGrackle::setup_grackle_fields(enzo_block, grackle_fields,
+					    i_hist);
+    delete_grackle_fields = true;
+  }
+
+  // because this function is const-qualified, grackle_rates_ currently has
+  // the type: const chemistry_data_storage *
+  // we need to drop the `const` to be able to pass to to func (this is okay
+  // because func will not actually modify the value).
+  chemistry_data_storage * grackle_rates_ptr
+    = const_cast<chemistry_data_storage *>(&grackle_rates_);
+
+  if ((*func)(enzo_config->method_grackle_chemistry, grackle_rates_ptr,
+	      grackle_units, grackle_fields, values) == ENZO_FAIL){
+    ERROR1("EnzoMethodGrackle::compute_local_property_()",
+	   "Error in call to Grackles's %s routine", func_name.c_str());
+  }
+  if (delete_grackle_fields){
+    EnzoMethodGrackle::delete_grackle_fields(grackle_fields);
+  }
+  return;
+}
+
 #endif //CONFIG_USE_GRACKLE
+
+//----------------------------------------------------------------------
+
+void EnzoMethodGrackle::deallocate_grackle_rates_() throw()
+{
+  const EnzoConfig * enzo_config = enzo::config();
+  // sanity check:
+  ASSERT("EnzoMethod::deallocate_grackle_rates_",
+	 "enzo::config() must not return NULL",
+	 enzo_config != NULL);
+#ifdef CONFIG_USE_GRACKLE
+  if (time_grackle_data_initialized_ == ENZO_FLOAT_UNDEFINED){
+    ERROR("EnzoMethodGrackle::deallocate_grackle_rates_",
+	  "grackle_rates_ data has not been allocated");
+  }
+  
+  // deallocate previously the allocated allocated grackle_rates_ (doesn't
+  // actually affect the chemistry_data pointer)
+  _free_chemistry_data(enzo_config->method_grackle_chemistry, &grackle_rates_);
+  // signal that grackle_data_ is not initialized
+  time_grackle_data_initialized_ = ENZO_FLOAT_UNDEFINED;
+#endif //CONFIG_USE_GRACKLE
+}
 
 //======================================================================

--- a/src/Enzo/enzo_EnzoMethodGrackle.hpp
+++ b/src/Enzo/enzo_EnzoMethodGrackle.hpp
@@ -28,7 +28,13 @@ inline void operator|(PUP::er &p, code_units &c){
   p | c.a_value;
 
 }
+
+typedef int (*grackle_local_property_func)(chemistry_data*,
+					   chemistry_data_storage *,
+					   code_units*, grackle_field_data*,
+					   enzo_float*);
 #endif
+
 
 
 class EnzoMethodGrackle : public Method {
@@ -47,7 +53,7 @@ public: // interface
                     const double time);
 
   // Destructor
-  virtual ~EnzoMethodGrackle() throw() {}
+  virtual ~EnzoMethodGrackle() throw() { deallocate_grackle_rates_(); }
 
   /// Charm++ PUP::able declarations
   PUPable_decl(EnzoMethodGrackle);
@@ -57,7 +63,8 @@ public: // interface
     : Method (m)
 #ifdef CONFIG_USE_GRACKLE
       , grackle_units_()
-      , grackle_chemistry_data_defined_(false)
+      , grackle_rates_()
+      , time_grackle_data_initialized_(ENZO_FLOAT_UNDEFINED)
 #endif
     {  }
 
@@ -74,13 +81,13 @@ public: // interface
     Method::pup(p);
 
     p | grackle_units_;
+    p | time_grackle_data_initialized_;
 
-//    DO NOT PUP THIS VARIABLE:
-//                ensures that Grackle's internal chemistry data
-//                structures are defined on each processor. This
-//                avoids having to write pup methods for all
-//                of Grackle's data structures.
-//    p | grackle_chemistry_data_defined_;
+    if (p.isUnpacking()) {
+      // the following recomputes grackle_rates_. This avoids having to write
+      // pup methods for all of Grackle's internal data structures
+      initialize_grackle_chemistry_data(time_grackle_data_initialized_);
+    }
 
   #endif /* CONFIG_USE_GRACKLE */
 
@@ -97,7 +104,7 @@ public: // interface
 
 #ifdef CONFIG_USE_GRACKLE
 
-  void initialize_grackle_chemistry_data(const double& current_time);
+  void initialize_grackle_chemistry_data(double current_time);
 
   static void setup_grackle_units(EnzoBlock * enzo_block,
                                   code_units * grackle_units,
@@ -139,11 +146,50 @@ public: // interface
       return;
  }
 
+  void calculate_cooling_time(Block * block, enzo_float* ct,
+			      code_units* grackle_units = NULL,
+			      grackle_field_data* grackle_fields = NULL,
+			      int i_hist = 0) const throw()
+  {
+    compute_local_property_(block, ct, grackle_units, grackle_fields, i_hist,
+			    &local_calculate_cooling_time,
+			    "local_calculate_cooling_time");
+  }
+
+  void calculate_pressure(Block * block, enzo_float* pressure,
+			  code_units* grackle_units = NULL,
+			  grackle_field_data* grackle_fields = NULL,
+			  int i_hist = 0) const throw()
+  {
+    compute_local_property_(block, pressure, grackle_units, grackle_fields,
+			    i_hist, &local_calculate_pressure,
+			    "local_calculate_pressure");
+  }
+
+  void calculate_temperature(Block * block, enzo_float* temperature,
+			     code_units* grackle_units = NULL,
+			     grackle_field_data* grackle_fields = NULL,
+			     int i_hist = 0) const throw()
+  {
+    compute_local_property_(block, temperature, grackle_units, grackle_fields,
+			    i_hist, &local_calculate_temperature,
+			    "local_calculate_temperature");
+  }
+
 #endif
 
 protected: // methods
 
+  void deallocate_grackle_rates_() throw();
+
 #ifdef CONFIG_USE_GRACKLE
+
+  // when grackle_units is NULL, new values are temporarily allocated
+  void compute_local_property_(Block * block, enzo_float* values,
+			       code_units* grackle_units,
+			       grackle_field_data* grackle_fields, int i_hist,
+			       grackle_local_property_func func,
+			       std::string func_name) const throw();
 
 #endif
 
@@ -157,7 +203,8 @@ protected: // methods
 // protected: // attributes
 
   code_units grackle_units_;
-  bool grackle_chemistry_data_defined_;
+  chemistry_data_storage grackle_rates_;
+  double time_grackle_data_initialized_;
 #endif
 
 };


### PR DESCRIPTION
This PR refactors calls to the external Grackle library to resolve SMP-mode issues.

**Problem Overview:**
The current procedure for setting up the `chemistry_data` struct on each PE (Processor Element) can be summarized by the following 2 steps:

  1. `EnzoConfig` dynamically allocates a local `chemistry_data` struct on each PE (Processor Element). It then calls `set_default_chemistry_parameters`, which both assigns this struct the default parameters and sets the global variable `grackle_data` equal to the address of this struct. Finally, the parameter file values are assigned to the appropriate fields of the struct that is pointed to by `grackle_data`. Note that the `EnzoConfig` destructor will deallocate the locally allocated struct.
  2. The constructor for `EnzoMethodGrackle` calls the instance method `EnzoMethodGrackle::initialize_grackle_chemistry_data`. This method ultimately executes  `initialize_chemistry_data`, which makes some modifications to the struct pointed to by the `grackle_data` global variable and sets up the `grackle_rates` global variable.
 
When running Enzo-E in non-SMP mode, each PE is on a separate 'logical' node. Thus has its own own copy of the global `grackle_data` and `grackle_rates` variables. However, in SMP-mode there are multiple PEs per 'logical' node and the global `grackle_data` and `grackle_rates` variables are shared between all PEs on a logical node.

This can leads to a few issues in SMP-mode:
  1. A small amount of memory can leak in `EnzoConfig` when multiple PEs try to store the result of `strdup` in `grackle_data->grackle_data_file`.
  2. There are memory leaks caused by the simultaneous calls to `initialize_chemistry_data` (pointers stored in `grackle_rates` that were allocated by one PE may be overwritten by the pointers allocated by another PE)
  3. It seems to be possible for the program to completely crash if the HDF5 files are simultaneously read by different PEs during `initialize_chemistry_data`. This is recorded in Issue #37 (I haven't been able to replicate it since I first reported it - so it seems like an infrequent occurrence).

**Solution:**
To resolve these issues, I have refactored the code to make use of the explicitly thread-safe local functions from grackle. In doing so, I generally tried to minimize changes to the existing functionallity. The most significant changes are as follows:
  - `EnzoMethodGrackle` now has a new private member variable, `grackle_rates` which stores the local instance of `chemistry_data_storage`. This is initialized in `EnzoMethodGrackle::initialize_grackle_chemistry_data`.
  - `EnzoComputePressure`, `EnzoComputeTemperature`, and `EnzoComputeCoolingTime` were refactored to call the new public instance methods of `EnzoMethodGrackle`: `calculate_pressure`, `calculate_temperature` and `calculate_cooling_time`. Doing this was cleaner than having each compute object retrieve the PE's local instances of `chemistry_data` and `chemistry_data_storage` from `EnzoConfig` and `EnzoMethodGrackle`. This change also makes `EnzoMethodGrackle` better encapuslate the majority of grackle-related operations. To help facillitate these changes, I introduced the `enzo::grackle_method` function to return a pointer to the PE's existing instance of `EnzoMethodGrackle` and new method to the `Problem` class to lookup registered `Method` instances by name (mirroring existing functionallity for `Physics` objects). 

Additionally, I moved the call to `EnzoMethodGrackle::initialize_grackle_chemistry_data` from the `compute` method to the `pup` method (during unpacking). Functionally, this only changes when the grackle structures are initialized after the object has been unpacked. This change removes all chances for the Compute objects to be called immediately after a (hypothetical) restart but before just means that the grackle_data can be initialized.

I have confirmed that this commit does not change the results of executing `input/method_grackle.in` (with just 1 PE or multiple PEs).

**Note:** I also considered (and partially implemented) an approach that used locks (`CmiNodeLock`)  and/or barrier synchronization (`CmiNodeBarrier`) to manage access to the global data structures. I ultimately choose to use the thread-safe local functions because it leads to simpler, less fragile code, has the same behavior in SMP and non-SMP mode, and is generally more consistent with the way other Methods are implemented. If there is a strong preference for using the global functions, I can revisit the approach.

In the future, (if these changes are approved) it may be worth creating a physics object to encapsulate all grackle operations (or maybe more generally to encapsulate equation-of-state related operations - I had already started thinking about this sort of thing with regards to my VL+CT integrator PR)