### PR TITLE
Rename "type" parameter of star_maker and background_acceleration methods to "flavor" (bugfix)

### DIFF
--- a/input/IsolatedGalaxy/WLM_small.in
+++ b/input/IsolatedGalaxy/WLM_small.in
@@ -97,7 +97,7 @@
               "star_maker"];
 
       star_maker {
-                  type = "stochastic";
+                  flavor = "stochastic";
                   use_density_threshold    = true;
                   use_velocity_divergence  = false;
                   use_dynamical_time       = false;
@@ -132,7 +132,7 @@
       # values for the background NFW potential
       #    also can have background stellar bulge and / or stellar disk potential
       background_acceleration {
-          type = "GalaxyModel";
+          flavor = "GalaxyModel";
           DM_density     = -1.0   ;  # specify this OR mass - not both - mass_radius must be virial if this is used
           DM_mass        = 1.0E10;   # mass interior to below radius (in Msun) -  (this particular value is virial mass)
           DM_mass_radius = 45.0;     # radius (kpc) corresponding to above mass (this is virial)

--- a/input/IsolatedGalaxy/method_isolatedgalaxy-particles.in
+++ b/input/IsolatedGalaxy/method_isolatedgalaxy-particles.in
@@ -101,7 +101,7 @@
 #          }
 
       background_acceleration {
-          type = "GalaxyModel";
+          flavor = "GalaxyModel";
           DM_density     = 3.07199E-25 ;   # cgs - central density for 1E10 Msun NFW halo
           DM_mass        = -1.0 ;# 1.0E10; # set < 0 to use density, > 0 uses this instead of density
           DM_mass_radius = 45.0;           # kpc virial radius (or radius within which above mass refers to)

--- a/input/IsolatedGalaxy/method_isolatedgalaxy.in
+++ b/input/IsolatedGalaxy/method_isolatedgalaxy.in
@@ -101,7 +101,7 @@
 #          }
 
       background_acceleration {
-          type = "GalaxyModel";
+          flavor = "GalaxyModel";
           DM_density     = 3.07199E-25 ;   # cgs - central density for 1E10 Msun NFW halo
           DM_mass        = -1.0 ;# 1.0E10; # set < 0 to use density, > 0 uses this instead of density
           DM_mass_radius = 45.0;           # kpc virial radius (or radius within which above mass refers to)

--- a/input/bb_unigrid_SF_FB.in
+++ b/input/bb_unigrid_SF_FB.in
@@ -165,7 +165,7 @@ Particle {
 
      star_maker {
        # run the stochastic star formation algorithm taken from star_maker_ssn in Enzo
-       type = "stochastic";                # only available option at the moment
+       flavor = "stochastic";                # only available option at the moment
        number_density_threshold = 100.0;   # in 1/cm^3
        minimum_star_mass        = 1000.0;  # for the sake of this algorithm, this IS the
                                            # mass of the particle formed.

--- a/input/method_feedback.in
+++ b/input/method_feedback.in
@@ -86,7 +86,7 @@ Method {
   # star maker is turned on here as a method just to list and comment the parameters,
   # but setting number density to something stupid so no stars actually form
   star_maker {
-     type = "stochastic";
+     flavor = "stochastic";
      number_density_threshold = 1.0E10; # set arbitrarily high - just turns this off 
      minimum_star_mass        = 1000.0; # have to set this for use with feedback routine at the moment
                                         #   this sets the minimum star mass, but for the sake of stochastic

--- a/src/Enzo/enzo_EnzoConfig.cpp
+++ b/src/Enzo/enzo_EnzoConfig.cpp
@@ -216,7 +216,7 @@ EnzoConfig::EnzoConfig() throw ()
   method_feedback_use_ionization_feedback(false),
   method_feedback_time_first_sn(-1), // in Myr
   // EnzoMethodStarMaker,
-  method_star_maker_type(""),                              // star maker type to use
+  method_star_maker_flavor(""),                              // star maker type to use
   method_star_maker_use_density_threshold(true),           // check above density threshold before SF
   method_star_maker_use_velocity_divergence(true),         // check for converging flow before SF
   method_star_maker_use_dynamical_time(true),              // compute t_ff / t_dyn. Otherwise take as 1.0
@@ -244,7 +244,7 @@ EnzoConfig::EnzoConfig() throw ()
   method_gravity_dt_max(0.0),
   method_gravity_accumulate(false),
   /// EnzoMethodBackgroundAcceleration
-  method_background_acceleration_type(""),
+  method_background_acceleration_flavor(""),
   method_background_acceleration_mass(0.0),
   method_background_acceleration_DM_mass(0.0),
   method_background_acceleration_DM_density(0.0),
@@ -550,7 +550,7 @@ void EnzoConfig::pup (PUP::er &p)
   p | method_feedback_use_ionization_feedback;
   p | method_feedback_time_first_sn;
 
-  p | method_star_maker_type;
+  p | method_star_maker_flavor;
   p | method_star_maker_use_density_threshold;
   p | method_star_maker_use_velocity_divergence;
   p | method_star_maker_use_dynamical_time;
@@ -571,7 +571,7 @@ void EnzoConfig::pup (PUP::er &p)
   p | method_gravity_dt_max;
   p | method_gravity_accumulate;
 
-  p | method_background_acceleration_type;
+  p | method_background_acceleration_flavor;
   p | method_background_acceleration_mass;
   p | method_background_acceleration_DM_mass;
   p | method_background_acceleration_DM_density;
@@ -1421,8 +1421,8 @@ void EnzoConfig::read_method_feedback_(Parameters * p)
 void EnzoConfig::read_method_star_maker_(Parameters * p)
 {
   
-  method_star_maker_type = p->value_string
-    ("Method:star_maker:type","stochastic");
+  method_star_maker_flavor = p->value_string
+    ("Method:star_maker:flavor","stochastic");
 
   method_star_maker_use_density_threshold = p->value_logical
     ("Method:star_maker:use_density_threshold",true);
@@ -1461,8 +1461,8 @@ void EnzoConfig::read_method_star_maker_(Parameters * p)
 
 void EnzoConfig::read_method_background_acceleration_(Parameters * p)
 {
-  method_background_acceleration_type = p->value_string
-   ("Method:background_acceleration:type","unknown");
+  method_background_acceleration_flavor = p->value_string
+   ("Method:background_acceleration:flavor","unknown");
 
   method_background_acceleration_mass = p->value_float
    ("Method:background_acceleration:mass",0.0);

--- a/src/Enzo/enzo_EnzoConfig.hpp
+++ b/src/Enzo/enzo_EnzoConfig.hpp
@@ -318,7 +318,7 @@ public: // interface
       method_feedback_use_ionization_feedback(false),
       method_feedback_time_first_sn(-1.0), // in Myr
       /// EnzoMethodStarMaker
-      method_star_maker_type(""),
+      method_star_maker_flavor(""),
       method_star_maker_use_density_threshold(true),           // check above density threshold before SF
       method_star_maker_use_velocity_divergence(true),         // check for converging flow before SF
       method_star_maker_use_dynamical_time(true),              //
@@ -347,7 +347,7 @@ public: // interface
       method_gravity_dt_max(1.0e10),
       method_gravity_accumulate(false),
       // EnzoMethodBackgroundAcceleration
-      method_background_acceleration_type(""),
+      method_background_acceleration_flavor(""),
       method_background_acceleration_mass(0.0),
       method_background_acceleration_DM_mass(0.0),
       method_background_acceleration_DM_density(0.0),
@@ -721,7 +721,7 @@ public: // attributes
 
   /// EnzoMethodStarMaker
 
-  std::string               method_star_maker_type;
+  std::string               method_star_maker_flavor;
   bool                      method_star_maker_use_density_threshold;
   bool                      method_star_maker_use_velocity_divergence;
   bool                      method_star_maker_use_dynamical_time;
@@ -755,7 +755,7 @@ public: // attributes
 
   /// EnzoMethodBackgroundAcceleration
 
-  std::string                method_background_acceleration_type;
+  std::string                method_background_acceleration_flavor;
   double                     method_background_acceleration_mass;
   double                     method_background_acceleration_DM_mass;
   double                     method_background_acceleration_DM_density;

--- a/src/Enzo/enzo_EnzoMethodBackgroundAcceleration.cpp
+++ b/src/Enzo/enzo_EnzoMethodBackgroundAcceleration.cpp
@@ -123,18 +123,18 @@ void EnzoMethodBackgroundAcceleration::compute_ (Block * block) throw()
 
   Particle particle = enzo_block->data()->particle();
 
-  if (enzo_config->method_background_acceleration_type == "GalaxyModel"){
+  if (enzo_config->method_background_acceleration_flavor == "GalaxyModel"){
 
     this->GalaxyModel(ax, ay, az, &particle, rank,
                       cosmo_a, enzo_config, enzo_units, enzo_block->dt);
 
-  } else if (enzo_config->method_background_acceleration_type == "PointMass"){
+  } else if (enzo_config->method_background_acceleration_flavor == "PointMass"){
     this->PointMass(ax, ay, az, &particle, rank,
                     cosmo_a, enzo_config, enzo_units, enzo_block->dt);
   } else {
 
     ERROR("EnzoMethodBackgroundAcceleration::compute_()",
-          "Background acceleration type not recognized");
+          "Background acceleration flavor not recognized");
 
   }
 

--- a/src/Enzo/enzo_EnzoProblem.cpp
+++ b/src/Enzo/enzo_EnzoProblem.cpp
@@ -694,7 +694,7 @@ Method * EnzoProblem::create_method_
   } else if (name == "star_maker") {
 
     // should generalize this to enable multiple maker types
-    if (enzo_config->method_star_maker_type == "stochastic"){
+    if (enzo_config->method_star_maker_flavor == "stochastic"){
       method = new EnzoMethodStarMakerStochasticSF();
     } else{ // does not do anything
       method = new EnzoMethodStarMaker();


### PR DESCRIPTION
Previously, the `star_maker` and `background_acceleration` methods had a `type` parameter, which was used to set different behaviours for these methods. However, this commit (which was part of PR #97): https://github.com/enzo-project/enzo-e/commit/1cfa4721f8fc04e6a28de6f4d0065691eee45415, introduced a `Method:type` parameter, which led to a conflict.

To get around this, I have replaced `Method:star_maker:type` with `Method:star_maker:flavor` and `Method:background_acceleration:type` with `Method:background_acceleration:flavor`.