### PR TITLE
Very small fix to test_cpp_test.py

### DIFF
--- a/tools/run_cpp_test.py
+++ b/tools/run_cpp_test.py
@@ -26,7 +26,7 @@ parser.add_argument(
     help = "the C++ binary that is to be executed"
 )
 parser.add_argument(
-    "args_for_command", metavar = "ARGS", action = "store", nargs = '*',
+    "args_for_command", metavar = "ARGS", action = "store", nargs = argparse.REMAINDER,
     default = [],
     help = "the arguments to the C++ binary that are to be executed"
 )


### PR DESCRIPTION
Teeny-tiny fix to allow arguments that begin with a dash (required for some charm++ builds).