### PR TITLE
Fixing another bug related to builds without Grackle

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -239,15 +239,18 @@ workflows:
    tests:
      jobs:
        - test-suite:
+           name: test-suite_single-prec
            prec: single
            usegrackle: true
            skiptest: false
        - test-suite:
+           name: test-suite_double-prec
            prec: double
            usegrackle: true
            skiptest: false
        - docs-build
        - test-suite:
+           name: build-no-grackle
            prec: double
            usegrackle: false
            skiptest: true

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -93,6 +93,32 @@ commands:
             pip install --upgrade setuptools
             pip install sphinx sphinx_rtd_theme
 
+  configure-build-system:
+    description: "Modifies the SConstruct file to use grackle or not."
+    parameters:
+      usegrackle:
+        type: boolean
+        default: true
+    steps:
+      - run:
+          name: "Modify the use_grackle parameter in SConstruct."
+          command: |
+            # convert boolean parameter to an env var storing 0 or 1
+            USE_GRACKLE=$(( 0 <<# parameters.usegrackle >> + 1 <</ parameters.usegrackle >> ))
+
+            source $BASH_ENV
+            # to help make sure that this doesn't fall through the cracks if
+            # parts of the build system change, check the validity of the default
+            # value of the use_grackle parameter
+            DFLT_GRACKLE_VAL=$(sed -n 's/^use_grackle *= *//p' SConstruct)
+            if [[ "$DFLT_GRACKLE_VAL" != "0" && "$DFLT_GRACKLE_VAL" != "1" ]];
+            then
+                echo "The \"use_grackle\" parameter in SConstruct has an unexpected value"
+                exit 1;
+            fi
+            # now update SConstruct so that "use_grackle" is given the value of $USE_GRACKLE
+            sed -i "s/^use_grackle *=.*/use_grackle = ${USE_GRACKLE}/" SConstruct
+
   build-and-test:
     description: "Compile enzo-e and run tests."
     parameters:
@@ -104,58 +130,45 @@ commands:
       skipfile:
         type: string
         default: notafile
+      usegrackle:
+        type: boolean
+        default: true
+      skiptest:
+        type: boolean
+        default: false
     steps:
       - run:
-          name: "Compile enzo-e and run tests."
+          name: "Fetch enzo-e files enzo-e and run tests."
           command: |
             source $BASH_ENV
             source $HOME/venv/bin/activate
             if [ ! -f << parameters.skipfile >> ]; then
               git checkout << parameters.tag >>
-              export CELLO_PREC=<< parameters.prec >>
-              make
-              source $HOME/venv/bin/activate
-              # the following environment variable indicates that the parallel
-              # vlct test(s) are to be skipped
-              export VL_PARALLEL_TEST_IP_CHARM=0
-              make test
             fi
 
+      - configure-build-system:
+          usegrackle: << parameters.usegrackle >>
 
-  build-no-grackle:
-    description: "Compile enzo-e without Grackle."
-    parameters:
-      prec:
-        type: string
-        default: double
-      tag:
-        type: string
-        default: tip
-    steps:
       - run:
-          name: "Compile enzo-e without grackle."
+          name: "Compile enzo-e and run tests."
           command: |
             source $BASH_ENV
             source $HOME/venv/bin/activate
 
-            git checkout << parameters.tag >>
-            export CELLO_PREC=<< parameters.prec >>
+            # convert boolean parameter to an env var storing 0 or 1
+            SKIP_TEST=$(( 0 <<# parameters.skiptest >> + 1 <</ parameters.skiptest >> ))
 
-            # to help make sure that this test doesn't get forgotten if parts
-            # of the build system change, check the validity of the default
-            # value of use_grackle
-            DFLT_GRACKLE_VAL=$(sed -n 's/^use_grackle *= *//p' SConstruct)
-            if [[ "$DFLT_GRACKLE_VAL" != "0" && "$DFLT_GRACKLE_VAL" != "1" ]];
-            then
-                echo "The \"use_grackle\" parameter in SConstruct has an unexpected value"
-                exit 1;
+            if [ ! -f << parameters.skipfile >> ]; then
+              export CELLO_PREC=<< parameters.prec >>
+              make
+              source $HOME/venv/bin/activate
+              if [[ $SKIP_TEST != 1 ]]; then
+                 # the following environment variable indicates that the
+                 # parallel VL+CT test(s) are to be skipped
+                 export VL_PARALLEL_TEST_IP_CHARM=0
+                 make test
+              fi
             fi
-
-            # now actually update SConstruct to have "use_grackle = 0"
-            sed -i "s/^use_grackle *=.*/use_grackle = 0/" SConstruct
-
-            # finally, try to build enzo-e
-            make
 
   build-docs:
     description: "Test the docs build."
@@ -172,6 +185,10 @@ jobs:
     parameters:
       prec:
         type: string
+      usegrackle:
+        type: boolean
+      skiptest:
+        type: boolean
 
     docker:
       - image: cimg/python:3.7
@@ -194,25 +211,18 @@ jobs:
           paths:
             - ~/local
 
-      - install-grackle:
-          prec: << parameters.prec >>
+      - when:
+          condition: << parameters.usegrackle >>
+          steps:
+            - install-grackle:
+                prec: << parameters.prec >>
 
       - build-and-test:
           prec: << parameters.prec >>
           tag: tip
           skipfile: notafile
-
-  test-build-no-grackle:
-    docker:
-      - image: cimg/python:3.7
-
-    working_directory: ~/enzo-e
-
-    steps:
-      - checkout
-      - set-env
-      - install-dependencies
-      - build-no-grackle
+          usegrackle: << parameters.usegrackle >>
+          skiptest: << parameters.skiptest >>
 
   docs-build:
     docker:
@@ -230,7 +240,14 @@ workflows:
      jobs:
        - test-suite:
            prec: single
+           usegrackle: true
+           skiptest: false
        - test-suite:
            prec: double
+           usegrackle: true
+           skiptest: false
        - docs-build
-       - test-build-no-grackle
+       - test-suite:
+           prec: double
+           usegrackle: false
+           skiptest: true

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -121,6 +121,42 @@ commands:
               make test
             fi
 
+
+  build-no-grackle:
+    description: "Compile enzo-e without Grackle."
+    parameters:
+      prec:
+        type: string
+        default: double
+      tag:
+        type: string
+        default: tip
+    steps:
+      - run:
+          name: "Compile enzo-e without grackle."
+          command: |
+            source $BASH_ENV
+            source $HOME/venv/bin/activate
+
+            git checkout << parameters.tag >>
+            export CELLO_PREC=<< parameters.prec >>
+
+            # to help make sure that this test doesn't get forgotten if parts
+            # of the build system change, check the validity of the default
+            # value of use_grackle
+            DFLT_GRACKLE_VAL=$(sed -n 's/^use_grackle *= *//p' SConstruct)
+            if [[ "$DFLT_GRACKLE_VAL" != "0" && "$DFLT_GRACKLE_VAL" != "1" ]];
+            then
+                echo "The \"use_grackle\" parameter in SConstruct has an unexpected value"
+                exit 1;
+            fi
+
+            # now actually update SConstruct to have "use_grackle = 0"
+            sed -i "s/^use_grackle *=.*/use_grackle = 0/" SConstruct
+
+            # finally, try to build enzo-e
+            make
+
   build-docs:
     description: "Test the docs build."
     steps:
@@ -166,6 +202,18 @@ jobs:
           tag: tip
           skipfile: notafile
 
+  test-build-no-grackle:
+    docker:
+      - image: cimg/python:3.7
+
+    working_directory: ~/enzo-e
+
+    steps:
+      - checkout
+      - set-env
+      - install-dependencies
+      - build-no-grackle
+
   docs-build:
     docker:
       - image: circleci/python:3.7.2
@@ -185,3 +233,4 @@ workflows:
        - test-suite:
            prec: double
        - docs-build
+       - test-build-no-grackle

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -138,7 +138,7 @@ commands:
         default: false
     steps:
       - run:
-          name: "Fetch enzo-e files enzo-e and run tests."
+          name: "Checkout target tag from enzo-e repository."
           command: |
             source $BASH_ENV
             source $HOME/venv/bin/activate

--- a/src/Enzo/enzo_EnzoConfig.cpp
+++ b/src/Enzo/enzo_EnzoConfig.cpp
@@ -598,9 +598,7 @@ void EnzoConfig::pup (PUP::er &p)
   p | units_length;
   p | units_time;
 
-  p  | method_grackle_use_grackle;
-  p  | method_grackle_use_cooling_timestep;
-  p  | method_grackle_radiation_redshift;
+  p | method_grackle_use_grackle;
 
 #ifdef CONFIG_USE_GRACKLE
   if (method_grackle_use_grackle) {


### PR DESCRIPTION
PR #49 introduced a minor change that breaks builds without Grackle (again). 

I've fixed this locally (it's a really easy fix). But I'm taking this as an opportunity to try to setup a CircleCi test to verify that Enzo-E can be built without Grackle (Our other tests already take a while, so I'm not going to run any tests with this build; I'm just checking if the build succeeds). 

I'm intentionally going to make some tests fail while testing this, but this will be ready for review by tomorrow. (I'll change this from WIP once it's ready and I'll add an edit to this post confirming that it's ready).

EDIT: I'm done. This is now ready for review.