### PR TITLE
Bugfix for "merge_sinks" tests 

### DIFF
--- a/input/merge_sinks/merge_sinks_test.in
+++ b/input/merge_sinks/merge_sinks_test.in
@@ -61,6 +61,7 @@ Particle {
 		       "id" , "int64"];
         position = [ "x", "y", "z" ];
         velocity = [ "vx", "vy", "vz" ];
+        group_list = "is_gravitating";
     }
 }
 


### PR DESCRIPTION
Fixed bug in `"merge_sinks"` tests: input parameter file now specifies that sink particles are in the `"is_gravitating"` group, which ensures that the `"pm_update"` method updates the particle positions, which means that the particles move towards each other and merge.