### PR TITLE
Multispecies Cosmology

### DIFF
--- a/SConstruct
+++ b/SConstruct
@@ -262,6 +262,7 @@ elif (arch == "faraday_gnu"):  from faraday_gnu  import *
 elif (arch == "faraday_gnu_debug"):  from faraday_gnu_debug  import *
 elif (arch == "frontera_gcc"): from frontera_gcc import *
 elif (arch == "frontera_icc"): from frontera_icc import *
+elif (arch == "expanse_icc"):  from expanse_icc  import *
 elif (arch == "mf_gnu"):       from mf_gnu       import *
 elif (arch == "mf_gnu_debug"): from mf_gnu_debug import *
 elif (arch == "stampede_gnu"): from stampede_gnu import *

--- a/config/expanse_icc.py
+++ b/config/expanse_icc.py
@@ -1,0 +1,75 @@
+import os
+from _common_search_paths import charm_path_search, grackle_path_search
+
+is_arch_valid = 1
+use_gfortran = 0
+smp = 0
+
+flags_arch = '-Wall -O3 -g'
+#flags_arch = '-fprofile-arcs -ftest-coverage'
+#flags_arch = '-Wall -g'
+#flags_arch = '-Wall -g -fsanitize=address -fno-omit-frame-pointer'
+#flags_arch = '-Wall -O3 -pg'
+
+# rdynamic required for backtraces
+#flags_link_charm = '-rdynamic' 
+#flags_link_charm = '-memory paranoid' 
+
+intel_dir = '/cm/shared/apps/spack/cpu/opt/spack/linux-centos8-zen/gcc-8.3.1/intel-19.1.1.217-4d42ptjd6wsnh5bgbzcv6lp44vxpjwut/compilers_and_libraries_2020.1.217/linux/bin/intel64'
+cc  = intel_dir + '/icc'
+f90 = intel_dir + '/ifort'
+
+flags_prec_single = ''
+flags_prec_double = '-r8'
+
+libpath_fortran = '/cm/shared/apps/spack/cpu/opt/spack/linux-centos8-zen/gcc-8.3.1/intel-19.1.1.217-4d42ptjd6wsnh5bgbzcv6lp44vxpjwut/compilers_and_libraries_2020.1.217/linux/compiler/lib/intel64'
+libs_fortran    = ['ifcore', 'ifport']
+
+
+#USE GFORTRAN INSTEAD OF IFORT
+if use_gfortran:
+    f90 = 'gfortran'
+    libpath_fortran = '/cm/shared/apps/spack/cpu/opt/spack/linux-centos8-zen/gcc-8.3.1/gcc-10.2.0-n7su7jf54rc7l2ozegds5xksy6qhrjin/lib64'
+    libs_fortran = ['gfortran']
+    flags_arch_fortran = '-ffixed-line-length-132'
+    flags_prec_double = '-fdefault-real-8 -fdefault-double-8'
+    flags_arch = '-O3 -Wall'
+    flags_fc = ''
+
+#############################
+
+home = os.getenv('HOME')
+
+charm_path = charm_path_search(home)
+
+use_papi=0
+papi_inc = '/usr/local/include'
+papi_lib = '/usr/local/lib'
+
+boost_path = os.getenv('BOOST_HOME')
+boost_inc  = boost_path + '/include'
+boost_lib  = boost_path + '/lib'
+
+hdf5_inc = os.getenv('HDF5HOME') + '/include'
+if hdf5_inc is None:
+	if os.path.exists('/usr/include/hdf5.h'):
+	        hdf5_inc    = '/usr/include'
+	elif os.path.exists('/usr/include/hdf5/serial/hdf5.h'):
+		hdf5_inc    = '/usr/include/hdf5/serial'
+	else:
+		raise Exception('HDF5 include file was not found.  Try setting the HDF5_INC environment variable such that $HDF5_INC/hdf5.h exists.')
+
+hdf5_lib = os.getenv('HDF5HOME') + '/lib'
+if hdf5_lib is None:
+	if os.path.exists('/usr/lib/libhdf5.a'):
+		hdf5_lib    = '/usr/lib'
+	elif os.path.exists('/usr/lib/x86_64-linux-gnu/hdf5/serial/libhdf5.a'):
+		hdf5_lib    = '/usr/lib/x86_64-linux-gnu/hdf5/serial'
+	else:
+		raise Exception('HDF5 lib file was not found.  Try setting the HDF5_LIB environment variable such that $HDF5_LIB/libhdf5.a exists.')
+
+png_path = os.getenv('LIBPNG_HOME')
+if png_path is None:
+	png_path     = '/lib/x86_64-linux-gnu'
+
+grackle_path = home + '/local' #grackle_path_search(home)

