### PR TITLE
Bugfix/cello/io

### DIFF
--- a/input/vlct/run_dual_energy_cloud_test.py
+++ b/input/vlct/run_dual_energy_cloud_test.py
@@ -80,11 +80,11 @@ def check_cloud_asym(fname, name, max_asym):
 
 def analyze_tests():
     r = []
-    r += check_cloud_asym('hlld_cloud_0.0625/hlld_cloud_0.0625.block_list',
+    r += check_cloud_asym('hlld_cloud_0.0625/cloud-data-000.block_list',
                           'hlld_cloud', 5.5e-13)
-    r += check_cloud_asym('hllc_cloud_0.0625/hllc_cloud_0.0625.block_list',
+    r += check_cloud_asym('hllc_cloud_0.0625/cloud-data-000.block_list',
                           'hllc_cloud', 3.6e-13)
-    r += check_cloud_asym('hlle_cloud_0.0625/hlle_cloud_0.0625.block_list',
+    r += check_cloud_asym('hlle_cloud_0.0625/cloud-data-000.block_list',
                           'hlle_cloud', 3.e-13)
     n_passed = np.sum(r)
     n_tests = len(r)

--- a/src/Cello/io_Output.cpp
+++ b/src/Cello/io_Output.cpp
@@ -126,6 +126,16 @@ std::string Output::expand_name_
  const std::vector<std::string> * args_p
 ) const throw()
 {
+  return expand_name_by_proc_(name_p, args_p, CkMyPe());
+}
+
+std::string Output::expand_name_by_proc_
+(
+ const std::string              * name_p,
+ const std::vector<std::string> * args_p,
+ const int proc
+) const throw()
+{
   if (*name_p == "") return "";
   
   const std::string & name = *name_p;
@@ -185,7 +195,7 @@ std::string Output::expand_name_
     if      (arg == "cycle") { sprintf (buffer_new,buffer, cycle_); }
     else if (arg == "time")  { sprintf (buffer_new,buffer, time_); }
     else if (arg == "count") { sprintf (buffer_new,buffer, count_); }
-    else if (arg == "proc")  { sprintf (buffer_new,buffer, CkMyPe()); }
+    else if (arg == "proc")  { sprintf (buffer_new,buffer, proc); }
     else if (arg == "flipflop")  { sprintf (buffer_new,buffer, count_%2); }
     else 
       {

--- a/src/Cello/io_Output.hpp
+++ b/src/Cello/io_Output.hpp
@@ -228,6 +228,12 @@ protected:
   (const std::string * file_name,
    const std::vector<std::string> * file_args) const throw();
 
+  std::string expand_name_by_proc_
+  (const std::string * file_name,
+   const std::vector<std::string> * file_args,
+   const int proc // processing element index
+  ) const throw();
+
   /// Return the path for this file group output.  Creates
   /// the subdirectories if they don't exist
   std::string directory () const

--- a/src/Cello/io_OutputData.cpp
+++ b/src/Cello/io_OutputData.cpp
@@ -133,7 +133,6 @@ void OutputData::write_block ( const  Block * block ) throw()
 
   std::string name_dir = expand_name_(&dir_name_,&dir_args_);
 
-
   // Write blocks text file
   std::string name_file;
   std::string name_out_file  = expand_name_(&file_name_,&file_args_);
@@ -144,7 +143,10 @@ void OutputData::write_block ( const  Block * block ) throw()
   }
 
   // strip extension, use this for name
-  name_file = name_out_file.substr(0, name_out_file.rfind("."));
+  name_file = expand_name_by_proc_(&file_name_, &file_args_, 0);
+  if (name_file.rfind(".") != std::string::npos) {
+    name_file = name_file.substr(0, name_file.rfind("."));
+  }
 
   const int num_blocks = cello::hierarchy()->num_blocks();
   int count = 0;

--- a/src/Cello/io_OutputData.cpp
+++ b/src/Cello/io_OutputData.cpp
@@ -141,12 +141,10 @@ void OutputData::write_block ( const  Block * block ) throw()
   if (name_dir == "") {
     // output block list and parameters to work directory
     name_dir  = ".";
-    // strip extension, use this for name
-    name_file = name_out_file.substr(0, name_out_file.rfind("."));
-  } else {
-    // output block list and parameters to subdirectory
-    name_file = name_dir;
   }
+
+  // strip extension, use this for name
+  name_file = name_out_file.substr(0, name_out_file.rfind("."));
 
   const int num_blocks = cello::hierarchy()->num_blocks();
   int count = 0;

--- a/tools/l1_error_norm.py
+++ b/tools/l1_error_norm.py
@@ -176,13 +176,20 @@ def get_block_list(dir_name):
                 break
         dir_name = dir_name[:stop_slice]
 
-    fname = os.path.join(dir_name,
-                         '.'.join((os.path.basename(dir_name), 'block_list')))
-    if not os.path.isfile(fname):
-        if not os.path.isdir(dir_name):
-            raise ValueError(
-                "{:s} is not the name of a directory".format(orig_dir_name))
-        raise ValueError("a file called {:s} can't be found".format(fname))
+    if not os.path.isdir(dir_name):
+        raise ValueError(
+            "{:s} is not the name of a directory.".format(orig_dir_name))
+
+    for file in os.listdir(dir_name):
+        if file.endswith(".block_list"):
+            fname = os.path.join(dir_name, file)
+            break;
+
+    if not fname:
+        raise ValueError(
+            "Could not find a block_list file in directory {:s}."
+            .format(orig_dir_name))
+
     return fname
 
 def _sanitize_units(arr):


### PR DESCRIPTION
**Problem A**
I have the following configuration in my `Output` group:
```
  data {
    type = "data";
    dir = "output/Hydro/hydro_static_2d";
    name = ["hydro_static_2d-data-%03d-%03d.h5", "cycle", "proc"];
    field_list = [ "velocity_x", "velocity_y" ];
    schedule {
      var = "cycle";
      step = 1;
      stop = 2;
    }
  }
```

The `dir` causes an incorrect output file for the `.parameters` file (etc.):
```
ERROR Error opening parameter file './output/Hydro/hydro_static_2d/./output/Hydro/hydro_static_2d.parameters' for writing
```

**Cause**
The issue appears to be in `Cello/io_OutputData.cpp` (line 141 by Andrew Emerick, 2020/03/05):
```
  if (name_dir == "") {
    // output block list and parameters to work directory
    name_dir  = ".";
    // strip extension, use this for name
    name_file = name_out_file.substr(0, name_out_file.rfind("."));
  } else {
    // output block list and parameters to subdirectory
    name_file = name_dir;
  }

  ...

    std::string param_file_name = name_dir+"/"+name_file+".parameters";
```

In the `else`, the `name_file` is being set to `name_dir`, resulting in the doubling of `name_dir` as the output file.

**Solution**
My solution is to remove the `else` and set the `name_file` to the same value for all cases:
```
  if (name_dir == "") {
    // output block list and parameters to work directory
    name_dir  = ".";
  }
  // strip extension, use this for name
  name_file = name_out_file.substr(0, name_out_file.rfind("."));

  ...

    std::string param_file_name = name_dir+"/"+name_file+".parameters";
```

**Result**
With the change, the parameters (and similar files) are created successfully, in my case, at:
```
output/Hydro/hydro_static_2d/hydro_static_2d-data-000-000.parameters
```