### PR TITLE
Shorten testing

### DIFF
--- a/input/Adapt/adapt.incl
+++ b/input/Adapt/adapt.incl
@@ -12,13 +12,13 @@ include "input/Adapt/adapt_slope.incl"
 
 Stopping { 
 	 cycle = 10000; 
-	 time = 0.1;
+	 time = 0.05;
 }
 
 Boundary { type = "periodic"; }
 
 Testing {
-   time_final  = 0.10;
+   time_final  = 0.05;
    cycle_final = 0;
 }
 
@@ -36,26 +36,26 @@ Output {
     hdf {
        field_list = ["density"];
        type     = "data";
-       include "input/Schedule/schedule_time_0.02.incl"
+       include "input/Schedule/schedule_time_0.01.incl"
     }
     de {
        field_list = ["density"];
        type     = "image";
-       include "input/Schedule/schedule_time_0.02.incl"
+       include "input/Schedule/schedule_time_0.01.incl"
        include "input/Colormap/colormap_blackbody.incl"
     }
     dl {
        field_list = ["density"];
        image_log = true;
        type     = "image";
-       include "input/Schedule/schedule_time_0.02.incl"
+       include "input/Schedule/schedule_time_0.01.incl"
        include "input/Colormap/colormap_blackbody.incl"
     }
     te {
 
        field_list = ["total_energy"];
        type     = "image";
-       include "input/Schedule/schedule_time_0.02.incl"
+       include "input/Schedule/schedule_time_0.01.incl"
        colormap = [1.0,1.0,1.0, 1.0,0.0,0.0,  0.75,0.25,0.0,  1.0,1.0,0.0,   0.0,1.0,0.0,  0.0,0.0,1.0,  0.5,1.0,0.5];
     }
 
@@ -63,7 +63,7 @@ Output {
 
        field_list = ["velocity_x"];
        type     = "image";
-       include "input/Schedule/schedule_time_0.02.incl"
+       include "input/Schedule/schedule_time_0.01.incl"
        colormap = [1.0,1.0,1.0, 1.0,0.0,0.0,  0.75,0.25,0.0,  1.0,1.0,0.0,   0.0,1.0,0.0,  0.0,0.0,1.0,  0.5,1.0,0.5];
     }
 
@@ -71,7 +71,7 @@ Output {
 
        field_list = ["velocity_y"];
        type     = "image";
-       include "input/Schedule/schedule_time_0.02.incl"
+       include "input/Schedule/schedule_time_0.01.incl"
        colormap = [1.0,1.0,1.0, 1.0,0.0,0.0,  0.75,0.25,0.0,  1.0,1.0,0.0,   0.0,1.0,0.0,  0.0,0.0,1.0,  0.5,1.0,0.5];
     }
 
@@ -81,7 +81,7 @@ Output {
 	image_reduce_type = "max";
         field_list = ["density"];
 	image_size = [513,513];
-        include "input/Schedule/schedule_time_0.02.incl"
+        include "input/Schedule/schedule_time_0.01.incl"
 	image_min = 0.0;
         include "input/Colormap/colormap_rainbow.incl"
       }

--- a/input/Balance/load-balance-4.in
+++ b/input/Balance/load-balance-4.in
@@ -37,14 +37,14 @@ Output {
 #     list = [];
       de {
            name = ["balance-de-%05d.png", "cycle"]; 
-           include "input/Schedule/schedule_cycle_2.incl"
+           schedule { var =  "cycle"; step = 20; }
            image_reduce_type = "max";
 	   image_type = "data";
            image_size = [1024,1024];
           }
       mesh {
            name = ["balance-mesh-%05d.png", "cycle"]; 
-           include "input/Schedule/schedule_cycle_2.incl"
+           schedule { var =  "cycle"; step = 20; }
 	   image_type = "mesh";
 	   image_size = [1025,1025];
            image_min = 0.0;

--- a/input/Schedule/schedule_time_0.01.incl
+++ b/input/Schedule/schedule_time_0.01.incl
@@ -1,0 +1,7 @@
+# File:    schedule_time_0.01.incl
+
+schedule {
+    var  = "time";
+    step = 0.01;
+}
+

--- a/src/Enzo/enzo_EnzoMethodPpml.cpp
+++ b/src/Enzo/enzo_EnzoMethodPpml.cpp
@@ -93,7 +93,9 @@ double EnzoMethodPpml::timestep (Block * block) const throw()
  
   /* 1) Compute Courant condition for baryons. */
  
-  if (EnzoBlock::NumberOfBaryonFields > 0) {
+  const int in = cello::index_static();
+  
+  if (EnzoBlock::NumberOfBaryonFields[in] > 0) {
  
     /* Find fields: density, total energy, velocity1-3. */
  

--- a/test/MeshGeneration/SConscript
+++ b/test/MeshGeneration/SConscript
@@ -29,17 +29,3 @@ env.Append(BUILDERS = { 'RunMesh' : run_mesh } )
 env_mv_mesh = env.Clone(COPY = 'mkdir -p ' + test_path + '/MethodHeat/Heat-1; mv `ls *.png *.h5` ' + test_path + '/MethodHeat/Heat-1')
 
 
-#-------------------------------------------------------------
-#load balancing
-#-------------------------------------------------------------
-
-#serial
-balance_mesh = env_mv_mesh.RunMesh (
-     'test_mesh-balanced.unit',
-     bin_path + '/enzo-p',
-     ARGS='input/Balance/mesh-balanced.in')
-
-Clean(balance_mesh,
-     [Glob('#/' + test_path + '/mesh-balanced*.png')])
-
-


### PR DESCRIPTION
CircleCI tests have been failing due to timing out on individual tests.  While testing needs some more serious updating to bring everything back online again (unit tests, cosmology, etc.), this is intended as a quick fix to shorten the time of longer tests so that CircleCI doesn't time out.  With the current tests being run, that's just "adapt-L5", which does simple hydro on a 2D AMR mesh, and "mesh-balanced", which is obsolete and redundant with adapt-L5 (it doesn't test load balancing as its current categorization would indicate; "balanced" here refers to maintaining the 2-1 mesh refinement jump limit).  When cosmology tests get re-added back in they will need to be updated to shorten their times as well.