### PR TITLE
Address minor oversight in the ported tests

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -304,8 +304,9 @@ add_subdirectory(src/External)
 
 include(CTest)
 
-option(USE_PYTHON_BASED_TESTS "Includes tests that require Python and yt" ON)
-if (USE_PYTHON_BASED_TESTS)
+# including the CTest module defines the BUILD_TESTING option. Its initial value is ON
+option(USE_YT_BASED_TESTS "Includes tests that require yt" ON)
+if (BUILD_TESTING)
   find_package(Python3)
   if (Python3_FOUND)
     message(STATUS
@@ -314,19 +315,23 @@ if (USE_PYTHON_BASED_TESTS)
       "version, try setting `-DPython3_FIND_VIRTUALENV=ONLY` or "
       "`-DPython3_EXECUTABLE=/path/to/desired/python`."
       )
+  else()
+    message(FATAL_ERROR
+     "You asked to build the tests, which require a python3 installation, but no python "
+     "installation was found. You can either install a python distribution (recommended) or "
+     "disable all tests by setting `-DBUILD_TESTING=OFF`."
+     )
+  endif()
 
+  if (USE_YT_BASED_TESTS)
     # Ensure all required packages are present
     include(${CMAKE_CURRENT_SOURCE_DIR}/cmake/PythonModuleCheck.cmake)
     required_python_modules_found("yt;libconf;h5py")
-  else()
-    message(FATAL_ERROR
-     "You asked to include Python/yt based tests, but no Python installation was found. "
-     "You can either disable those tests by setting `-DUSE_PYTHON_BASED_TESTS=OFF` or "
-     "install a Python distribution with yt (recommended)."
-     )
   endif()
+
+  add_subdirectory(test)
 endif()
-add_subdirectory(test)
+
 
 # extract compile defs from from Cello to populate config
 get_directory_property( CELLO_CPPDEFINES DIRECTORY src/Cello COMPILE_DEFINITIONS )

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -6,32 +6,37 @@ function(setup_test_dir TESTDIR)
   file(CREATE_LINK ${PROJECT_SOURCE_DIR}/input ${PROJECT_BINARY_DIR}/test/${TESTDIR}/input SYMBOLIC)
 endfunction()
 
+set(CPP_TEST_RUNNER ${PROJECT_SOURCE_DIR}/tools/run_cpp_test.py)
+
 # Test wrapper function calling unit tests (separate binaries) directly
 function(setup_test_unit TESTNAME TESTDIR TESTBIN)
   setup_test_dir(${TESTDIR})
+  set(FULLTESTDIR ${PROJECT_BINARY_DIR}/test/${TESTDIR})
   add_test(
     NAME ${TESTNAME}
-    COMMAND ${TESTBIN}
-    WORKING_DIRECTORY ${PROJECT_BINARY_DIR}/test/${TESTDIR})
+    COMMAND ${Python3_EXECUTABLE} ${CPP_TEST_RUNNER} --output-dump ${FULLTESTDIR}/${TESTNAME}.log $<TARGET_FILE:${TESTBIN}>
+    WORKING_DIRECTORY ${FULLTESTDIR})
   set_tests_properties(${TESTNAME} PROPERTIES LABELS "serial;unit" )
 endfunction()
 
 # Test wrapper functions calling enzo-e directly
 function(setup_test_serial TESTNAME TESTDIR INFILE)
   setup_test_dir(${TESTDIR})
+  set(FULLTESTDIR ${PROJECT_BINARY_DIR}/test/${TESTDIR})
   add_test(
     NAME ${TESTNAME}
-    COMMAND enzo-e ${INFILE}
-    WORKING_DIRECTORY ${PROJECT_BINARY_DIR}/test/${TESTDIR})
+    COMMAND ${Python3_EXECUTABLE} ${CPP_TEST_RUNNER} --output-dump ${FULLTESTDIR}/${TESTNAME}.log $<TARGET_FILE:enzo-e> ${INFILE}
+    WORKING_DIRECTORY ${FULLTESTDIR})
   set_tests_properties(${TESTNAME} PROPERTIES LABELS "serial;enzo" )
 endfunction()
 
 function(setup_test_parallel TESTNAME TESTDIR INFILE)
   setup_test_dir(${TESTDIR})
