### PR TITLE
Address compiler warning - stop implicit cast from ``const char*`` to ``char*``

### DIFF
--- a/src/Enzo/FofLib.cpp
+++ b/src/Enzo/FofLib.cpp
@@ -289,7 +289,7 @@ static enzo_float *x1,*x2;
 /* LOCAL FUNCTIONS */
 /*******************/
 
-static void ErrorHandler(char *errstr) {
+static void ErrorHandler(const char *errstr) {
   /* Error handler */
   fprintf(stderr, "Fatal error in Foflib.c: %s.\n", errstr);
   fprintf(stderr, "Exiting to system.\n");


### PR DESCRIPTION
As the title implies, this avoids several unnecessary casts from ``const char*`` to ``char*`` (which previously raised compiler warnings)