### PR TITLE
Addressed issue with inconsistent `EnzoComputeTemperature` units…

### DIFF
--- a/src/Cello/problem_Units.hpp
+++ b/src/Cello/problem_Units.hpp
@@ -97,14 +97,6 @@ public: // virtual methods
   virtual double length() const
   { return length_; }
 
-  virtual double temperature() const
-  {
-    // don't compute temperature units here since we need physical constants
-    // that are not defined in this layer
-    ERROR("Units::temperature",
-          "the base class doesn't support calculation of temperature units.");
-  }
-
   /// Return velocity units scaling factor (derived)
   virtual double velocity() const
   { return length() / time(); }

--- a/src/Enzo/enzo_EnzoComputeTemperature.cpp
+++ b/src/Enzo/enzo_EnzoComputeTemperature.cpp
@@ -123,7 +123,7 @@ void EnzoComputeTemperature::compute_(Block * block,
     for (int i=0; i<m; i++) {
       enzo_float density     = std::max(d[i], (enzo_float) density_floor_);
       enzo_float temperature = p[i] * mol_weight_ / density;
-      t[i] = std::max(temperature, (enzo_float)temperature_floor_) * enzo_units->temperature();
+      t[i] = std::max(temperature, (enzo_float)temperature_floor_);
     }
   }
 

--- a/src/Enzo/enzo_EnzoInitialBurkertBodenheimer.cpp
+++ b/src/Enzo/enzo_EnzoInitialBurkertBodenheimer.cpp
@@ -120,7 +120,8 @@ void EnzoInitialBurkertBodenheimer::enforce_block
 
   const double gamma = EnzoBlock::Gamma[in];
   //const double energy = (1e-3*(enzo_constants::kboltz)*temperature_ / ((gamma - 1.0) * (1.0 * enzo_constants::mass_hydrogen)))/enzo_units->energy();
-  const double energy = (temperature_/enzo_units->temperature()) / ((gamma-1.0)) / enzo_config->ppm_mol_weight;
+  const double energy = ((temperature_/enzo_units->kelvin_per_energy_units())
+                         / ((gamma-1.0)) / enzo_config->ppm_mol_weight);
 
   // fixed for now about 1 / 10 solar
   const double inner_metal_fraction = 0.0010; // sub-solar
@@ -250,7 +251,7 @@ void EnzoInitialBurkertBodenheimer::enforce_block
 		  float m2mode = 1.0 + 0.1*cos(2.*phi);
 		  d[i] += density * m2mode;
 		}
-                t[i]  = temperature_ / enzo_units->temperature();
+                t[i]  = temperature_; // field has units of Kelvin
 
     if (metal) metal[i] = d[i]*inner_metal_fraction;
 

--- a/src/Enzo/enzo_EnzoInitialCosmology.cpp
+++ b/src/Enzo/enzo_EnzoInitialCosmology.cpp
@@ -44,7 +44,7 @@ void EnzoInitialCosmology::enforce_block
   
   const double default_mu = 0.6;
 
-  const double internal_energy = temperature_/units->temperature()
+  const double internal_energy = temperature_/units->kelvin_per_energy_units()
     /default_mu/(gamma_-1.0);
 
   Field field = block->data()->field();

--- a/src/Enzo/enzo_EnzoInitialFeedbackTest.cpp
+++ b/src/Enzo/enzo_EnzoInitialFeedbackTest.cpp
@@ -140,8 +140,10 @@ void EnzoInitialFeedbackTest::enforce_block
 
          for (int dim = 0; dim < 3; dim++) v3[dim][i] = 0.0;
 
-         ge[i] = enzo_config->initial_feedback_test_temperature / enzo_config->ppm_mol_weight / enzo_units->temperature() /
-                         (enzo_config->field_gamma - 1.0);
+         ge[i] = (enzo_config->initial_feedback_test_temperature /
+                  enzo_config->ppm_mol_weight /
+                  enzo_units->kelvin_per_energy_units() /
+                  (enzo_config->field_gamma - 1.0));
 
          for (int dim = 0; dim < 3; dim ++)
              te[i] = ge[i] + 0.5 * v3[dim][i] * v3[dim][i];

--- a/src/Enzo/enzo_EnzoInitialGrackleTest.cpp
+++ b/src/Enzo/enzo_EnzoInitialGrackleTest.cpp
@@ -187,9 +187,10 @@ void EnzoInitialGrackleTest::enforce_block
           mu = grackle_fields_.density[i] / mu;
         } // end primordial_chemistry > 0
 
-        grackle_fields_.internal_energy[i] = pow(10.0, ((temperature_slope * (iy-gy)) +
-                                      log10(enzo_config->initial_grackle_test_minimum_temperature)))/
-                             mu / enzo_units->temperature() / (enzo_config->field_gamma - 1.0);
+        grackle_fields_.internal_energy[i] =
+          (pow(10.0, ((temperature_slope * (iy-gy)) +
+           log10(enzo_config->initial_grackle_test_minimum_temperature)))/
+           mu / enzo_units->kelvin_per_energy_units() / (enzo_config->field_gamma - 1.0));
         total_energy[i]    = grackle_fields_.internal_energy[i];
       }
     }