+  set(FULLTESTDIR ${PROJECT_BINARY_DIR}/test/${TESTDIR})
   add_test(
     NAME ${TESTNAME}
-    COMMAND ${PARALLEL_LAUNCHER} ${PARALLEL_LAUNCHER_NPROC_ARG} ${PARALLEL_LAUNCHER_NPROC} ${PROJECT_BINARY_DIR}/bin/enzo-e ${INFILE}
-    WORKING_DIRECTORY ${PROJECT_BINARY_DIR}/test/${TESTDIR})
+    COMMAND ${Python3_EXECUTABLE} ${CPP_TEST_RUNNER} --output-dump ${FULLTESTDIR}/${TESTNAME}.log ${PARALLEL_LAUNCHER} ${PARALLEL_LAUNCHER_NPROC_ARG} ${PARALLEL_LAUNCHER_NPROC} $<TARGET_FILE:enzo-e> ${INFILE}
+    WORKING_DIRECTORY ${FULLTESTDIR})
   set_tests_properties(${TESTNAME} PROPERTIES LABELS "parallel;enzo" )
 endfunction()
 
@@ -153,7 +158,7 @@ setup_test_parallel(Performance-Initial-PNG  Performance/InitialPng   input/Hell
 setup_test_serial(PPM-1 MethodPPM/Ppm-1  input/PPM/method_ppm-1.in)
 setup_test_parallel(PPM-8 MethodPPM/Ppm-8  input/PPM/method_ppm-8.in)
 
-if (USE_PYTHON_BASED_TESTS)
+if (USE_YT_BASED_TESTS)
   # VLCT
   setup_test_serial_python(vlct_dual_energy_cloud vlct "input/vlct/run_dual_energy_cloud_test.py")
   setup_test_serial_python(vlct_MHD_shock_tube vlct "input/vlct/run_MHD_shock_tube_test.py")

--- a/tools/run_cpp_test.py
+++ b/tools/run_cpp_test.py
@@ -26,7 +26,8 @@ parser.add_argument(
     help = "the C++ binary that is to be executed"
 )
 parser.add_argument(
-    "args", metavar = "ARGS", action = "store", nargs = '*', default = [],
+    "args_for_command", metavar = "ARGS", action = "store", nargs = '*',
+    default = [],
     help = "the arguments to the C++ binary that are to be executed"
 )
 
@@ -102,7 +103,8 @@ if __name__ == '__main__':
     else:
         dump_path = args.output_dump
 
-    success = execute_command(command = args.command, args = args.args,
+    success = execute_command(command = args.command,
+                              args = args.args_for_command,
                               output_dump = dump_path)
     if not success:
         out = 1

--- a/tools/run_cpp_test.py
+++ b/tools/run_cpp_test.py
@@ -1,0 +1,118 @@
+import argparse
+import subprocess
+import sys
+import tempfile
+
+_description = '''\
+Runs a test that is directly encoded in a C++ binary (the binary is specified
+by COMMAND and optional arguments are specified by ARGS), that makes use of the
+Cello testing machinery. After the test completes, this program determines
+whether it was succesful and returns an appropriate exit code (an exit code of
+0 indicates the test was entirely successful).
+'''
+
+
+parser = argparse.ArgumentParser(description = _description)
+parser.add_argument(
+    "--output-dump", action = "store", default = None,
+    help = ("Specifies the path where a copy of the standard output stream "
+            "from the execution of the program should optionally be dumped "
+            "(the data is still written to the standard output stream). The "
+            "contents of this file may be used to determine the outcome of "
+            "the tests.")
+)
+parser.add_argument(
+    "command", metavar = "COMMAND", action = "store",
+    help = "the C++ binary that is to be executed"
+)
+parser.add_argument(
+    "args", metavar = "ARGS", action = "store", nargs = '*', default = [],
+    help = "the arguments to the C++ binary that are to be executed"
+)
+
+def execute_command(command, args, output_dump):
+    """
+    Executes the command. This will write a copy of stdout to the file 
+    specified by output_dump (while continuing to write to stdout).
+
+    Returns
+    -------
+    success: bool
+        True indicates the program completed succesfully
+    """
+    arg_l = [command] + args + ['|', 'tee', output_dump]
+    exit_code = subprocess.call(' '.join(arg_l), shell = True)
+    return exit_code == 0
+
+def log_suggests_test_failure(log_path):
+    """
+    Returns whether the log has any contents suggestive of a test failure.
+
+    Notes
+    -----
+    This logic is ported from the build.sh script from earlier versions of
+    Enzo-E (for concreteness, we considered the file from commit 
+    3f7f33f4c6254f718dc3deead5c8119a50f26318)
+    """
+
+    def _num_occurences(pattern, skip_binary_file_search = False):
+        # employs grep to count the number of occurences of a pattern
+        if skip_binary_file_search:
+            flags = ""
+        else:
+            flags = "-I"
+        command = 'grep {} "{}" {} | wc -l'.format(flags, pattern, log_path)
+        return int(subprocess.check_output(command, shell = True))
+
+    # check the log for any lines explicitly reporting failures (lines 184-189)
+    #  - I suspect that passing the -I flag to grep in the original shell
+    #    script was a typo (which tells grep to assume that a binary file
+    #    doesn't contain a match) 
+    n_fail_lines = _num_occurences("^ FAIL", skip_binary_file_search = True)
+    #n_incomplete_lines = _num_occurences("^ incomplete",
+    #                                     skip_binary_file_search = True)
+    #n_pass_lines = _num_occurences("^ pass", skip_binary_file_search = True)
+    if n_fail_lines > 0:
+        return True
+
+    # check for signs that a test may have crashed (lines 199-202)
+    num_crashes = (_num_occurences("UNIT TEST BEGIN") -
+                   _num_occurences("UNIT TEST END"))
+    if num_crashes != 0:
+        return True
+
+    # check other indications of a failure (lines 242-243)
+    # - the following logic was originally used to determine failures in a
+    #   nicely formated text report but did not affect the exit code.
+    # - the original logic suggests that there was a problem with the test if
+    #   _num_occurences("BEGIN") == 0 (but again didn't reflect that in the
+    #   exit code)
+    has_BEGIN = _num_occurences("BEGIN") > 0
+    has_END_CELLO = _num_occurences("END CELLO") > 0
+    if has_BEGIN and not has_END_CELLO:
+        return True # the test failed
+    else:
+        return False
+
+if __name__ == '__main__':
+    args = parser.parse_args()
+
+    if args.output_dump is None:
+        dump_path = tempfile.mktemp() # path for a temporary file
+    else:
+        dump_path = args.output_dump
+
+    success = execute_command(command = args.command, args = args.args,
+                              output_dump = dump_path)
+    if not success:
+        out = 1
+    elif log_suggests_test_failure(dump_path):
+        out = 1
+    else:
+        out = 0
+
+    # cleanup the temporary file
+    if args.output_dump is None:
+        os.remove(dump_path)
+
+    sys.exit(out)


### PR DESCRIPTION
In the process of porting the C++ unit tests and the tests that compare the final simulation time or final cycle to the actual simulation time/cycle at the end of an Enzo-E simulations, there was a minor oversight  that reduced the functionality of these tests. 

The new system implicitly assumes that the exit code of these C++ tests always indicated whether the test passed or not. However, that is not presently the case (as long as the program gracefully exits, it reports an exit code of 0). As a consequence, a test could fail (e.g. the final simulation time could be different from the expected final time), but CTest would still report the test as passing. As a concrete example, one can do the following:
- modify line 79 of `input/PPM/ppm.incl` so that you replace `time_final  = [1.04069762624371];` with something like `time_final = [10.0];`.
- then when you execute `ctest --verbose -R PPM-1` from the build directory, `ctest` reports that the test failed, even though the output clearly states the final time of the simulation is incorrect.

My first instinct to solve this was to pipeline running the simulation, dumping stdout to a log file, and then call a script that parse the logfile and exits with the appropriate exit code. Unfortunately, the way that ctest works requires that a test is entirely encapsulated by a single command (that takes optional potential arguments).

To that end, I have introduced a python script called `tools/run_cpp_test.py` to do all 3 steps for us at once. The script wraps and executes an arbitrary command (much like a profiling tool like `time` or `perf-stat`) and then parses the standard output stream to check for indications that the test may have failed (I have ported this logic from the `build.sh` script from just before we transitioned to cmake).

As a concrete example, one could execute the following command from the repository's root directory:
```
python3 tools/run_cpp_test.py --output-dump sim_output.log path/to/enzo-e input/PPM/method_ppm-1.in
```
Note that the optional `--output-dump` argument specifies where the script writes a copy of stdout (It still continues to write a copy of stdout to stdout). This is what the script parses to check if the program succeeded. If you don't specify this, the program will write a copy of stdout to a temporary file that will be deleted once the program ends.

There are 2 other alternative approaches for addressing this problem:
1. We continue to use the wrapper script approach, but rewrite it in a different language (like bash or c++)
2. Modify the unit testing machinery to always exit with a non-zero exit code if it detects a testing error. Likewise, we would need to modify Cello/Enzo-E to exit with a non-zero exit code if the testing machinery detects an unexpected completion time/completion cycle.

I actually really like the 2nd approach as a longer term solution. But, that will take some additional work and this PR at least offers a near-term solution.