### PR TITLE
Add name to job commands.

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -4,60 +4,68 @@ commands:
   set-env:
     description: "Set environment variables."
     steps:
-      - run: |
-          echo 'export LD_LIBRARY_PATH=$HOME/local/lib:$LD_LIBRARY_PATH' >> $BASH_ENV
-          echo 'export CELLO_ARCH=linux_gnu' >> $BASH_ENV
-          echo 'export CHARM_ARGS=++local' >> $BASH_ENV
-          echo 'export HDF5_INC=/usr/include/hdf5/serial' >> $BASH_ENV
-          echo 'export HDF5_LIB=/usr/lib/x86_64-linux-gnu' >> $BASH_ENV
-          echo 'export CHARM_HOME=$HOME/local/charm-6.9.0' >> $BASH_ENV
-          echo 'export GRACKLE_HOME=$HOME/local' >> $BASH_ENV
-          # tag the tip so we can go back to it
-          git tag tip
+      - run:
+          name: "Set environment variables."
+          command: |
+            echo 'export LD_LIBRARY_PATH=$HOME/local/lib:$LD_LIBRARY_PATH' >> $BASH_ENV
+            echo 'export CELLO_ARCH=linux_gnu' >> $BASH_ENV
+            echo 'export CHARM_ARGS=++local' >> $BASH_ENV
+            echo 'export HDF5_INC=/usr/include/hdf5/serial' >> $BASH_ENV
+            echo 'export HDF5_LIB=/usr/lib/x86_64-linux-gnu' >> $BASH_ENV
+            echo 'export CHARM_HOME=$HOME/local/charm-6.9.0' >> $BASH_ENV
+            echo 'export GRACKLE_HOME=$HOME/local' >> $BASH_ENV
+            # tag the tip so we can go back to it
+            git tag tip
 
   install-dependencies:
     description: "Install dependencies."
     steps:
-      - run: |
-          source $BASH_ENV
-          sudo apt-get update
-          sudo apt-get install -y bc csh libhdf5-serial-dev gfortran libtool-bin libpapi-dev libpng-dev libboost-all-dev
-          # apt-get installs hdf5 libraries with _serial
-          sudo ln -s /usr/lib/x86_64-linux-gnu/libhdf5_serial.so /usr/lib/x86_64-linux-gnu/libhdf5.so
-          # Install charm++
-          mkdir -p $HOME/local
-          if [ ! -f $HOME/local/charm-6.9.0/bin/charmrun ]; then
-            cd $HOME/local
-            wget http://charm.cs.illinois.edu/distrib/charm-6.9.0.tar.gz
-            tar xvfz charm-6.9.0.tar.gz
-            rm charm-6.9.0.tar.gz
-            cd charm-6.9.0
-            ./build charm++ netlrts-linux-x86_64 -j4 --with-production
-          fi
+      - run:
+          name: "Install dependencies."
+          command: |
+            source $BASH_ENV
+            sudo apt-get update
+            sudo apt-get install -y bc csh libhdf5-serial-dev gfortran libtool-bin libpapi-dev libpng-dev libboost-all-dev
+            # apt-get installs hdf5 libraries with _serial
+            sudo ln -s /usr/lib/x86_64-linux-gnu/libhdf5_serial.so /usr/lib/x86_64-linux-gnu/libhdf5.so
+            # Install charm++
+            mkdir -p $HOME/local
+            if [ ! -f $HOME/local/charm-6.9.0/bin/charmrun ]; then
+              cd $HOME/local
+              wget http://charm.cs.illinois.edu/distrib/charm-6.9.0.tar.gz
+              tar xvfz charm-6.9.0.tar.gz
+              rm charm-6.9.0.tar.gz
+              cd charm-6.9.0
+              ./build charm++ netlrts-linux-x86_64 -j4 --with-production
+            fi
 
   install-grackle:
     description: "Install grackle."
     steps:
-      - run: |
-          git clone -b master https://github.com/grackle-project/grackle $HOME/grackle
-          cd $HOME/grackle
-          ./configure
-          cd src/clib
-          make machine-linux-gnu
-          make
-          make install
+      - run:
+          name: "Install grackle."
+          command: |
+            git clone -b master https://github.com/grackle-project/grackle $HOME/grackle
+            cd $HOME/grackle
+            ./configure
+            cd src/clib
+            make machine-linux-gnu
+            make
+            make install
 
   install-docs-dependencies:
     description: "Install dependencies for docs build."
     steps:
-      - run: |
-          sudo apt-get update
-          python3 -m venv $HOME/venv
-          source $HOME/venv/bin/activate
-          pip install --upgrade pip
-          pip install --upgrade wheel
-          pip install --upgrade setuptools
-          pip install sphinx sphinx_rtd_theme
+      - run:
+          name: "Install dependencies for docs build."
+          command: |
+            sudo apt-get update
+            python3 -m venv $HOME/venv
+            source $HOME/venv/bin/activate
+            pip install --upgrade pip
+            pip install --upgrade wheel
+            pip install --upgrade setuptools
+            pip install sphinx sphinx_rtd_theme
 
   build-and-test:
     description: "Compile enzo-e and run tests."
@@ -71,22 +79,26 @@ commands:
         type: string
         default: notafile
     steps:
-      - run: |
-          source $BASH_ENV
-          if [ ! -f << parameters.skipfile >> ]; then
-            git checkout << parameters.tag >>
-            export CELLO_PREC=<< parameters.prec >>
-            make
-            make test
-          fi
+      - run:
+          name: "Compile enzo-e and run tests."
+          command: |
+            source $BASH_ENV
+            if [ ! -f << parameters.skipfile >> ]; then
+              git checkout << parameters.tag >>
+              export CELLO_PREC=<< parameters.prec >>
+              make
+              make test
+            fi
 
   build-docs:
     description: "Test the docs build."
     steps:
-      - run: |
-          source $HOME/venv/bin/activate
-          cd doc/source
-          python -m sphinx -M html "." "_build" -W
+      - run:
+          name: "Test the docs build."
+          command: |
+            source $HOME/venv/bin/activate
+            cd doc/source
+            python -m sphinx -M html "." "_build" -W
 
 jobs:
   test-suite:


### PR DESCRIPTION
This doesn't change any commands, just adds a name to each section of the build. The only thing this does is make it so the steps on circleci have easily parsable names instead of a word salad of all the commands being run.