--- a/src/Enzo/enzo_EnzoInitialIsolatedGalaxy.cpp
+++ b/src/Enzo/enzo_EnzoInitialIsolatedGalaxy.cpp
@@ -78,12 +78,12 @@ EnzoInitialIsolatedGalaxy::EnzoInitialIsolatedGalaxy
                                    enzo_units->mass();
   this->gas_fraction_            = config->initial_IG_gas_fraction;
   this->disk_temperature_        = config->initial_IG_disk_temperature /
-                                   enzo_units->temperature();
+                                   enzo_units->kelvin_per_energy_units();
   this->disk_metal_fraction_     = config->initial_IG_disk_metal_fraction;
   this->gas_halo_mass_           = config->initial_IG_gas_halo_mass * enzo_constants::mass_solar /
                                    enzo_units->mass();
   this->gas_halo_temperature_    = config->initial_IG_gas_halo_temperature /
-                                   enzo_units->temperature();
+                                   enzo_units->kelvin_per_energy_units();
   this->gas_halo_metal_fraction_ = config->initial_IG_gas_halo_metal_fraction;
   this->gas_halo_density_        = config->initial_IG_gas_halo_density /
                                    enzo_units->density();

--- a/src/Enzo/enzo_EnzoMethodGrackle.cpp
+++ b/src/Enzo/enzo_EnzoMethodGrackle.cpp
@@ -635,9 +635,11 @@ void EnzoMethodGrackle::ResetEnergies ( EnzoBlock * enzo_block) throw()
 
          mu = density[i] / mu;
 
-         internal_energy[i] = pow(10.0, ((temperature_slope * (iy-gy)) +
-                              log10(enzo_config->initial_grackle_test_minimum_temperature)))/
-                              mu / enzo_units->temperature() / (enzo_config->field_gamma - 1.0);
+         internal_energy[i] =
+           (pow(10.0, ((temperature_slope * (iy-gy)) +
+                       log10(enzo_config->initial_grackle_test_minimum_temperature)))/
+            mu / enzo_units->kelvin_per_energy_units() /
+            (enzo_config->field_gamma - 1.0));
          total_energy[i] = internal_energy[i];
 
        }

--- a/src/Enzo/enzo_EnzoMethodTurbulence.cpp
+++ b/src/Enzo/enzo_EnzoMethodTurbulence.cpp
@@ -134,12 +134,8 @@ void EnzoMethodTurbulence::compute ( Block * block) throw()
   field.dimensions (0,&mx,&my,&mz);
   const int rank = ((mz == 1) ? ((my == 1) ? 1 : 2) : 3);
 
-  // the temperature field is in units of K. we need to convert it to units
-  // of specific energy (or velocity_units^2). Some people might refer to
-  // this as "temperature units".
   EnzoUnits* enzo_units = enzo::units();
