### PR TITLE
Auto-detect the number of cores in the build script

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -10,6 +10,7 @@ commands:
             echo 'export CHARM_VER=6.10.2' >> $BASH_ENV
             echo 'export LD_LIBRARY_PATH=$HOME/local/lib:$LD_LIBRARY_PATH' >> $BASH_ENV
             echo 'export CELLO_ARCH=linux_gnu' >> $BASH_ENV
+            echo 'export CELLO_BUILD_NCORE=4' >> $BASH_ENV
             echo 'export CHARM_ARGS=++local' >> $BASH_ENV
             echo 'export HDF5_INC=/usr/include/hdf5/serial' >> $BASH_ENV
             echo 'export HDF5_LIB=/usr/lib/x86_64-linux-gnu' >> $BASH_ENV

--- a/build.sh
+++ b/build.sh
@@ -25,7 +25,15 @@ S0=`date +"%S"`
 
 log="log.build"
 
-proc=4
+# Set to zero to use all avaiable cores.  To override, set to a non-zero value
+# or use CELLO_BUILD_NCORE environment variable
+proc=0
+if [[ ! -z ${CELLO_BUILD_NCORE} ]]; then
+   proc=${CELLO_BUILD_NCORE}
+elif [[ ${proc} -eq 0 ]]; then
+   # first command: Linux. second command: macOS
+   proc=$(grep -c ^processor /proc/cpuinfo 2>/dev/null || sysctl -n hw.ncpu)
+fi
 
 # set default target
 
@@ -114,6 +122,7 @@ echo "BEGIN enzo-e/Cello ${0}"
 echo "arch=$arch"
 echo "prec=$prec"
 echo "target=$target"
+echo "proc=$proc"
 
 rm -f "test/*/running.$arch.$prec"
 

--- a/doc/source/tutorial/getting_started.rst
+++ b/doc/source/tutorial/getting_started.rst
@@ -238,12 +238,14 @@ fragment below may differ due to the file being updated.)
 Building
 ========
 
-After configuring Cello for your computer, the Cello framework and
-Enzo-E application can be compiled using "make", which in turn calls
-the included ``./build.sh`` script.  Other options are available for
-generating useful `https://orgmode.org/ <org-mode>`_ files, generating
-doxygen documentation, running
-regression tests, and running code analysis tools.
+After configuring Cello for your computer, the Cello framework and Enzo-E
+application can be compiled using "make", which in turn calls the included
+``./build.sh`` script.  By default, the build system will use all available
+cores.  To specify the number of cores to compile Cello, either set the ``proc``
+variable in ``./build.sh`` or set the environment variable ``CELLO_BUILD_NCORE``
+to the desired value.  Other options are available for generating useful
+`https://orgmode.org/ <org-mode>`_ files, generating doxygen documentation,
+running regression tests, and running code analysis tools.
 
         ==================  ===============================================================
         ==================  ===============================================================


### PR DESCRIPTION
I got tired of stashing my changes to `build.sh` because I had `proc` a different value 😄 

By default, it will use all of the cores.  This can be overridden by setting either the proc variable in build.sh or the environment variable `CELLO_BUILD_NCORE`. I couldn't test whether this works on macOS

```
sysctl -n hw.ncpu
```

It'd be great if someone with macOS could test whether this command gives the number of cores.