### PR TITLE
Clarify how to specify libpng installation path.

### DIFF
--- a/doc/source/tutorial/getting_started.rst
+++ b/doc/source/tutorial/getting_started.rst
@@ -175,8 +175,11 @@ If packages (external libraries) are not found automatically or if the wrong one
 picked up, you can specify the search path by
 ``-D<package_name>_ROOT=/PATH/TO/PACKAGE/INSTALL``,
 cf., the ``cmake`` example command just above.
-Note, these package location are also picked up from the environment, i.e., an alternative
-option  is ``export <package_name>_ROOT=/PATH/TO/PACKAGE/INSTALL`` .
+Note:
+
+* these package location are also picked up from the environment, i.e., an alternative option  is ``export <package_name>_ROOT=/PATH/TO/PACKAGE/INSTALL`` .
+
+* to specify the path to a ``libpng`` install, use ``-DPNG_ROOT=/PATH/TO/LIBPNG`` instead of ``-DLIBPNG_ROOT=...``.
 
 The last option is a machine specific configuration file (see below).
 

--- a/doc/source/tutorial/getting_started.rst
+++ b/doc/source/tutorial/getting_started.rst
@@ -177,7 +177,7 @@ picked up, you can specify the search path by
 cf., the ``cmake`` example command just above.
 Note:
 
-* these package location are also picked up from the environment, i.e., an alternative option  is ``export <package_name>_ROOT=/PATH/TO/PACKAGE/INSTALL`` .
+* these package locations are also picked up from the environment, i.e., an alternative option  is ``export <package_name>_ROOT=/PATH/TO/PACKAGE/INSTALL`` .
 
 * to specify the path to a ``libpng`` install, use ``-DPNG_ROOT=/PATH/TO/LIBPNG`` instead of ``-DLIBPNG_ROOT=...``.
 


### PR DESCRIPTION
Clarifying that you would use `-DPNG_ROOT` instead of `-DLIBPNG_ROOT`