### PR TITLE
Can supply Grackle path via environment variable

### DIFF
--- a/config/frontera_intel.py
+++ b/config/frontera_intel.py
@@ -63,4 +63,4 @@ png_path     = '/usr/lib64'
 if os.path.isdir(home + '/public/Grackle/src/clib'):
 	grackle_path = home + '/public/Grackle/src/clib'
 else:
-	grackle_path = grackle_path_search(home)
+	grackle_path = os.getenv(GRACKLE_PATH, grackle_path_search(home))

--- a/config/linux_gcc_9.py
+++ b/config/linux_gcc_9.py
@@ -63,4 +63,4 @@ png_path = os.getenv('LIBPNG_HOME', '/lib/x86_64-linux-gnu')
 boost_inc = os.getenv('BOOST_INC', '/usr/include/boost')
 boost_lib = os.getenv('BOOST_LIB', '/usr/lib/x86_64-linux-gnu')
 
-grackle_path = grackle_path_search(home)
+grackle_path = os.getenv(GRACKLE_PATH, grackle_path_search(home))

--- a/config/linux_gnu.py
+++ b/config/linux_gnu.py
@@ -65,4 +65,4 @@ png_path = os.getenv('LIBPNG_HOME', '/lib/x86_64-linux-gnu')
 boost_inc = os.getenv('BOOST_INC', '/usr/include/boost')
 boost_lib = os.getenv('BOOST_LIB', '/usr/lib/x86_64-linux-gnu')
 
-grackle_path = grackle_path_search(home)
+grackle_path = os.getenv('GRACKLE_PATH', os.getenv(GRACKLE_PATH, grackle_path_search(home)))

--- a/config/linux_intel.py
+++ b/config/linux_intel.py
@@ -53,4 +53,4 @@ png_path = os.getenv('LIBPNG_HOME')
 if png_path is None:
 	png_path     = '/lib/x86_64-linux-gnu'
 
-grackle_path_search = grackle_path_search(home)
+grackle_path_search = os.getenv(GRACKLE_PATH, grackle_path_search(home))

--- a/config/stampede_gnu.py
+++ b/config/stampede_gnu.py
@@ -65,4 +65,4 @@ png_path     = '/usr/lib64'
 if os.path.isdir(home + '/public/Grackle/src/clib'):
 	grackle_path = home + '/public/Grackle/src/clib'
 else:
-	grackle_path = grackle_path_search(home)
+	grackle_path = os.getenv(GRACKLE_PATH, grackle_path_search(home))

--- a/config/stampede_intel.py
+++ b/config/stampede_intel.py
@@ -70,4 +70,4 @@ png_path     = '/usr/lib64'
 if os.path.isdir(home + '/public/Grackle/src/clib'):
 	grackle_path = home + '/public/Grackle/src/clib'
 else:
-	grackle_path = grackle_path_search(home)
+	grackle_path = os.getenv(GRACKLE_PATH, grackle_path_search(home))


### PR DESCRIPTION
Made a small tweak to config files that auto-searched for the Grackle install to let it be a little more flexible. The user can instead define the environment variable GRACKLE_PATH to override the results of the search. Only tested `linux_gnu`.