### PR TITLE
Updated references from 'enzo-p' to 'enzo-e'.

### DIFF
--- a/test/Restart/SConscript
+++ b/test/Restart/SConscript
@@ -200,14 +200,14 @@ if use_valgrind == 0:
     # VL+CT Checkpoint-Restart Test
     env_ckpt_restart.RunCkptRestartSerial(
         os.path.join(os.getcwd(),'test_restart_vlct.unit'),
-        bin_path + '/enzo-p',
+        bin_path + '/enzo-e',
         TEST_NAME = 'restart_vlct',
         INPUTFILE = 'input/Checkpoint/checkpoint_vlct.in')
 
     # Boundary Checkpoint-Restart Test
     env_ckpt_restart.RunCkptRestartSerial(
         os.path.join(os.getcwd(),'test_restart_boundary.unit'),
-        bin_path + '/enzo-p',
+        bin_path + '/enzo-e',
         TEST_NAME = 'restart_boundary',
         INPUTFILE = 'input/Checkpoint/checkpoint_boundary.in')
 
@@ -225,7 +225,7 @@ if use_valgrind == 0:
 
         env_ckpt_restart.RunCkptRestartParallel(
             'test_restart_grackle.unit',
-            bin_path + '/enzo-p',
+            bin_path + '/enzo-e',
             TEST_NAME = 'restart_grackle',
             INPUTFILE = 'test/Restart/restart_grackle.in'
         )

--- a/tools/ckpt_restart_test.py
+++ b/tools/ckpt_restart_test.py
@@ -444,7 +444,7 @@ def run_ckpt_restart_test(test_name, template_input_path, enzoe_wrapper,
 # Setup the parser for the CLI
 
 _default_enzoe_binary = os.path.join(
-    os.path.dirname(os.path.abspath(__file__)),'../bin/enzo-p'
+    os.path.dirname(os.path.abspath(__file__)),'../bin/enzo-e'
 )
 
 _description = """\


### PR DESCRIPTION
There were a few lingering references to enzo-p in the restart tests.