### PR TITLE
Write New Outputs on Restart

### DIFF
--- a/doc/source/param/restart.incl
+++ b/doc/source/param/restart.incl
@@ -4,4 +4,19 @@
 :Default: :d:`""`
 :Scope:     :c:`Cello`
 
-:e:`This optional parameter is used to specify the name of a parameter file to read on restart.  Its purpose is to allow a simulation to be restarted with slightly different parameter values, e.g. with a smaller courant number.  Currently, very few parameters are supported in the restart parameter file, just` :p:`Field` : :p:`courant` :e:`and` :p:`Testing` : :p:`time_final`.
+:e:`This optional parameter is used to specify the name of a parameter
+file to read on restart.  Its purpose is to allow a simulation to be
+restarted with slightly different parameter values.  Currently, very
+few parameters are supported in the restart parameter file. These
+include:`
+
+  * Modifying the value of :p:`Testing` : :p:`time_final`
+
+  * Specifying new output file sets. These should be specified in an
+    :p:`Output` Group in a similar manner to how the file set would be
+    specified in a normal parameter file. The entries of :p:`Output` :
+    :p:`list` should NOT include any of the names of file sets
+    specified in the original input file (the entries in the restart
+    file's :p:`Output` : :p:`list` are effectively appended to the
+    list of entries from the original file). Note that the properties
+    for existing file sets can NOT be be modified.

--- a/src/Cello/io_OutputCheckpoint.cpp
+++ b/src/Cello/io_OutputCheckpoint.cpp
@@ -77,6 +77,7 @@ void OutputCheckpoint::update_config_()
     config->testing_time_final[0] = p.value_float
       ("Testing:time_final",0.0);
   }
+  config->read_output_from_restart(&p);
 
 }
 

--- a/src/Cello/io_OutputCheckpoint.cpp
+++ b/src/Cello/io_OutputCheckpoint.cpp
@@ -14,7 +14,7 @@ OutputCheckpoint::OutputCheckpoint
 (
  int index,
  const Factory * factory,
- Config * config,
+ const Config * config,
  int process_count
 ) throw ()
   : Output(index,factory),

--- a/src/Cello/io_OutputCheckpoint.hpp
+++ b/src/Cello/io_OutputCheckpoint.hpp
@@ -22,7 +22,7 @@ public: // functions
   /// Create an uninitialized OutputCheckpoint object
   OutputCheckpoint(int index, 
 		   const Factory * factory, 
-		   Config * config, 
+		   const Config * config,
 		   int process_count) throw();
 
   /// Destructor

--- a/src/Cello/io_OutputData.cpp
+++ b/src/Cello/io_OutputData.cpp
@@ -18,7 +18,7 @@ OutputData::OutputData
 (
  int index,
  const Factory * factory,
- Config * config
+ const Config * config
 ) throw ()
   : Output(index,factory),
     text_block_count_(0)

--- a/src/Cello/io_OutputData.hpp
+++ b/src/Cello/io_OutputData.hpp
@@ -26,7 +26,7 @@ public: // functions
   /// Create an uninitialized OutputData object
   OutputData(int index,
 	     const Factory * factory,
-	     Config * config) throw();
+	     const Config * config) throw();
 
   /// Close the file if it is open
   virtual ~OutputData() throw();

--- a/src/Cello/parameters_Config.cpp
+++ b/src/Cello/parameters_Config.cpp
@@ -1502,3 +1502,22 @@ int Config::read_schedule_(Parameters * p, const std::string group)
 }
 //======================================================================
 
+void Config::read_output_from_restart (Parameters * parameters) throw()
+{
+  // first, ensure the user isn't trying to mutate existing output file sets
+  // (this is mostly provided as a convenience)
+  parameters->group_set(0,"Output");
+  int i = -1;
+  while(parameters->group(++i) != ""){
+    std::string fileset_name = parameters->group(i);
+    ASSERT1("Config::read_output_from_restart",
+            ("The \"%s\" output file set alreay existed prior to restart. You "
+             "can't modify the properties of existing file sets at restart."),
+            fileset_name,
+            (std::find(output_list.begin(), output_list.end(), fileset_name)
+             == output_list.end()));
+  }
+
+  // next, actually read the output file
+  read_output_ (parameters, true);
+}

--- a/src/Cello/parameters_Config.cpp
+++ b/src/Cello/parameters_Config.cpp
@@ -789,7 +789,9 @@ void Config::read_monitor_ (Parameters * p) throw()
 
 //----------------------------------------------------------------------
 