--- a/input/test_cosmo-dd-multispecies.in
+++ b/input/test_cosmo-dd-multispecies.in
@@ -1,0 +1,109 @@
+include "input/test_cosmo-dd-fc0.in"
+
+
+Field {
+   list += ["HI_density",
+	   "HII_density",
+	   "HeI_density",
+	   "HeII_density",
+	   "HeIII_density",
+	   "e_density",
+           "metal_density",
+	   "cooling_time",
+	   "temperature",
+	   "gamma"];
+}
+
+Group {
+    list = ["color", "derived"];
+    color {
+       field_list = [
+              "HI_density",
+              "HII_density",
+              "HeI_density",
+              "HeII_density",
+              "HeIII_density",
+              "e_density",
+              "metal_density",
+              "cooling_time",
+              "temperature",
+              "pressure",
+              "gamma" ];
+    }
+
+    derived {
+	field_list = ["temperature",
+		      "pressure",
+		      "cooling_time"];
+    }
+
+}
+
+Method {
+     list = [ "pm_deposit", "gravity", "ppm", "grackle", "pm_update", "comoving_expansion" ];
+    
+     output {
+        field_list += ["HI_density",
+	                 "HII_density",
+	                 "HeI_density",
+	                 "HeII_density",
+	                 "HeIII_density",
+	                 "e_density",
+                         "metal_density",
+	                 "cooling_time",
+	                 "temperature",
+	                 "gamma"]; 
+     } 
+     grackle {
+        courant = 0.50; # meaningless unless use_cooling_timestep = true;
+
+        data_file = "input/CloudyData_UVB=HM2012.h5";
+
+        with_radiative_cooling  = 1;
+        primordial_chemistry    = 1;  # 1, 2, or 3
+        metal_cooling           = 0;  # 0 or 1 (off/on)
+        UVbackground            = 1;  # on or off
+        metallicity_floor = 0.0; # metallicity floor in solar units
+        cmb_temperature_floor   = 1;
+
+        self_shielding_method = 0;  # see pg. 23-24 of https://grackle.readthedocs.io/_/downloads/en/latest/pdf/
+
+        HydrogenFractionByMass = 0.73;
+
+        # set this to true to limit the maximum timestep to the product of the
+        # minimum cooling/heating time and courant.
+        use_cooling_timestep = false; # default is false
+     }
+}
+
+
+Output {
+     list = ["hdf5"];
+     hdf5 {
+          dir = ["Dir_COSMO_MULTI_%04d","cycle"];
+          field_list += ["HI_density",
+	                 "HII_density",
+	                 "HeI_density",
+	                 "HeII_density",
+	                 "HeIII_density",
+	                 "e_density",
+                         "metal_density",
+	                 "cooling_time",
+	                 "temperature",
+	                 "gamma"];
+        }
+     de   { dir = [ "Dir_COSMO_MULTI_%04d", "cycle" ]; }
+     depa { dir = [ "Dir_COSMO_MULTI_%04d", "cycle" ]; }
+     ax   { dir = [ "Dir_COSMO_MULTI_%04d", "cycle" ]; }
+     ay   { dir = [ "Dir_COSMO_MULTI_%04d", "cycle" ]; }
+     az   { dir = [ "Dir_COSMO_MULTI_%04d", "cycle" ]; }
+     dark { dir = [ "Dir_COSMO_MULTI_%04d", "cycle" ]; }
+     mesh { dir = [ "Dir_COSMO_MULTI_%04d", "cycle" ]; }
+     po   { dir = [ "Dir_COSMO_MULTI_%04d", "cycle" ]; }
+     hdf5 { dir = [ "Dir_COSMO_MULTI_%04d", "cycle" ]; }
+     dep  { dir = [ "Dir_COSMO_MULTI_%04d", "cycle" ]; }
+     check { dir = [ "Dir_COSMO_MULTI_%04d-checkpoint", "count" ]; }
+}
+
+Stopping {cycle = 160;}
+

