### PR TITLE
Bugfix: add nonexistent field to group

### DIFF
--- a/input/Checkpoint/checkpoint_grackle.in
+++ b/input/Checkpoint/checkpoint_grackle.in
@@ -73,8 +73,12 @@
    # but not everything
     color {
        field_list = [
-              "HI_density",
-              "HII_density",
+# because the entries for the first 2 fields were purposefully commented out
+# from Field::list, we need to comment them out here too (you can't add a
+# non-existant field to a group). This is okay: when EnzoMethodGrackle creates
+# these missing fields, it will automatically add them to the "color" group
+#              "HI_density",
+#              "HII_density",
               "HM_density",
               "HeI_density",
               "HeII_density",

--- a/input/PPML/ppml.incl
+++ b/input/PPML/ppml.incl
@@ -52,7 +52,6 @@
       }
 
    }
- include "input/flux_correct.incl"
 
    Initial {
 

--- a/src/Cello/parameters_Config.cpp
+++ b/src/Cello/parameters_Config.cpp
@@ -65,7 +65,6 @@ void Config::pup (PUP::er &p)
 
   p | num_fields;
   p | field_list;
-  p | field_index;
   p | field_alignment;
   PUParray(p,field_centering,3);
   PUParray(p,field_ghost_depth,3);
@@ -510,6 +509,8 @@ void Config::read_field_ (Parameters * p) throw()
 
   field_list.resize(num_fields);
 
+  std::map<std::string, int> field_index;
+
   for (int i=0; i<num_fields; i++) {
     field_list[i] = p->list_value_string(i, "Field:list");
     field_index[field_list[i]] = i;
@@ -575,17 +576,16 @@ void Config::read_field_ (Parameters * p) throw()
 
   int num_groups = p->list_length("Group:list");
 
-  const std::map<std::string,int>& field_index_ref = field_index;
-  auto find_field_index = [&field_index_ref](const std::string& field,
-                                             const std::string& group) -> int
+  auto find_field_index = [&field_index](const std::string& field,
+                                         const std::string& group) -> int
     {
-      // NEVER use field_index[field] to access the index of a field unless
-      // you're certain field_index already contains an entry for field. In
+      // don't use field_index[field] to access the index of a field because
+      // we're not certain field_index already contains an entry for field. In
       // the case where field_index doesn't already contain an entry for field,
       // then an entry is created (with an incorrect index)
 
-      auto search = field_index_ref.find(field);
-      if (search == field_index_ref.end()){
+      auto search = field_index.find(field);
+      if (search == field_index.end()){
         ERROR2("Config::read_field_",
                ("Can't add the \"%s\" field to the \"%s\" group because the "
                 "field has not been defined"),

--- a/src/Cello/parameters_Config.hpp
+++ b/src/Cello/parameters_Config.hpp
@@ -48,7 +48,6 @@ public: // interface
     boundary_field_list(),
     num_fields(0),
     field_list(),
-    field_index(),
     field_alignment(0),
     field_padding(0),
     field_history(0),
@@ -222,7 +221,6 @@ public: // interface
       boundary_field_list(),
       num_fields(0),
       field_list(),
-      field_index(),
       field_alignment(0),
       field_padding(0),
       field_history(0),
@@ -425,7 +423,6 @@ public: // attributes
 
   int                        num_fields;
   std::vector<std::string>   field_list;
-  std::map<std::string,int>  field_index;
   int                        field_alignment;
   std::vector<int>           field_centering [3];
   int                        field_ghost_depth[3];


### PR DESCRIPTION
This bug arose because of an annoying property of `std::map`:
- In this scenario, `field_index` is an instance of `std::map<std::string,int>` that maps field names to field indices.
- While adding fields to groups, based on an input configuration file, the old code checked for the index associated with a field name, `field`, using `field_index[field]`.
- Unfortunately, if `field` is not already contained by `field_index`, a new key-value pair is inserted into `field_index` (This is required to support the syntax like `field_index["density"] = 3;`).
- As a result, when users tried to add previously undeclared fields to a group, a different field was added to the group instead.

An alternative fix would be to replace `field_index[field]` with `field_index.at(field)`. In cases where `field_index` does not already contain field, an exception would be raised. However, my chosen solution provides a more detailed error message that tells users what they did wrong.

While doing this, I also noticed that it was unnecessary for `field_index` to be an attribute of `Config`. The map is constructed and used inside of `Config::read_field_` and then it is never touched again. With that in mind, I removed `field_index` from `Config`'s attributes and made it into a local variable.