-void Config::read_output_ (Parameters * p) throw()
+void Config::read_output_ (Parameters * p,
+                           bool append_restart_parameters // default: =false
+                           ) throw()
 {
   //--------------------------------------------------
   // Output
@@ -797,10 +799,16 @@ void Config::read_output_ (Parameters * p) throw()
 
   p->group_set(0,"Output");
 
-  num_output = p->list_length("list");
+  if (!append_restart_parameters){ // sanity check!
+    ASSERT("Config::read_output_",
+           ("num_outputs should be 0 the first time that this function is "
+            "called."),
+           num_output == 0);
+  }
+  int num_new_output = p->list_length("list");
+  num_output += num_new_output;
 
   p->group_set(0,"Output");
-
 
   output_list.resize(num_output);
   output_type.resize(num_output);
@@ -831,16 +839,37 @@ void Config::read_output_ (Parameters * p) throw()
   output_particle_list.resize(num_output);
   output_name.resize(num_output);
 
-  output_dir_global = p->value_string("dir_global",".");
+  if (append_restart_parameters){
+    ASSERT("Config::read_output_",
+           "Output::dir_global must be consistent with the original value.",
+           output_dir_global == p->value_string("dir_global","."));
+  } else {
+    output_dir_global = p->value_string("dir_global",".");
+  }
 
-  for (int index_output=0; index_output<num_output; index_output++) {
+  for (int fileset_index=0; fileset_index<num_new_output; fileset_index++) {
 
-    TRACE1 ("index = %d",index_output);
+    int index_output = (num_output - num_new_output) + fileset_index;
+    TRACE2 ("fileset_index = %d, index = %d",fileset_index, index_output);
 
-    output_list[index_output] = 
-      p->list_value_string (index_output,"Output:list","unknown");
+    std::string fileset_name =
+      p->list_value_string (fileset_index,"Output:list","unknown");
+    bool existing_fset = std::find(output_list.begin(), output_list.end(),
+                                   fileset_name) != output_list.end();
 
-    p->group_set(1,output_list[index_output]);
+    if (existing_fset && append_restart_parameters){
+      ERROR1("Config::read_output_",
+             ("\"%s\" appears more that once in the Output:list that is "
+              "concatenated from the config file and the restart file"),
+             fileset_name.c_str());
+    } else if (existing_fset){
+      ERROR1("Config::read_output_",
+             "\"%s\" appears more that once in Output:list.",
+             fileset_name.c_str());
+    }
+
+    output_list[index_output] = fileset_name;
+    p->group_set(1,fileset_name);
 
     output_type[index_output] = p->value_string("type","unknown");
 
@@ -905,14 +934,14 @@ void Config::read_output_ (Parameters * p) throw()
     }
 
     // Read schedule for the Output object
-      
+
     p->group_push("schedule");
     output_schedule_index[index_output] = 
       read_schedule_(p, output_list[index_output]);
     p->group_pop();
 
     // Image 
-    
+
     if (output_type[index_output] == "image") {
 
 
@@ -989,7 +1018,7 @@ void Config::read_output_ (Parameters * p) throw()
       }
 
     }
-  }  
+  }
 
 }
 

--- a/src/Cello/parameters_Config.hpp
+++ b/src/Cello/parameters_Config.hpp
@@ -580,7 +580,8 @@ protected: // functions
   void read_mesh_        ( Parameters * ) throw();
   void read_method_      ( Parameters * ) throw();
   void read_monitor_     ( Parameters * ) throw();
-  void read_output_      ( Parameters * ) throw();
+  void read_output_      ( Parameters * p,
+                           bool append_restart_parameters = false) throw();
   void read_particle_    ( Parameters * ) throw();
   void read_performance_ ( Parameters * ) throw();
   void read_physics_     ( Parameters * ) throw();

--- a/src/Cello/parameters_Config.hpp
+++ b/src/Cello/parameters_Config.hpp
@@ -343,6 +343,10 @@ public: // interface
 
   /// Read values from the Parameters object
   void read (Parameters * parameters) throw();
+
+  /// Read values for new output filesets from a Parameter object representing
+  /// a restart file.
+  void read_output_from_restart (Parameters * parameters) throw();
   
 public: // attributes
 

--- a/src/Cello/problem_Problem.cpp
+++ b/src/Cello/problem_Problem.cpp
@@ -256,7 +256,7 @@ void Problem::initialize_restrict(Config * config) throw()
 //----------------------------------------------------------------------
 
 void Problem::initialize_output