--- a/src/Cello/cello.hpp
+++ b/src/Cello/cello.hpp
@@ -510,6 +510,9 @@ namespace cello {
   // Solar mass in CGS
   const double mass_solar = 1.98841586e33;
 
+  // Solar metallicity
+  const double metallicity_solar = 0.012;
+
   // Hydrogen mass in CGS
   const double mass_hydrogen = 1.67262171e-24;
 

--- a/src/Enzo/enzo_EnzoConfig.cpp
+++ b/src/Enzo/enzo_EnzoConfig.cpp
@@ -234,6 +234,7 @@ EnzoConfig::EnzoConfig() throw ()
   method_grackle_chemistry(),
   method_grackle_use_cooling_timestep(false),
   method_grackle_radiation_redshift(-1.0),
+  method_grackle_metallicity_floor(0.0),
 #endif
   // EnzoMethodGravity
   method_gravity_grav_const(0.0),
@@ -619,6 +620,7 @@ void EnzoConfig::pup (PUP::er &p)
   if (method_grackle_use_grackle) {
     p  | method_grackle_use_cooling_timestep;
     p  | method_grackle_radiation_redshift;
+    p  | method_grackle_metallicity_floor;
     if (p.isUnpacking()) { method_grackle_chemistry = new chemistry_data; }
     p | *method_grackle_chemistry;
   } else {
@@ -1242,6 +1244,11 @@ void EnzoConfig::read_method_grackle_(Parameters * p)
     // for when not using cosmology - redshift of UVB
     method_grackle_radiation_redshift = p->value_float
       ("Method:grackle:radiation_redshift", -1.0);
+
+    // set a metallicity floor
+    method_grackle_metallicity_floor = p-> value_float
+      ("Method:grackle:metallicity_floor", 0.0);
+
 
     // Set Grackle parameters from parameter file
     method_grackle_chemistry->with_radiative_cooling = p->value_integer

--- a/src/Enzo/enzo_EnzoConfig.hpp
+++ b/src/Enzo/enzo_EnzoConfig.hpp
@@ -335,6 +335,7 @@ public: // interface
       method_grackle_chemistry(nullptr),
       method_grackle_use_cooling_timestep(false),
       method_grackle_radiation_redshift(-1.0),
+      method_grackle_metallicity_floor(0.0),
 #endif
       // EnzoMethodGravity
       method_gravity_grav_const(0.0),
@@ -729,6 +730,7 @@ public: // attributes
   chemistry_data *           method_grackle_chemistry;
   bool                       method_grackle_use_cooling_timestep;
   double                     method_grackle_radiation_redshift;
+  double                     method_grackle_metallicity_floor;
 #endif /* CONFIG_USE_GRACKLE */
 
   /// EnzoMethodGravity

--- a/src/Enzo/enzo_EnzoInitialCosmology.cpp
+++ b/src/Enzo/enzo_EnzoInitialCosmology.cpp
@@ -72,5 +72,29 @@ void EnzoInitialCosmology::enforce_block
   }
 
   block->initial_done();
-  
+
+#ifdef CONFIG_USE_GRACKLE
+  // initialize chemistry fields if doing multispecies 
+  if (enzo::config()->method_grackle_chemistry)
+  {
+    chemistry_data * grackle_chemistry =
+    enzo::config()->method_grackle_chemistry;
+ 
+    if ( (grackle_chemistry->primordial_chemistry > 0) || (grackle_chemistry->metal_cooling == 1))
+    {
+        Field field = block->data()->field();
+        EnzoBlock * enzo_block = enzo::block(block);
+        grackle_field_data grackle_fields_; 
+        code_units grackle_units_;
+ 
+        //create data struct to be fed into grackle
+        EnzoMethodGrackle::setup_grackle_units(enzo_block, & grackle_units_);        
+        EnzoMethodGrackle::setup_grackle_fields(enzo_block, & grackle_fields_);
+
+        //initialize density fields for various chemical species
+        EnzoMethodGrackle::update_grackle_density_fields(enzo_block, & grackle_fields_);
+    }
+  }
+#endif 
+
 }

