### PR TITLE
Annotated ``cello::error`` with the ``[[noreturn]]`` attribute

### DIFF
--- a/src/Cello/error_Error.cpp
+++ b/src/Cello/error_Error.cpp
@@ -69,7 +69,7 @@ extern void cello::message
 
 //----------------------------------------------------------------------
 
-void cello::error()
+[[ noreturn ]] void cello::error()
 {
   const int buffer_size = 64;
 

--- a/src/Cello/error_Error.hpp
+++ b/src/Cello/error_Error.hpp
@@ -310,7 +310,7 @@ namespace cello {
    const char * message,
    ...);
 
-  void error();
+  [[ noreturn ]] void error();
 }
 
 #endif /* ERROR_ERROR_HPP */


### PR DESCRIPTION
Apologies for the influx of small pull requests. But this one should be extremely easy to review.

For the following snippet of code:

```
int foo(char arg){
  if (arg == 'a'){
    return 0;
  } else if (arg == 'b'){
    return 1;
  }
  ERROR("foo", "arg must be 'a' or 'b'");
}
```

The compiler would have previously issued a warning (depending on the compiler flags) saying complaining that we are missing a return statement at end of a non-void function. The same thing would happen if we replaced the if-statement with an exhaustive switch statement.

However, now that we have introduced this attribute, the compiler now understands that we will never reach the end of the `foo` function when we raise an error and it will no longer issue a warning.

More details about the `noreturn` attribute can be found here: https://en.cppreference.com/w/cpp/language/attributes/noreturn