-(Config * config,
+(const Config * config,
  const Factory * factory) throw()
 {
   FieldDescr * field_descr = cello::field_descr();
@@ -857,7 +857,7 @@ Output * Problem::create_output_
 (
  std::string    name,
  int index,
- Config *  config,
+ const Config *  config,
  const Factory * factory
  ) throw ()
 /// @param name           Name of Output object to create

--- a/src/Cello/problem_Problem.cpp
+++ b/src/Cello/problem_Problem.cpp
@@ -112,6 +112,10 @@ void Problem::pup (PUP::er &p)
   for (int i=0; i<n; i++) {
     p | output_list_[i]; // PUP::able
   }
+  // initialize any new Output objects that might have been added to config
+  // from a restart_file while unpacking OutputCheckpoint
+  if (up) initialize_output (cello::config(), cello::simulation()->factory(),
+                             true);
 
   p | prolong_; // PUP::able
   p | restrict_; // PUP::able

--- a/src/Cello/problem_Problem.cpp
+++ b/src/Cello/problem_Problem.cpp
@@ -257,11 +257,21 @@ void Problem::initialize_restrict(Config * config) throw()
 
 void Problem::initialize_output
 (const Config * config,
- const Factory * factory) throw()
+ const Factory * factory,
+ bool restart_append_objects /* default: false */) throw()
 {
   FieldDescr * field_descr = cello::field_descr();
-  
-  for (int index=0; index < config->num_output; index++) {
+
+  int start = (int)output_list_.size();
+
+  if (!restart_append_objects) { // sanity check
+    ASSERT("Problem::initialize_output",
+           ("No Output objects should be initialized when this function is "
+            "called (except when initializing new Output objects specified at "
+            "restart)"), start == 0);
+  }
+
+  for (int index=start; index < config->num_output; index++) {
 
     std::string type       = config->output_type[index];
 

--- a/src/Cello/problem_Problem.hpp
+++ b/src/Cello/problem_Problem.hpp
@@ -195,7 +195,8 @@ public: // interface
 
   /// Initialize the output objects
   void initialize_output(const Config * config,
-			 const Factory * factory) throw();
+                         const Factory * factory,
+                         bool restart_append_objects = false) throw();
 
   /// Initialize the method objects
   void initialize_method(Config * config) throw();

--- a/src/Cello/problem_Problem.hpp
+++ b/src/Cello/problem_Problem.hpp
@@ -194,7 +194,7 @@ public: // interface
   void initialize_stopping(Config * config ) throw();
 
   /// Initialize the output objects
-  void initialize_output(Config * config,
+  void initialize_output(const Config * config,
 			 const Factory * factory) throw();
 
   /// Initialize the method objects
@@ -269,7 +269,7 @@ protected: // functions
 
   /// Create named output object
   virtual Output *   create_output_  
-  (std::string type, int index, Config * config,
+  (std::string type, int index, const Config * config,
    const Factory * ) throw ();
 
   /// Create named prolongation object

--- a/src/Cello/simulation_Simulation.cpp
+++ b/src/Cello/simulation_Simulation.cpp
@@ -228,8 +228,6 @@ void Simulation::pup (PUP::er &p)
   p | stop_;
   p | phase_;
 
-  p | problem_; // PUPable
-
   if (up) performance_ = new Performance;
   p | *performance_;
 
@@ -255,6 +253,10 @@ void Simulation::pup (PUP::er &p)
 
   if (up) particle_descr_ = new ParticleDescr;
   p | *particle_descr_;
+
+  // FieldDescr and ParticleDescr need to be unpacked before Problem in case
+  // new Output objects are generated while unpacking the Problem instance
+  p | problem_; // PUPable
 
   if (up && (phase_ == phase_restart)) {
     monitor_->header();


### PR DESCRIPTION
In this PR I introduced the capability to specify new output file-sets during a restart from a checkpoint. To keep things manageable, the user is NOT allowed to mutate the properties of file-sets that were previously specified. I also updated the website documentation to reflect this new capability. This involved shuffling the order of some Cello operations, so I definitely would like @jobordner to eventually review this.

Note that I dropped the comment from the documentation stating that `Field:courant` could be updated during a restart because a comment at the top of  `initial/Checkpoint/restart.incl` explains that a change in where the courant factor is specified, had broken this feature.

An updated version of `initial/Checkpoint/restart.incl` that makes use of these features can be found [here](https://pastebin.com/9rratFB7).

I still need to introduce an automated test checking this feature before this is ready for review, but I need to work on something else more immediately.

I also wanted to receive some feedback on a related topic:
---

For those who don't know, simulation properties are currently only updated during a restart by a special restart-parameter file. The path to this file must be specified with the `Restart:file` parameter when initially launching the simulation for the very first time. 

Unfortunate, this means that if a user runs an expensive simulation and wants to use the feature introduced in this PR to generate new outputs after restarting from a checkpoint, they need to anticipate this scenario before they even launch the simulation. If they didn't anticipate this need (or just forgot to specify `Restart:file`), they must rerun the entire simulation up to that point where they want to restart.

The fact that charm++ doesn't seem to allow the user to pass new arguments to the program during a restart seems to be the source of the problem. I have 2 potential solutions to address this problem, and I want to get some feedback:
1. I wrote a separate branch where the user can specify the output file via an ``CELLO_RESTART_FILE``. However, I found it difficult to make sure that the variable was properly in the charm++ runtime when I ran it on my local machine. It only seemed to work if I ran the code with `++local` (and there were some weird issues with restarting `input/Checkpoint/checkpoint_ppm-8.in` while `++local`). I also tried to use the `++runscript` option to set the environment variable, but couldn't get it to work. Consequently, I have serious concerns about this approach to work (especially on clusters with multiple nodes). But maybe my concerns aren't warranted (If we pursue this approach I would need help).
2. My alternative idea is much simpler. When  `Restart:file` isn't specified, we could just look for the restart parameter file at some default path (maybe `./restart.in`?), and we continue with the restart even if the file can't be found. When  `Restart:file` is specified, we would use the existing behavior (raise an error if no restart parameter file can be found at the specified path). I have another separate branch where I implemented a variation on this idea and it seems to work well.

My inclination is to go with solution 2, but I wanted to check to see if anybody had any thoughts or preferences