### PR TITLE
Quick Bugfix in RestartTest

### DIFF
--- a/build.sh
+++ b/build.sh
@@ -172,7 +172,7 @@ printf "done\n"
 printf "done\n" >> $log
 
 # TESTS
-
+count_test_crashes=0
 if [ $target == "test" ]; then
 
     rm -f              test/STOP
@@ -203,6 +203,7 @@ if [ $target == "test" ]; then
       crash=$((test_begin - $test_end))
 
       if [ $crash != 0 ]; then
+         let "count_test_crashes++"
          line="   CRASH: $test\n"
          printf "$line"
          printf "$line" >> $log
@@ -258,6 +259,7 @@ if [ $target == "test" ]; then
     
     echo "Test run summary"
     echo
+    echo "   Test runs crashed:   $count_test_crashes"
     echo "   Test runs attempted: $count_attempted"
     echo "   Test runs started:   $count_started"
     if [ $count_attempted -gt $count_started ]; then
@@ -273,7 +275,7 @@ if [ $target == "test" ]; then
     fi
     echo
 
-    if [ $f -gt 0 ] || [ $crash -gt 0 ] ; then
+    if [ $f -gt 0 ] || [ $count_test_crashes -gt 0 ] ; then
 	echo "Exiting testing with failures:"
 	echo "@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@"
 	cat "$dir/fail.$configure"

--- a/input/Checkpoint/checkpoint_vlct.in
+++ b/input/Checkpoint/checkpoint_vlct.in
@@ -22,6 +22,7 @@
       list = ["mhd_vlct"];
       mhd_vlct{
          courant = 0.4;
+         mhd_choice = "no_bfield";
          riemann_solver = "hllc";
          half_dt_reconstruct_method = "nn";
          full_dt_reconstruct_method = "plm";

--- a/src/Enzo/enzo_EnzoConfig.hpp
+++ b/src/Enzo/enzo_EnzoConfig.hpp
@@ -78,6 +78,13 @@ inline void operator|(PUP::er &p, chemistry_data &c){
  p | c.radiative_transfer_hydrogen_only;
  p | c.self_shielding_method;
  p | c.H2_self_shielding;
+ p | c.h2_charge_exchange_rate;
+ p | c.h2_dust_rate;
+ p | c.h2_h_cooling_rate;
+ p | c.collisional_excitation_rates;
+ p | c.collisional_ionisation_rates;
+ p | c.recombination_cooling_rates;
+ p | c.bremsstrahlung_cooling_rates;
 }
 #endif
 

--- a/test/Restart/SConscript
+++ b/test/Restart/SConscript
@@ -58,13 +58,15 @@ env_mv_out=env.Clone(COPY = 'mv *.png *.h5 Dir_* ' + test_path)
 # setup the checkpoint-restart tests
 import os, os.path
 if use_valgrind == 0:
+    import sys
+    python_path = sys.executable
 
     # All of the SCons paths are given relative to main-directory.
     # This tool is meant to be executed from within the current directory.
     # With that in mind, we need to adjust the paths in the commands
-    _cmd = ('../../tools/ckpt_restart_test.py $TEST_NAME '
-            '--input ../../$INPUTFILE --output ../../$TARGET '
-            '--include-directive-root ../../ --restart_cycle $RESTART_CYCLE '
+    _cmd = (python_path + ' ../../tools/ckpt_restart_test.py $TEST_NAME '
+            '--input ../../$INPUTFILE --output ../../$TARGET ' +
+            '--include-directive-root ../../ --restart_cycle $RESTART_CYCLE ' +
             '--stop_cycle $STOP_CYCLE --enzo ../../$SOURCE')
 
     _parallel_run_parts = parallel_run.split()


### PR DESCRIPTION
It's come to my attention that the checkpoint-restart test for the VL+CT test is failing. I've confirmed that it's breaking for a very simple reason (I forgot to add the `Method:mhd_vlct:mhd_choice` parameter to the input file in PR #74).

But before I upload the commit solving this problem, I'm first going to make sure I've resolved a minor bug in `build.sh` that had let the script exit with an exit-code indicating success, even when some tests crashed. I believe, this prevented the bug from being reported by the Continuous Integration (in other words, I want to confirm that the Continuous Integration reports a failure once I've fixed the bug in `build.sh`, but not the VL+CT checkpoint bug).

**EDIT:** This is now ready for review. I also had to update the PUP routine for Grackle's `chemistry_data` struct. This should be extremely easy to review.