### PR TITLE
`EnzoMethodGrackle` Hotfix: Fixed bug in `cello::define_field_in_group`

### DIFF
--- a/src/Cello/cello.cpp
+++ b/src/Cello/cello.cpp
@@ -310,8 +310,9 @@ namespace cello {
   (std::string field_name, std::string group_name,
    int cx, int cy, int cz)
   {
-    define_field (field_name,cx,cy,cz);
+    int out = define_field (field_name,cx,cy,cz);
     field_groups()->add(field_name,group_name);
+    return out;
   }
  
   //---------------------------------------------------------------------- 


### PR DESCRIPTION
The function in question did not return any values (when it should have been returning the id of the newly created field). 

This caused the function to cause a segmentation fault whenever it was executed while using the default settings for `linux_gnu` (which involve heavy optimizations), with at least some version of gcc (I encountered the issue with version 9.3.0).

The only automated test that executed this function is currently the Checkpoint-Restart test for `EnzoMethodGrackle`. But to be clear, ANY simulation involving Grackle would be affected by this bug (there just aren't any other automated tests involving Grackle).