### PR TITLE
Reintroducing CelloArray Unit Test

### DIFF
--- a/src/Cello/test_CelloArray.cpp
+++ b/src/Cello/test_CelloArray.cpp
@@ -591,7 +591,7 @@ class VariableAssignmentTests{
   // these are tests that check that check the assignments of arrays to
   // variables.
 
-  template<template<typename, std::size_t> typename Builder>
+  template<template<typename, std::size_t> class Builder>
   void test_assignment_(){
     // vector used to hold expected results (the contents of this vector will
     // be updated throughout this test
@@ -728,8 +728,8 @@ class VariableAssignmentTests{
 
   }
 
-  template<template<typename, std::size_t> typename Builder1,
-           template<typename, std::size_t> typename Builder2>
+  template<template<typename, std::size_t> class Builder1,
+           template<typename, std::size_t> class Builder2>
   void test_deepcopy_assignment_(){
     std::string func_name =
       ("VariableAssignmentTests::test_deepcopy_assignment_<" +
@@ -786,7 +786,7 @@ class BulkAssignmentTest{
 
 public:
 
-  template<template<typename, std::size_t> typename Builder>
+  template<template<typename, std::size_t> class Builder>
   void test_assign_from_scalar_(){
     std::string func_name = "BulkAssignmentTest::test_assign_from_scalar_";
 
@@ -814,8 +814,8 @@ public:
   }
   
 
-  template<template<typename, std::size_t> typename Builder1,
-           template<typename, std::size_t> typename Builder2>
+  template<template<typename, std::size_t> class Builder1,
+           template<typename, std::size_t> class Builder2>
   void test_assign_from_array_(){
     std::string func_name =
       ("BulkAssignmentTest::test_assign_from_array_<" +
@@ -869,8 +869,8 @@ public:
   }
 
 
-  template<template<typename, std::size_t> typename Builder1,
-           template<typename, std::size_t> typename Builder2>
+  template<template<typename, std::size_t> class Builder1,
+           template<typename, std::size_t> class Builder2>
   void test_assign_subarrays_(){
     // These tests actually uncovered a longstanding bug
     std::string func_name =
@@ -989,7 +989,7 @@ private:
   }
 public:
 
-  template<template<typename, std::size_t> typename Builder>
+  template<template<typename, std::size_t> class Builder>
   void test_pass_by_val_(){
     Builder<double, 2> builder(2,3);
     CelloArray<double, 2> *arr_ptr = builder.get_arr();

--- a/test/ArrayComponent/SConscript
+++ b/test/ArrayComponent/SConscript
@@ -1,0 +1,29 @@
+Import('env')
+Import('parallel_run')
+Import('serial_run')
+Import('ip_charm')
+
+Import('bin_path')
+Import('test_path')
+
+#----------------------------------------------------------
+#defines
+#----------------------------------------------------------
+
+env['CPIN'] = 'touch parameters.out; mv parameters.out ${TARGET}.in'
+env['RMIN'] = 'rm -f parameters.out'
+
+date_cmd = 'echo $TARGET > test/STATUS; echo "---------------------"; date +"%Y-%m-%d %H:%M:%S";'
+
+run_array = Builder(action = "$RMIN; " + date_cmd + serial_run + " $SOURCE $ARGS > $TARGET 2>&1; $CPIN; $COPY")
+env.Append(BUILDERS = { 'RunArray' : run_array } )
+env_mv_array = env.Clone(COPY = 'mkdir -p ' + test_path + '/ArrayComponent/CelloArray; mv `ls *.png *.h5` ' + test_path + '/ArrayComponent/CelloArray')
+
+#-------------------------------------------------------------
+#load balancing
+#-------------------------------------------------------------
+
+
+env_mv_array.RunArray (
+     'test_CelloArray.unit',
+     bin_path + '/test_CelloArray')

--- a/test/SConscript
+++ b/test/SConscript
@@ -49,7 +49,7 @@ SConscript('Balance/SConscript')
 #----------------------------------------------------------------------
 # ARRAY COMPONENT         
 #----------------------------------------------------------------------
-#env.RunSerial('test_CelloArray.unit',bin_path + '/test_CelloArray')
+SConscript('ArrayComponent/SConscript')
 
 #----------------------------------------------------------------------
 # DATA COMPONENT         


### PR DESCRIPTION
This PR reintroduces the CelloArray Unit Test to the testing framework. The unit test itself was originally created, added to the testing framework, and reviewed as PR #62. However, the test seems to have fallen through the cracks while merging with the test overhaul PR.

This PR simply remedies that situation. 

I also made a very minor tweak to the unit test itself to address complaints from the compiler about non-compliance with C++11. I literally just replaced `typename` in some nested templates with `class`.