-  enzo_float temp_to_energy_u =
-    cello::mass_hydrogen*std::pow(enzo_units->velocity(),2)/cello::kboltz;
+  const enzo_float kelvin_per_energy_u = enzo_units->kelvin_per_energy_units();
 
   if (block->is_leaf()) {
 
@@ -154,7 +150,7 @@ void EnzoMethodTurbulence::compute ( Block * block) throw()
 	    enzo_float v  = velocity[id][i];
 	    enzo_float v2 = v*v;
 	    enzo_float a  = driving[id][i];
-	    enzo_float ti = temp_to_energy_u / temperature[i];
+	    enzo_float ti = kelvin_per_energy_u  / temperature[i];
 
 	    g[index_turbulence_vad] +=   v*a*d;
 	    g[index_turbulence_aad] +=   a*a*d;
@@ -273,14 +269,9 @@ void EnzoMethodTurbulence::compute_resume
     double box_mass = domain_x * domain_y * domain_z * density_initial_;
 
 
-    // temperature_initial_ is in units of K. we need to convert it to
-    // units of specific energy or velocity_units^2. Some people might refer to
-    // this as "temperature units".
     EnzoUnits* enzo_units = enzo::units();
-    double temp_to_energy_u =
-      cello::mass_hydrogen*std::pow(enzo_units->velocity(),2)/cello::kboltz;
-
-    float v_rms = mach_number_ * sqrt(temperature_initial_ / temp_to_energy_u);
+    float v_rms = mach_number_ * sqrt(temperature_initial_ /
+                                      enzo_units->kelvin_per_energy_units());
 
     edot_ = 0.81/box_size*box_mass*v_rms*v_rms*v_rms;
 

--- a/src/Enzo/enzo_EnzoMethodTurbulence.cpp
+++ b/src/Enzo/enzo_EnzoMethodTurbulence.cpp
@@ -134,6 +134,13 @@ void EnzoMethodTurbulence::compute ( Block * block) throw()
   field.dimensions (0,&mx,&my,&mz);
   const int rank = ((mz == 1) ? ((my == 1) ? 1 : 2) : 3);
 
+  // the temperature field is in units of K. we need to convert it to units
+  // of specific energy (or velocity_units^2). Some people might refer to
+  // this as "temperature units".
+  EnzoUnits* enzo_units = enzo::units();
+  enzo_float temp_to_energy_u =
+    cello::mass_hydrogen*std::pow(enzo_units->velocity(),2)/cello::kboltz;
+
   if (block->is_leaf()) {
 
     for (int iz=0; iz<nz; iz++) {
@@ -147,7 +154,7 @@ void EnzoMethodTurbulence::compute ( Block * block) throw()
 	    enzo_float v  = velocity[id][i];
 	    enzo_float v2 = v*v;
 	    enzo_float a  = driving[id][i];
-	    enzo_float ti = 1.0 / temperature[i];
+	    enzo_float ti = temp_to_energy_u / temperature[i];
 
 	    g[index_turbulence_vad] +=   v*a*d;
 	    g[index_turbulence_aad] +=   a*a*d;
@@ -265,7 +272,15 @@ void EnzoMethodTurbulence::compute_resume
     double box_size = domain_x;
     double box_mass = domain_x * domain_y * domain_z * density_initial_;
 
-    float v_rms = mach_number_ * sqrt(temperature_initial_);
+
+    // temperature_initial_ is in units of K. we need to convert it to
+    // units of specific energy or velocity_units^2. Some people might refer to
+    // this as "temperature units".
+    EnzoUnits* enzo_units = enzo::units();
+    double temp_to_energy_u =
+      cello::mass_hydrogen*std::pow(enzo_units->velocity(),2)/cello::kboltz;
+
+    float v_rms = mach_number_ * sqrt(temperature_initial_ / temp_to_energy_u);
 
     edot_ = 0.81/box_size*box_mass*v_rms*v_rms*v_rms;
 

--- a/src/Enzo/enzo_EnzoPhysicsCosmology.hpp
+++ b/src/Enzo/enzo_EnzoPhysicsCosmology.hpp
@@ -204,17 +204,21 @@ public: // interface
       pow(1.0 + initial_redshift_,1.5);
   }
 
-  /// Return current temperature units (requires set_current_time())
-  double temperature_units() const
-  {
-    return 1.81723e6*pow(comoving_box_size_,2.0)*omega_matter_now_*
-                      (1.0 + initial_redshift_);
-  }
-
   double velocity_units() const
   {
     return 1.22475e7*comoving_box_size_*sqrt(omega_matter_now_)*
                       sqrt(1.0 + initial_redshift_);
+  }
+
+  /// Returns the scaling factor to be divided by temperature to convert from
+  /// units of Kelvin to units of specific internal energy
+  ///
+  /// The original Enzo refered to this quantity as "temperature units", but in
+  /// Enzo-E we primarily track temperature in units of Kelvin
+  double kelvin_per_energy_units() const
+  {
+    return 1.81723e6*pow(comoving_box_size_,2.0)*omega_matter_now_*
+                      (1.0 + initial_redshift_);
   }
 
   void print () const

--- a/src/Enzo/enzo_EnzoUnits.hpp
+++ b/src/Enzo/enzo_EnzoUnits.hpp
@@ -89,8 +89,19 @@ public: // virtual methods
       Units::length() : cosmology_->length_units();
   }
 
-  /// Return temperature units scaling factor (virtual)
-  virtual double temperature() const
+  /// Return velocity units scaling factor (virtual)
+  virtual double velocity() const
+  {
+    return (cosmology_ == NULL) ?
+      Units::velocity() : cosmology_->velocity_units();
+  }
+
+  /// Returns the scaling factor to be divided by temperature to convert from
+  /// units of Kelvin to units of specific internal energy
+  ///
+  /// The original Enzo refered to this quantity as "temperature units", but in
+  /// Enzo-E we primarily track temperature in units of Kelvin
+  double kelvin_per_energy_units() const
   {
     if (cosmology_ == NULL){
       // The Units base-class can't compute the temperature code units for the
@@ -100,15 +111,8 @@ public: // virtual methods
       return (enzo_constants::mass_hydrogen * (vel_units * vel_units) /
               enzo_constants::kboltz);
     } else {
-      return cosmology_->temperature_units();
+      return cosmology_->kelvin_per_energy_units();
     }
-  }
-  
-  /// Return velocity units scaling factor (virtual)
-  virtual double velocity() const
-  {
-    return (cosmology_ == NULL) ?
-      Units::velocity() : cosmology_->velocity_units();
   }
   
 private: // functions


### PR DESCRIPTION
Addressed issue where `EnzoComputeTemperature` returned the `"temperature"` in different units based on whether we used Grackle or not (when using Grackle, the output was in Kelvin). @brittonsmith and I talked about it, and we decided to track the temperature field in units of Kelvin (since temperature units are kind of a nebulous).

I modified `EnzoMethodTurbulence`, accordingly. Other people should speak up if they disagree. I took a quick glance at `EnzoInitialIsolatedGalaxy` and `EnzoInitialGrackle`, and I don't think they require any changes.

I'm tempted to remove the `Units::temperature()` method and rename `EnzoUnits::temperature()` so it's called something like `EnzoUnits::temperature_in_energy_units()`. I would appreciate feedback about this latter point (maybe we turn this into an Issue).