### PR TITLE
Installation doc tweaks

### DIFF
--- a/doc/source/tutorial/getting_started.rst
+++ b/doc/source/tutorial/getting_started.rst
@@ -291,6 +291,14 @@ could be used instead by add ``++local`` to ``charmrun``, e.g.:
 
      ``~/Charm/bin/charmrun ++local +p4 bin/enzo-p input/HelloWorld/Hi.in``
 
+If you receive an error like
+
+.. code-block:: bash
+    Charmrun> Timeout waiting for node-program to connect
+
+trying running ``./bin/enzo-p`` without ``charmrun`` as crashes due to, e.g.,
+libraries not being found may not be displaying.
+
 If all goes well, Enzo-E will run the Hello World problem.  Below are
 some of the generated images from the longer-running "HelloWorld.in"
 problem (note "HelloWorld.in" runs for about an hour, compared to a

--- a/doc/source/tutorial/getting_started.rst
+++ b/doc/source/tutorial/getting_started.rst
@@ -293,7 +293,8 @@ could be used instead by add ``++local`` to ``charmrun``, e.g.:
 
 If you receive an error like
 
-.. code-block:: bash
+..  code-block:: bash
+
     Charmrun> Timeout waiting for node-program to connect
 
 trying running ``./bin/enzo-p`` without ``charmrun`` as crashes due to, e.g.,

--- a/doc/source/tutorial/getting_started.rst
+++ b/doc/source/tutorial/getting_started.rst
@@ -164,6 +164,19 @@ using the ``CHARM_HOME`` environment variable.
   ``export CHARM_HOME=$HOME/Charm/charm.6.10``  Set directory of Charm++ used
   ============================================  =============================
 
+4. Specify Grackle directory
+--------------------------
+
+At compile time, Enzo-E will try to automatically find your Grackle installation.
+If compilation fails because ``grackle.h`` cannot be included, it is possible
+that the directory was incorrectly identified. You can specify
+Grackle's installation directory with the ``GRACKLE_HOME`` environment variable:
+
+  =================================== =====================================
+  =================================== =====================================
+  ``export GRACKLE_HOME=$HOME/local`` Set directory of Grackle installation
+  =================================== =====================================
+
 Porting
 =======
 

--- a/doc/source/tutorial/getting_started.rst
+++ b/doc/source/tutorial/getting_started.rst
@@ -165,7 +165,7 @@ using the ``CHARM_HOME`` environment variable.
   ============================================  =============================
 
 4. Specify Grackle directory
---------------------------
+----------------------------
 
 At compile time, Enzo-E will try to automatically find your Grackle installation.
 If compilation fails because ``grackle.h`` cannot be included, it is possible


### PR DESCRIPTION
In PR #96 I was informed that Enzo-E's build infrastructure did already have a way of specifying the Grackle installation folder (the ``GRACKLE_HOME`` environment variable) that I didn't know about. I have added this to the installation documentation, along with a bit of advice I received for debugging Charmrun timeouts.