### PR TITLE
ParticleDescr helper functions fix

### DIFF
--- a/src/Cello/data_Particle.hpp
+++ b/src/Cello/data_Particle.hpp
@@ -204,8 +204,8 @@ public: // interface
 
   /// Check if given constant exists
 
-  bool has_constant(int it, std::string constant) const
-  { return particle_descr_->has_constant(it,constant); }
+  bool is_constant(int it, std::string constant) const
+  { return particle_descr_->is_constant(it,constant); }
 
 
   //--------------------------------------------------

--- a/src/Cello/data_ParticleDescr.cpp
+++ b/src/Cello/data_ParticleDescr.cpp
@@ -262,11 +262,7 @@ bool ParticleDescr::is_attribute(int it, std::string attribute_name) const
 
   auto iter=attribute_index_[it].find(attribute_name);
 
-  int index = (iter != attribute_index_[it].end()) ? iter->second : -1;
-
-  static int count[CONFIG_NODE_SIZE] = {0};
-
-  return !((index == -1) && (count[cello::index_static()]++ < 10));
+  return iter != attribute_index_[it].end();
 }
 //----------------------------------------------------------------------
 

--- a/src/Cello/data_ParticleDescr.cpp
+++ b/src/Cello/data_ParticleDescr.cpp
@@ -409,7 +409,7 @@ int ParticleDescr::constant_offset (int it, int ic) const
 
 //----------------------------------------------------------------------
 
-bool ParticleDescr::has_constant(int it, std::string constant_name) const
+bool ParticleDescr::is_constant(int it, std::string constant_name) const
 {
   ASSERT1("ParticleDescr::constant_index",
           "Trying to access unknown particle type %d",
@@ -418,9 +418,8 @@ bool ParticleDescr::has_constant(int it, std::string constant_name) const
 
   auto iter=constant_index_[it].find(constant_name);
 
-  bool check = (iter != constant_index_[it].end()) ? true : false;
-
-  return check;
+  return iter != constant_index_[it].end();
+  
 }
 
 

--- a/src/Cello/data_ParticleDescr.hpp
+++ b/src/Cello/data_ParticleDescr.hpp
@@ -84,7 +84,7 @@ public: // interface
 
   /// Check if given constant exists for the given particle type
 
-  bool has_constant (int it, std::string constant) const;
+  bool is_constant (int it, std::string constant) const;
 
   //--------------------------------------------------
   // ATTRIBUTES

--- a/src/Enzo/enzo_EnzoMethodPmDeposit.cpp
+++ b/src/Enzo/enzo_EnzoMethodPmDeposit.cpp
@@ -168,7 +168,7 @@ void EnzoMethodPmDeposit::compute ( Block * block) throw()
 
       // Determine if particle has a constant mass, or if mass varies
       // and we need to use the mass attribute
-      if (particle.has_constant (it,"mass")){
+      if (particle.is_constant (it,"mass")){
 
         const int ic_mass = particle.constant_index (it, "mass");
         dens = *((enzo_float *)(particle.constant_value (it,ic_mass)));


### PR DESCRIPTION
Two small changes:

1 - Renamed ParticleDescr::has_constant to ParticleDescr::is_constant and simplified the code a bit
2 - Simplified ParticleDescr::is_attribute. No longer uses the const variable. Simply tests if a given attribute name is in a particle types list of attributes.
