### PR TITLE
Tweaked the website homepage to mention the VL+CT integrator

### DIFF
--- a/doc/source/index.rst
+++ b/doc/source/index.rst
@@ -29,18 +29,20 @@ programming system, targeting the development of Exascale software
 applications, and actively developed at the Parallel Programming
 Laboratory at the University of Illinois, Urbana-Champaign.
 
-Enzo-E currently has two hyperbolic solvers: `PPM
+Enzo-E currently has three hyperbolic solvers: `PPM
 <http://adsabs.harvard.edu/abs/1995CoPhC..89..149B>`_, an enhanced
 piecewise parabolic method solver that was migrated to Enzo-E from the
-ENZO code base, and `PPML <http://arxiv.org/abs/0905.2960>`_, an ideal
-compressible MHD solver originally implemented in serial Fortran.
-More recently, physics and infrastructure capabilities have been
-developed for particle methods, including an implementation of ENZO's
-CIC particle-mesh gravity solver, and cosmological expansion with
-comoving coordinates.  Currently we are collaborating with
-`Prof. Daniel Reynolds <http://faculty.smu.edu/reynolds/>`_ on
-developing and implementing a highly scalable multigrid-based linear
-solver.
+ENZO code base, `PPML <http://arxiv.org/abs/0905.2960>`_, an ideal
+compressible MHD solver originally implemented in serial Fortran, and
+`VL+CT <http://adsabs.harvard.edu/abs/2009NewA...14..139S>`_, a
+dimensionally-unsplit compressible MHD solver implemented specifically
+for Enzo-E in C++.  More recently, physics and infrastructure
+capabilities have been developed for particle methods, including an
+implementation of ENZO's CIC particle-mesh gravity solver, and
+cosmological expansion with comoving coordinates.  Currently we are
+collaborating with `Prof. Daniel Reynolds
+<http://faculty.smu.edu/reynolds/>`_ on developing and implementing a
+highly scalable multigrid-based linear solver.
 
 .. toctree::
    :maxdepth: 1


### PR DESCRIPTION
This PR is extremely self-explanatory. I just tweaked the website homepage to mention the VL+CT integrator.

As long as the docs build, I wouldn't worry about any other test failures (due to time-out issues) because this only modifies one page related to the website.