### PR TITLE
Unpins the version numbers of matplotlib and yt

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -54,7 +54,7 @@ commands:
             pip install --upgrade pip
             pip install --upgrade wheel
             pip install --upgrade setuptools
-            pip install Cython numpy h5py matplotlib==3.3.3 libconf yt==3.6.1
+            pip install Cython numpy h5py matplotlib libconf yt
 
   install-grackle:
     description: "Install grackle."


### PR DESCRIPTION
The version numbers of matplotlib and yt installed in the CircleCI pipeline are no longer pins. This allows tests to use the latest versions of these packages.