### PR TITLE
Update vlct test scripts

### DIFF
--- a/input/vlct/run_HD_linear_wave_test.py
+++ b/input/vlct/run_HD_linear_wave_test.py
@@ -12,6 +12,7 @@
 #   2.) Check that the L1-norm error is the same for left propagating and right
 #       propagating sound waves
 
+import os
 import os.path
 import shutil
 import sys
@@ -21,7 +22,7 @@ from functools import partial
 import numpy as np
 
 from testing_utils import \
-    CalcSimL1Norm, EnzoEWrapper, isclose, standard_analyze, prep_cur_dir
+    CalcSimL1Norm, EnzoEWrapper, isclose, standard_analyze, testing_context
 
 from run_MHD_linear_wave_test import \
     analyze_linwave, identical_l1_error_linwave
@@ -45,8 +46,7 @@ def run_tests(executable):
 
 def analyze_tests():
     # define the functor for evaluating the norm of the L1 error vector
-    l1_func = CalcSimL1Norm("tools/l1_error_norm.py",
-                            ["density","velocity_x","velocity_y","velocity_z",
+    l1_func = CalcSimL1Norm(["density","velocity_x","velocity_y","velocity_z",
                              "pressure",])
 
     # define the template for the directory holding the simulation data
@@ -115,20 +115,17 @@ def cleanup():
 
 if __name__ == '__main__':
 
-    executable = 'bin/enzo-e'
+    executable = os.environ.get('ENZOE_BIN', 'bin/enzo-e')
 
-    # this script can either be called from the base repository or from
-    # the subdirectory: input/vlct
-    prep_cur_dir(executable)
+    with testing_context():
+        # run the tests
+        tests_complete = run_tests(executable)
 
-    # run the tests
-    tests_complete = run_tests(executable)
+        # analyze the tests
+        tests_passed = analyze_tests()
 
-    # analyze the tests
-    tests_passed = analyze_tests()
-
-    # cleanup the tests
-    cleanup()
+        # cleanup the tests
+        cleanup()
 
     if tests_passed:
         sys.exit(0)

--- a/input/vlct/run_MHD_linear_wave_test.py
+++ b/input/vlct/run_MHD_linear_wave_test.py
@@ -12,6 +12,7 @@
 #   2.) Check that the L1-norm error is the same for left propagating and right
 #       propagating fast waves
 
+import os
 import os.path
 import shutil
 import sys
@@ -21,7 +22,7 @@ from functools import partial
 import numpy as np
 
 from testing_utils import \
-  CalcSimL1Norm, EnzoEWrapper, isclose, standard_analyze, prep_cur_dir
+  CalcSimL1Norm, EnzoEWrapper, isclose, standard_analyze, testing_context
 
 
 # this executes things in standalone mode
@@ -155,8 +156,7 @@ def identical_l1_error_linwave(nblocks, wave_name, res, l1_functor, template,
 
 def analyze_tests():
     # define the functor for evaluating the norm of the L1 error vector
-    l1_func = CalcSimL1Norm("tools/l1_error_norm.py",
-                            ["density","velocity_x","velocity_y","velocity_z",
+    l1_func = CalcSimL1Norm(["density","velocity_x","velocity_y","velocity_z",
                              "pressure","bfield_x","bfield_y","bfield_z"])
 
     # define the template for the directory holding the simulation data
@@ -229,20 +229,18 @@ def cleanup():
 
 if __name__ == '__main__':
 
-    executable = 'bin/enzo-e'
+    executable = os.environ.get('ENZOE_BIN', 'bin/enzo-e')
 
-    # this script can either be called from the base repository or from
-    # the subdirectory: input/vlct
-    prep_cur_dir(executable)
+    with testing_context():
 
-    # run the tests
-    tests_complete = run_tests(executable)
+        # run the tests
+        tests_complete = run_tests(executable)
 
-    # analyze the tests
-    tests_passed = analyze_tests()
+        # analyze the tests
+        tests_passed = analyze_tests()
 
-    # cleanup the tests
-    cleanup()
+        # cleanup the tests
+        cleanup()
 
     if tests_passed:
         sys.exit(0)

--- a/input/vlct/run_MHD_shock_tube_test.py
+++ b/input/vlct/run_MHD_shock_tube_test.py
@@ -12,6 +12,7 @@
 #
 # We should probably try small convergence tests like Athena++
 
+import os
 import os.path
 import sys
 import shutil
@@ -20,7 +21,7 @@ from functools import partial
 import numpy as np
 
 from testing_utils import \
-    prep_cur_dir, standard_analyze, EnzoEWrapper, CalcTableL1Norm
+    testing_context, standard_analyze, EnzoEWrapper, CalcTableL1Norm
 
 def run_tests(executable):
 
@@ -60,8 +61,7 @@ def analyze_shock(ref_val, axis, target_template, name_template,
 def analyze_tests():
     # define the functor for evaluating the norm of the L1 error vector
     ref_table = "input/vlct/MHD_shock_tube/rj2a_shock_tube_t0.2_res256.csv"
-    l1_func= CalcTableL1Norm("tools/l1_error_norm.py",
-                             ["density","velocity_x","velocity_y","velocity_z",
+    l1_func= CalcTableL1Norm(["density","velocity_x","velocity_y","velocity_z",
                               "pressure","bfield_x","bfield_y","bfield_z"],
                              default_ref_table = ref_table)
 
@@ -102,20 +102,18 @@ def cleanup():
 
 if __name__ == '__main__':
 
-    executable = 'bin/enzo-e'
+    executable = os.environ.get('ENZOE_BIN', 'bin/enzo-e')
 
-    # this script can either be called from the base repository or from
-    # the subdirectory: input/vlct
-    prep_cur_dir(executable)
+    with testing_context():
 
-    # run the tests
-    run_tests(executable)
+        # run the tests
+        run_tests(executable)
 
-    # analyze the tests
-    tests_passed = analyze_tests()
+        # analyze the tests
+        tests_passed = analyze_tests()
 
-    # cleanup the tests
-    cleanup()
+        # cleanup the tests
+        cleanup()
 
     if tests_passed:
         sys.exit(0)

--- a/input/vlct/run_dual_energy_cloud_test.py
+++ b/input/vlct/run_dual_energy_cloud_test.py
@@ -14,7 +14,7 @@ import yt
 
 yt.mylog.setLevel(30) # set yt log level to "WARNING"
 
-from testing_utils import prep_cur_dir, EnzoEWrapper
+from testing_utils import testing_context, EnzoEWrapper
 
 def run_tests(executable):
 
@@ -99,20 +99,17 @@ def cleanup():
             shutil.rmtree(dir_name)
 
 if __name__ == '__main__':
-    executable = 'bin/enzo-e'
+    executable = os.environ.get('ENZOE_BIN', 'bin/enzo-e')
 
-    # this script can either be called from the base repository or from
-    # the subdirectory: input/vlct
-    prep_cur_dir(executable)
+    with testing_context():
+        # run the tests
+        tests_complete = run_tests(executable)
 
-    # run the tests
-    tests_complete = run_tests(executable)
+        # analyze the tests
+        tests_passed = analyze_tests()
 
-    # analyze the tests
-    tests_passed = analyze_tests()
-
-    # cleanup the tests
-    cleanup()
+        # cleanup the tests
+        cleanup()
 
     if tests_passed:
         sys.exit(0)

--- a/input/vlct/run_dual_energy_shock_tube_test.py
+++ b/input/vlct/run_dual_energy_shock_tube_test.py
@@ -30,7 +30,7 @@ import shutil
 import subprocess
 import math
 
-from testing_utils import prep_cur_dir, EnzoEWrapper, CalcTableL1Norm
+from testing_utils import testing_context, EnzoEWrapper, CalcTableL1Norm
 from run_MHD_shock_tube_test import analyze_shock
 
 def run_tests(executable):
@@ -50,8 +50,7 @@ def analyze_tests():
                       'sod_shock_tube_t0.25_res128.csv')
     verbose_l1_calc = False # Print out command line call
     verbose_analyze = False # Print out summaries of passed tests
-    l1_functor = CalcTableL1Norm("tools/l1_error_norm.py",
-                                 default_ref_table = ref_table_path,
+    l1_functor = CalcTableL1Norm(default_ref_table = ref_table_path,
                                  verbose = verbose_l1_calc)
     kwargs = dict(
         target_template = 'method_vlct-1-sod_{}_de_M10_0.25/',
@@ -112,31 +111,31 @@ if __name__ == '__main__':
             + "number of processes. {:d} arguments ".format(len(sys.argv)-1)
             + "were provided")
 
+    enzoe_binary = os.environ.get('ENZOE_BIN', 'bin/enzo-e')
+
     if nproc <= 0:
         raise ValueError("number of processes must be a positive integer")
     elif nproc == 1:
-        executable = 'bin/enzo-e'
+        executable = enzoe_binary
     else:
         charm_args = os.environ.get('CHARM_ARGS')
         if charm_args is None:
-            executable_template = 'charmrun +p{:d} bin/enzo-e'
+            executable_template = 'charmrun +p{:d} ' + enzoe_binary
         else:
             executable_template \
                 = ' '.join(['charmrun', charm_args, '+p{:d}', 'bin/enzo-e'])
         executable = executable_template.format(nproc)
 
-    # this script can either be called from the base repository or from
-    # the subdirectory: input/vlct
-    prep_cur_dir('bin/enzo-e')
+    with testing_context():
 
-    # run the tests
-    run_tests(executable)
+        # run the tests
+        run_tests(executable)
 
-    # analyze the tests
-    tests_passed = analyze_tests()
+        # analyze the tests
+        tests_passed = analyze_tests()
 
-    # cleanup the tests
-    cleanup()
+        # cleanup the tests
+        cleanup()
 
     if tests_passed:
         sys.exit(0)

--- a/input/vlct/run_dual_energy_shock_tube_test.py
+++ b/input/vlct/run_dual_energy_shock_tube_test.py
@@ -118,12 +118,22 @@ if __name__ == '__main__':
     elif nproc == 1:
         executable = enzoe_binary
     else:
+        if 'CHARM_HOME' in os.environ:
+            charm_binary = os.path.join(os.environ['CHARM_HOME'],
+                                        'bin/charmrun')
+            assert os.access(charm_binary, os.X_OK)
+        elif shutil.which('charmrun') is not None:
+            charm_binary = 'charmrun' # it's in our path
+        else:
+            raise RuntimeError("Could not find the charmrun binary. Use the "
+                               "CHARM_HOME environment variable to help "
+                               "specify its location.")
         charm_args = os.environ.get('CHARM_ARGS')
         if charm_args is None:
-            executable_template = 'charmrun +p{:d} ' + enzoe_binary
+            executable_template = charm_binary + ' +p{:d} ' + enzoe_binary
         else:
             executable_template \
-                = ' '.join(['charmrun', charm_args, '+p{:d}', 'bin/enzo-e'])
+                = ' '.join([charm_binary, charm_args, '+p{:d}', 'bin/enzo-e'])
         executable = executable_template.format(nproc)
 
     with testing_context():

--- a/input/vlct/run_passive_advect_sound_test.py
+++ b/input/vlct/run_passive_advect_sound_test.py
@@ -20,12 +20,11 @@ import sys
 
 import numpy as np
 
-from testing_utils import EnzoEWrapper, CalcSimL1Norm, isclose, prep_cur_dir
+from testing_utils import EnzoEWrapper, CalcSimL1Norm, isclose, testing_context
 
 data_dir_template = "method_vlct-1-{:s}_passive_soundN16-{:.1f}"
 
-calc_l1_norm = CalcSimL1Norm("tools/l1_error_norm.py",
-                             ["density","velocity_x","velocity_y","velocity_z",
+calc_l1_norm = CalcSimL1Norm(["density","velocity_x","velocity_y","velocity_z",
                               "total_energy","bfield_x","bfield_y","bfield_z",
                               "red"])
 
@@ -90,20 +89,18 @@ def cleanup():
 
 if __name__ == '__main__':
 
-    executable = 'bin/enzo-e'
+    executable = os.environ.get('ENZOE_BIN', 'bin/enzo-e')
 
-    # this script can either be called from the base repository or from
-    # the subdirectory: input/vlct
-    prep_cur_dir(executable)
+    with testing_context():
 
-    # run the tests
-    run_tests(executable)
+        # run the tests
+        run_tests(executable)
 
-    # analyze the tests
-    tests_passed = analyze_tests()
+        # analyze the tests
+        tests_passed = analyze_tests()
 
-    # cleanup the tests
-    cleanup()
+        # cleanup the tests
+        cleanup()
 
     if tests_passed:
         sys.exit(0)

--- a/test/run_vlct_test.sh
+++ b/test/run_vlct_test.sh
@@ -58,6 +58,16 @@ if [[ "$YT_INSTALLED" == "0" ]]; then
     exit 1
 fi
 
+if [ ! -d ./test ]; then
+    if [ -e ./test ]; then
+        echo "A FILE called test exists that is not a directory"
+        exit 1
+    fi
+    echo "There is no directory called ./test - Creating it now"
+    mkdir test
+fi
+
+
 
 # Now to run the actual tests:
 


### PR DESCRIPTION
I've made 2 main changes to the python scripts used to run the VL+CT tests.

1. I made it possible to run those scripts from any directory. This should help a lot with executing these tests using `ctest` (in https://github.com/jobordner/enzo-e/pull/4 ). Longer term, we might want to refactor some of these tests.

2. I tweaked `run_dual_energy_shock_tube_test.py` to let you run the test in parallel with `charmrun` when it's not in your `PATH` (this was an oversight). This is done by looking at the `CHARM_HOME` directory.