### PR TITLE
Load Balance regression tests #135

### DIFF
--- a/test/SConscript
+++ b/test/SConscript
@@ -45,26 +45,26 @@ enzo_bin = bin_path + '/enzo-e'
 #----------------------------------------------------------------------
 ### TEMPORARILY DISABLED: pending addressing Issue 135
 ### https://github.com/enzo-project/enzo-e/issues/135
-### SConscript('Balance/SConscript')
+SConscript('Balance/SConscript')
 #----------------------------------------------------------------------
 
 #----------------------------------------------------------------------
 # ARRAY COMPONENT
 #----------------------------------------------------------------------
-SConscript('ArrayComponent/SConscript')
+##SConscript('ArrayComponent/SConscript')
 
 #----------------------------------------------------------------------
 # DATA COMPONENT
 #----------------------------------------------------------------------
 #----------------------------------------------------------------------
-SConscript('DataComponent/SConscript')
+##SConscript('DataComponent/SConscript')
 #----------------------------------------------------------------------
 
 #----------------------------------------------------------------------
 # ERROR COMPONENT
 #----------------------------------------------------------------------
 #----------------------------------------------------------------------
-SConscript('ErrorComponent/SConscript')
+##SConscript('ErrorComponent/SConscript')
 #----------------------------------------------------------------------
 
 ### env.RunSerial('test_Refresh.unit', bin_path + '/test_Refresh')
@@ -75,45 +75,45 @@ SConscript('ErrorComponent/SConscript')
 #----------------------------------------------------------------------
 #INITIAL COMPONENT
 #----------------------------------------------------------------------
-SConscript('InitialComponent/SConscript')
+##SConscript('InitialComponent/SConscript')
 
 #----------------------------------------------------------------------
 # IOCOMPONENT
 #----------------------------------------------------------------------
-SConscript('IOComponent/SConscript')
+##SConscript('IOComponent/SConscript')
 
 #----------------------------------------------------------------------
 # MEMORY COMPONENT
 #----------------------------------------------------------------------
 #----------------------------------------------------------------------
-SConscript('MemoryComponent/SConscript')
+##SConscript('MemoryComponent/SConscript')
 
 #----------------------------------------------------------------------
 # METHOD Gravity TESTS
 #----------------------------------------------------------------------
-SConscript('MethodGravity/SConscript')
+##SConscript('MethodGravity/SConscript')
 
 ### env.RunSerial('test_ProlongLinear.unit',  bin_path + '/test_ProlongLinear')
 
 #----------------------------------------------------------------------
 # METHOD COSMOLOGY TESTS
 #----------------------------------------------------------------------
-SConscript('MethodCosmology/SConscript')
+##SConscript('MethodCosmology/SConscript')
 
 #----------------------------------------------------------------------
 # METHOD FLUX CORRECT TESTS
 #----------------------------------------------------------------------
-SConscript('MethodFluxCorrect/SConscript')
+##SConscript('MethodFluxCorrect/SConscript')
 
 #----------------------------------------------------------------------
 # METHOD HEAT TESTS
 #----------------------------------------------------------------------
-SConscript('MethodHeat/SConscript')
+##SConscript('MethodHeat/SConscript')
 
 #----------------------------------------------------------------------
 # METHOD PPM TESTS
 #----------------------------------------------------------------------
-SConscript('MethodPpm/SConscript')
+##SConscript('MethodPpm/SConscript')
 
 ### cosmo_cg = env_rm_png.RunParallel \
 ###       ('test_cosmo-cg.unit',enzo_bin, ARGS='input/test_cosmo-cg.in')
@@ -276,22 +276,22 @@ SConscript('MethodPpm/SConscript')
 #----------------------------------------------------------------------
 # SERIAL RESTART
 #----------------------------------------------------------------------
-SConscript('Restart/SConscript')
+##SConscript('Restart/SConscript')
 
 #----------------------------------------------------------------------
 # BOUNDARY CONDITIONS
 #----------------------------------------------------------------------
-SConscript('BoundaryConditions/SConscript')
+##SConscript('BoundaryConditions/SConscript')
 
 #----------------------------------------------------------------------
 # MESH GENERATION
 #----------------------------------------------------------------------
-SConscript('MeshGeneration/SConscript')
+##SConscript('MeshGeneration/SConscript')
 
 #----------------------------------------------------------------------
 # AMRPPM
 #----------------------------------------------------------------------
-SConscript('AmrPpm/SConscript')
+##SConscript('AmrPpm/SConscript')
 
 ### Clean(env_mv_out.RunParallel ('test_adapt-L5-P1.unit',enzo_bin, 
 ### 		ARGS='input/adapt-L5-P1.in'),
@@ -315,27 +315,27 @@ SConscript('AmrPpm/SConscript')
 
 
 #----------------------------------------------------------------------
-SConscript('Performance/SConscript')
+##SConscript('Performance/SConscript')
 
 #----------------------------------------------------------------------
 # OUTPUT
 #----------------------------------------------------------------------
-SConscript('Output/SConscript')
+##SConscript('Output/SConscript')
 
 #----------------------------------------------------------------------
 # PARTICLES
 #----------------------------------------------------------------------
-SConscript('Particles/SConscript')
+##SConscript('Particles/SConscript')
 
 #----------------------------------------------------------------------
 # CELLO
 #----------------------------------------------------------------------
-SConscript('Cello/SConscript')
+##SConscript('Cello/SConscript')
 
 #----------------------------------------------------------------------
 # UnitsComponent
 #----------------------------------------------------------------------
-SConscript('UnitsComponent/SConscript')
+##SConscript('UnitsComponent/SConscript')
 
 
 


### PR DESCRIPTION
I created the pull request to reproduce the Balance tests issue on circleci to understand. When I run each separately on our cluster, they don't hang and run but fail at cycle 8 due to timing setting in the input file.

 FAIL  0/1 include/enzo_finalize.hpp 13 Enzo-E final cycle
0 00002.32 Testing actual   cycle:  8
0 00002.32 Testing expected cycle:  20
0 00002.32 Testing actual   time:  0.05
0 00002.32 Testing tolerance:      0.0001
0 00002.32 Testing expected time:  0.00138340515331947
0 00002.32 Testing relative error: 0.972332
0 00002.32 Testing minimum relative error: 0.972332
 FAIL  0/1 include/enzo_finalize.hpp 36 Enzo-E final time