### PR TITLE
Fixing particle mass in test_cosmo.incl

### DIFF
--- a/input/test_cosmo.incl
+++ b/input/test_cosmo.incl
@@ -283,7 +283,7 @@ Adapt {
  Particle {
      dark {
          attributes = [ "x", "default", "y", "default", "z", "default", "vx", "default", "vy", "default", "vz", "default", "ax", "default", "ay", "default", "az", "default", "is_local", "default"];
-         constants = [ "density", "default", 0.8666666666667000 ];
+         constants = [ "mass", "default", 0.8666666666667000/(32.0*32.0*32.0) ];
          position = [ "x", "y", "z" ];
          velocity = [ "vx", "vy", "vz" ];
          group_list = ["is_gravitating"];


### PR DESCRIPTION
Very small fix to test_cosmo.incl so that it runs -- initializing DM mass as "mass" (not "density"). These files didn't get updated after PR #89 merged