### PR TITLE
Particle masses

### DIFF
--- a/src/Cello/data_Particle.hpp
+++ b/src/Cello/data_Particle.hpp
@@ -125,6 +125,11 @@ public: // interface
   int num_attributes(int it) const
   { return particle_descr_->num_attributes(it); }
 
+  /// Check if attribute exists
+
+  bool has_attribute (int it, std::string attribute) const
+  { return particle_descr_->has_attribute(it,attribute); }
+
   /// Return the index for the given attribute
 
   int attribute_index (int it, std::string attribute) const
@@ -197,6 +202,10 @@ public: // interface
   int constant_offset(int it, int ic) const
   { return particle_descr_->constant_offset(it,ic); }
 
+  /// Check if given constant exists
+
+  bool has_constant(int it, std::string constant) const
+  { return particle_descr_->has_constant(it,constant); }
 
   //--------------------------------------------------
   // BYTES

--- a/src/Cello/data_ParticleDescr.cpp
+++ b/src/Cello/data_ParticleDescr.cpp
@@ -253,6 +253,24 @@ int ParticleDescr::attribute_index (int it, std::string attribute_name) const
 
 //----------------------------------------------------------------------
 
+bool ParticleDescr::has_attribute(int it, std::string attribute_name) const
+{
+  ASSERT1("ParticleDescr::is_attribute",
+          "Trying to access unknown particle type '%s'",
+          type_name(it).c_str(),
+          (0 <= it && it < num_types()));
+
+  auto iter=attribute_index_[it].find(attribute_name);
+
+  int index = (iter != attribute_index_[it].end()) ? iter->second : -1;
+
+  static int count[CONFIG_NODE_SIZE] = {0};
+
+  return !((index == -1) && (count[cello::index_static()]++ < 10));
+}
+
+//----------------------------------------------------------------------
+
 std::string ParticleDescr::attribute_name (int it, int ia) const
 {
   ASSERT2("ParticleDescr::attribute_name",
@@ -389,6 +407,23 @@ int ParticleDescr::constant_offset (int it, int ic) const
             (0 <= ic && ic < num_constants(it))));
   return constant_offset_[it][ic]; 
 }
+
+//----------------------------------------------------------------------
+
+bool ParticleDescr::has_constant(int it, std::string constant_name) const
+{
+  ASSERT1("ParticleDescr::constant_index",
+          "Trying to access unknown particle type '%s'",
+          type_name(it).c_str(),
+          (0 <= it && it < num_types()));
+
+  auto iter=constant_index_[it].find(constant_name);
+
+  bool check = (iter != constant_index_[it].end()) ? true : false;
+
+  return check;
+}
+
 
 //----------------------------------------------------------------------
 // Bytes

--- a/src/Cello/data_ParticleDescr.hpp
+++ b/src/Cello/data_ParticleDescr.hpp
@@ -82,6 +82,10 @@ public: // interface
    /// Return a pointer to the given constant for the given type
   char * constant_value (int it, int ic);
 
+  /// Check if given constant exists for the given particle type
+  
+  bool has_constant (int it, std::string constant) const;
+
   //--------------------------------------------------
   // ATTRIBUTES
   //--------------------------------------------------
@@ -93,6 +97,10 @@ public: // interface
   /// Return the number of attributes of the given type.
 
   int num_attributes(int it) const;
+
+  /// Check if attribute exists
+
+  bool has_attribute (int it, std::string attribute) const;
 
   /// Return the index for the given attribute
 

--- a/src/Enzo/enzo_EnzoMethodPmDeposit.cpp
+++ b/src/Enzo/enzo_EnzoMethodPmDeposit.cpp
@@ -2,7 +2,7 @@
 
 /// @file     enzo_EnzoMethodPmDeposit.cpp
 /// @author   James Bordner (jobordner@ucsd.edu)
-/// @author   Stefan Arridge (stefan.arridge@gmail.com)
+/// Edited:   Stefan Arridge (stefan.arridge@gmail.com)
 /// @date     Fri Apr  2 17:05:23 PDT 2010
 /// @brief    Implements the EnzoMethodPmDeposit class
 ///
@@ -117,19 +117,11 @@ void EnzoMethodPmDeposit::compute ( Block * block) throw()
 					  block->time() + alpha_*block->dt());
     }
 
-    // Stefan: Not sure if cell widths need to be converted to a physical
-    // length
-    //if (rank >= 1) hx *= cosmo_a;
-    //if (rank >= 2) hy *= cosmo_a;
-    //if (rank >= 3) hz *= cosmo_a;
-
     double inv_vol = 1.0;
     if (rank >= 1) inv_vol /= hx;
     if (rank >= 2) inv_vol /= hy;
     if (rank >= 3) inv_vol /= hz;
 
-    // Stefan: Unsure of the meaning of this line. How is cosmological time
-    // defined in Enzo?
     const double dt = alpha_ * block->dt() / cosmo_a;
 
     // Get the number of particle types in the 'has_mass' group
@@ -217,7 +209,8 @@ void EnzoMethodPmDeposit::compute ( Block * block) throw()
           for (int ip=0; ip<np; ip++) {
 
 	    // Stefan: Unsure about this line, doesn't match what's in the
-	    // Enzo paper
+	    // Enzo paper, which says that particles are drifted by half a timestep
+	    // before being deposited to the grid
             double x = xa[ip*dp] + vxa[ip*dv]*dt;
 
             double tx = nx*(x - xm) / (xp - xm) - 0.5;


### PR DESCRIPTION
This changes `EnzoMethodPmDeposit` so that that all particles in the 'has_mass' group are taken into account when calculating the mass field, and the particles' mass attribute/constant is always interpreted as a quantity with dimensions of mass, rather than sometimes density. This fixes issue #83.

This may cause some issues with some of the Collapse tests, since those were written assuming that 'mass' is really density.