### PR TITLE
Convert remaining "colour" instances to "color"  

### DIFF
--- a/input/vlct/passive_advect_sound_wave/passive_advection_test.incl
+++ b/input/vlct/passive_advect_sound_wave/passive_advection_test.incl
@@ -5,9 +5,9 @@
    }
 
    Group {
-      list = ["colour"];
+      list = ["color"];
 
-      colour {
+      color {
          field_list = ["red"];
       }
    }

--- a/src/Enzo/enzo_EnzoCenteredFieldRegistry.hpp
+++ b/src/Enzo/enzo_EnzoCenteredFieldRegistry.hpp
@@ -27,7 +27,7 @@
 /// @brief    vector of passively advected group names
 ///
 /// This should be updated as new groups are added
-const std::vector<std::string> passive_group_names = {"colour"};
+const std::vector<std::string> passive_group_names = {"color"};
 
 //----------------------------------------------------------------------
 

--- a/src/Enzo/enzo_EnzoInitialCloud.cpp
+++ b/src/Enzo/enzo_EnzoInitialCloud.cpp
@@ -460,7 +460,7 @@ void EnzoInitialCloud::enforce_block
   FieldDescr * field_descr = cello::field_descr();
   const bool use_cloud_dye
     = (field_descr->is_field("cloud_dye") &&
-       field_descr->groups()->is_in("cloud_dye", "colour"));
+       field_descr->groups()->is_in("cloud_dye", "color"));
   EFlt3DArray cloud_dye_density;
   if (use_cloud_dye){
     cloud_dye_density = array_factory.from_name("cloud_dye");
@@ -468,10 +468,10 @@ void EnzoInitialCloud::enforce_block
 
   const bool set_metal_density
     = (field_descr->is_field("metal_density") &&
-       field_descr->groups()->is_in("metal_density","colour"));
+       field_descr->groups()->is_in("metal_density","color"));
   if (metal_mass_frac_>0.){
     ASSERT("EnzoInitialCloud::enforce_block",
-	   "metal_denisty field must be in the \"colour\" group since a metal "
+	   "metal_denisty field must be in the \"color\" group since a metal "
 	   "mass fraction was specified.", set_metal_density);
   }
   EFlt3DArray metal_density;


### PR DESCRIPTION
Last week we pulled in a PR (I think it was #49) that changed instances of "colour" to "color". This updates the remaining instances in the VL+CT-related machinery.