### PR TITLE
Changing single/double particle precision in parameter files to default

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -22,6 +22,7 @@ charmrun
 config.log
 errors.org
 warnings.org
+doc/dox-xml
 
 # ignore directories used for building branches
 build-*/Cello/*

--- a/input/Hydro/tracer.incl
+++ b/input/Hydro/tracer.incl
@@ -4,10 +4,10 @@ Particle {
 
    trace {
       attributes = ["id", "int64",
-		    "x", "single",
-                    "y", "single",
-		    "z", "single",
-                    "is_local", "single"];
+		              "x", "default",
+                    "y", "default",
+		              "z", "default",
+                    "is_local", "default"];
       position = ["x","y","z"];
    }
 }

--- a/input/IsolatedGalaxy/WLM_small.in
+++ b/input/IsolatedGalaxy/WLM_small.in
@@ -163,17 +163,17 @@ Solver {
 
 #     Turn this on if using live DM
 #     dark {
-#         attributes = [ "x", "single",
-#                        "y", "single",
-#                        "z", "single",
-#                        "vx", "single",
-#                        "vy", "single",
-#                        "vz", "single",
-#                        "ax", "single",
-#                        "ay", "single",
-#                        "az", "single" ,
-#                        "mass", "single",
-#                        "is_local", "single"];
+#         attributes = [ "x", "default",
+#                        "y", "default",
+#                        "z", "default",
+#                        "vx", "default",
+#                        "vy", "default",
+#                        "vz", "default",
+#                        "ax", "default",
+#                        "ay", "default",
+#                        "az", "default" ,
+#                        "mass", "default",
+#                        "is_local", "default"];
 #         position = [ "x", "y", "z" ];
 #         velocity = [ "vx", "vy", "vz" ];
 #         group_list = ["is_gravitating"];
@@ -181,17 +181,17 @@ Solver {
 #     }
 
     star {
-         attributes = [ "x", "double",
-                        "y", "double",
-                        "z", "double",
-                        "vx", "double",
-                        "vy", "double",
-                        "vz", "double",
-                        "ax", "double",
-                        "ay", "double",
-                        "az", "double",
-                        "mass", "double",
-                        "is_local","double"];
+         attributes = [ "x", "default",
+                        "y", "default",
+                        "z", "default",
+                        "vx", "default",
+                        "vy", "default",
+                        "vz", "default",
+                        "ax", "default",
+                        "ay", "default",
+                        "az", "default",
+                        "mass", "default",
+                        "is_local","default"];
          position = [ "x", "y", "z" ];
          velocity = [ "vx", "vy", "vz" ];
 #

--- a/input/IsolatedGalaxy/method_isolatedgalaxy-particles.in
+++ b/input/IsolatedGalaxy/method_isolatedgalaxy-particles.in
@@ -129,17 +129,17 @@
 #     list = [ "dark" , "stars"];
      list = [ "dark" ];
      dark {
-         attributes = [ "x", "single",
-                        "y", "single",
-                        "z", "single",
-                        "vx", "single",
-                        "vy", "single",
-                        "vz", "single",
-                        "ax", "single",
-                        "ay", "single",
-                        "az", "single",
-			"mass", "single", 
-                        "is_local", "single"];
+         attributes = [ "x", "default",
+                        "y", "default",
+                        "z", "default",
+                        "vx", "default",
+                        "vy", "default",
+                        "vz", "default",
+                        "ax", "default",
+                        "ay", "default",
+                        "az", "default",
+			                  "mass", "default", 
+                        "is_local", "default"];
          position = [ "x", "y", "z" ];
          velocity = [ "vx", "vy", "vz" ];
          group_list = ["is_gravitating"];
@@ -149,17 +149,17 @@
      }
 
 #    stars {
-#         attributes = [ "x", "single",
-#                        "y", "single",
-#                        "z", "single",
-#                        "vx", "single",
-#                        "vy", "single",
-#                        "vz", "single",
-#                        "ax", "single",
-#                        "ay", "single",
-#                        "az", "single" ,
-			 "mass", "single",
-#                        "is_local", "single"];
+#         attributes = [ "x", "default",
+#                        "y", "default",
+#                        "z", "default",
+#                        "vx", "default",
+#                        "vy", "default",
+#                        "vz", "default",
+#                        "ax", "default",
+#                        "ay", "default",
+#                        "az", "default" ,
+#                        "mass", "default",
+#                        "is_local", "default"];
 #         position = [ "x", "y", "z" ];
 #         velocity = [ "vx", "vy", "vz" ];
 #         group_list = ["is_gravitating"];

--- a/input/IsolatedGalaxy/method_isolatedgalaxy.in
+++ b/input/IsolatedGalaxy/method_isolatedgalaxy.in
@@ -128,17 +128,17 @@
 # Particle {
 #     list = [ "dark" , "stars"];
 #     dark {
-#         attributes = [ "x", "single",
-#                        "y", "single",
-#                        "z", "single",
-#                        "vx", "single",
-#                        "vy", "single",
-#                        "vz", "single",
-#                        "ax", "single",
-#                        "ay", "single",
-#                        "az", "single" ,
-#			 "mass", "single",
-#                        "is_local", "single"];
+#         attributes = [ "x", "default",
+#                        "y", "default",
+#                        "z", "default",
+#                        "vx", "default",
+#                        "vy", "default",
+#                        "vz", "default",
+#                        "ax", "default",
+#                        "ay", "default",
+#                        "az", "default",
+#                        "mass", "default",
+#                        "is_local", "default"];
 #         position = [ "x", "y", "z" ];
 #         velocity = [ "vx", "vy", "vz" ];
 #         group_list = ["is_gravitating"];
@@ -146,17 +146,17 @@
 #     }
 
 #    stars {
-#         attributes = [ "x", "single",
-#                        "y", "single",
-#                        "z", "single",
-#                        "vx", "single",
-#                        "vy", "single",
-#                        "vz", "single",
-#                        "ax", "single",
-#                        "ay", "single",
-#                        "az", "single" ,
-#			 "mass", "single",
-#                        "is_local", "single"];
+#         attributes = [ "x", "default",
+#                        "y", "default",
+#                        "z", "default",
+#                        "vx", "default",
+#                        "vy", "default",
+#                        "vz", "default",
+#                        "ax", "default",
+#                        "ay", "default",
+#                        "az", "default",
+#                        "mass", "default",
+#                        "is_local", "default"];
 #         position = [ "x", "y", "z" ];
 #         velocity = [ "vx", "vy", "vz" ];
 #         group_list = ["is_gravitating"];

--- a/input/Particle/test_particle.incl
+++ b/input/Particle/test_particle.incl
@@ -72,10 +72,10 @@
      list = [ "trace" ];
      trace {
          attributes = [ "id", "int64", 
-                        "x", "single", 
-                        "y", "single",
-                        "z", "single",
-                        "is_local", "single"];
+                        "x", "default", 
+                        "y", "default",
+                        "z", "default",
+                        "is_local", "default"];
          position = [ "x", "y", "z" ];
      };
  }

--- a/input/Particle/test_particle.incl
+++ b/input/Particle/test_particle.incl
@@ -72,10 +72,10 @@
      list = [ "trace" ];
      trace {
          attributes = [ "id", "int64", 
-                        "x", "default", 
-                        "y", "default",
-                        "z", "default",
-                        "is_local", "default"];
+                        "x", "single", 
+                        "y", "single",
+                        "z", "single",
+                        "is_local", "single"];
          position = [ "x", "y", "z" ];
      };
  }

--- a/input/Sedov/config/config-trace-on.incl
+++ b/input/Sedov/config/config-trace-on.incl
@@ -4,9 +4,9 @@ Particle {
    list += ["trace"];
    trace {
       attributes = ["id", "int64",
-		    "x", "single",
-                    "y", "single",
-		    "z", "single",
+		              "x", "default",
+                    "y", "default",
+                    "z", "default",
                     "is_local", "int64"];
       position = ["x","y","z"];
    }

--- a/input/bb_unigrid_SF_FB.in
+++ b/input/bb_unigrid_SF_FB.in
@@ -98,20 +98,20 @@ Particle {
     list = ["star"];
 
     star {
-        attributes = [ "x", "double",
-                       "y", "double",
-                       "z", "double",
-                       "vx", "double",
-                       "vy", "double",
-                       "vz", "double",
-                       "ax", "double",
-                       "ay", "double",
-                       "az", "double",
-                       "is_local", "double",
-                       "mass", "double",
-                       "creation_time", "double",
-                       "lifetime", "double",
-                       "metal_fraction", "double" ];
+        attributes = [ "x", "default",
+                       "y", "default",
+                       "z", "default",
+                       "vx", "default",
+                       "vy", "default",
+                       "vz", "default",
+                       "ax", "default",
+                       "ay", "default",
+                       "az", "default",
+                       "is_local", "default",
+                       "mass", "default",
+                       "creation_time", "default",
+                       "lifetime", "default",
+                       "metal_fraction", "default" ];
         position = [ "x", "y", "z" ];
         velocity = [ "vx", "vy", "vz" ];
         group_list = ["is_gravitating"];

--- a/input/method_feedback.in
+++ b/input/method_feedback.in
@@ -141,20 +141,20 @@ Particle {
     list = ["star"];
 
     star {
-        attributes = [ "x", "double",
-                       "y", "double",
-                       "z", "double",
-                       "vx", "double",
-                       "vy", "double",
-                       "vz", "double",
-                       "ax", "double",
-                       "ay", "double",
-                       "az", "double",
-                       "mass", "double",
-                       "is_local", "double",
-                       "creation_time", "double",
-                       "lifetime", "double",
-                       "metal_fraction", "double" ];
+        attributes = [ "x", "default",
+                       "y", "default",
+                       "z", "default",
+                       "vx", "default",
+                       "vy", "default",
+                       "vz", "default",
+                       "ax", "default",
+                       "ay", "default",
+                       "az", "default",
+                       "mass", "default",
+                       "is_local", "default",
+                       "creation_time", "default",
+                       "lifetime", "default",
+                       "metal_fraction", "default" ];
         position = [ "x", "y", "z" ];
         velocity = [ "vx", "vy", "vz" ];
         group_list = ["is_gravitating"];


### PR DESCRIPTION
As discussed in #197, a precision mismatch can happen between the particle attributes and fields. A short-term solution is to set the attribute precision to "default" instead of single or double in the offending parameter files, which this PR addresses.