--- a/src/Enzo/enzo_EnzoMethodGrackle.hpp
+++ b/src/Enzo/enzo_EnzoMethodGrackle.hpp
@@ -198,6 +198,8 @@ public: // interface
 			    "local_calculate_temperature");
   }
 
+  void enforce_metallicity_floor(EnzoBlock * enzo_block) throw();
+
 #endif
 
 protected: // methods

--- a/src/Enzo/enzo_SolveHydroEquations.cpp
+++ b/src/Enzo/enzo_SolveHydroEquations.cpp
@@ -71,9 +71,6 @@ int EnzoBlock::SolveHydroEquations
 
   }
 
-  // No subgrids, so colindex is NULL
-  int *colindex         = NULL;
-
   /* Compute size (in enzo_floats) of the current grid. */
 
   int rank = cello::rank();
@@ -174,6 +171,7 @@ int EnzoBlock::SolveHydroEquations
   int *vindex    = p; p+=3*2;
   int *windex    = p; p+=3*2;
   int *geindex   = p; p+=3*2;
+  int *colindex  = p; p+=3*2*ncolor;
 
   // Offsets computed from the "standard" pointer to the start of each
   // flux data
@@ -196,7 +194,8 @@ int EnzoBlock::SolveHydroEquations
   long long min=std::numeric_limits<long long>::max();
   long long max=std::numeric_limits<long long>::lowest();
 #endif  
-  
+ 
+  index_color = 0; 
   for (int i_f=0; i_f<nf; i_f++) {
     int * flux_index = 0;
     const int index_field = flux_data->index_field(i_f);
@@ -208,6 +207,11 @@ int EnzoBlock::SolveHydroEquations
     if (field_name == "velocity_z")      flux_index = windex;
     if (field_name == "total_energy")    flux_index = Eindex;
     if (field_name == "internal_energy") flux_index = geindex;
+    
+    if (field.groups()->is_in(field_name,"color")) {
+      flux_index = colindex + 3*2*index_color;
+      index_color++;
+    }
 
     for (int axis=0; axis<rank; axis++) {
       leftface[axis] = l3[axis];


### PR DESCRIPTION
Resubmitting this PR in a cleaner state

Changes are as follows:

1. Small bugfix in `enzo_SolveHydroEquations.cpp`, where `colindex` was initialized as NULL and never updated, which caused segfaults when doing color field advection.
2. Initializing chemistry fields in `enzo_EnzoInitialCosmology.cpp`
3. Explicitly calculating cosmology units in `EnzoMethodGrackle::setup_grackle_units()`. This is necessary because `setup_grackle_units` gets called in the constructor, which causes virtual functions `enzo_units->length()`, `time()`, etc. to reference the wrong version when doing cosmology runs
4. Added metallicity floor parameter
5. Added config file for building on Expanse