### PR TITLE
Moved physics constants from Cello layer to Enzo layer

### DIFF
--- a/src/Cello/cello.hpp
+++ b/src/Cello/cello.hpp
@@ -574,51 +574,6 @@ namespace cello {
   // pi
   const double pi = 3.14159265358979324;
 
-  // ergs per eV
-  const double erg_eV = 1.60217653E-12;
-
-  // eV per erg
-  const double eV_erg = 6.24150948E11;
-
-  // Boltzman constant in CGS
-  const double kboltz = 1.3806504e-16;
-
-  // Solar mass in CGS
-  const double mass_solar = 1.98841586e33;
-
-  // Hydrogen mass in CGS
-  const double mass_hydrogen = 1.67262171e-24;
-
-  // Electron mass in CGS
-  const double mass_electron = 9.10938291E-28;
-
-  // parsec in CGS
-  const double pc_cm  = 3.0856775809623245E18;
-
-  // Kiloparsec in CGS
-  const double kpc_cm = 3.0856775809623245E21;
-
-  // Megaparsec in CGS
-  const double Mpc_cm = 3.0856775809623245E24;
-
-  // speed of light in CGS
-  const double clight = 29979245800.0;
-
-  // Gravitational constant in CGS
-  const double grav_constant = 6.67384E-8;
-
-  // year in seconds
-  const double yr_s = 3.1556952E7;
-
-  // kyr in seconds
-  const double kyr_s = 3.1556952E10;
-
-  // Myr in seconds
-  const double Myr_s = 3.1556952E13;
-
-  // Approximate mean molecular weight of metals
-  const double mu_metal = 16.0;
-
   // precision functions
   double machine_epsilon     (int);
   template <class T>

--- a/src/Cello/problem_Units.hpp
+++ b/src/Cello/problem_Units.hpp
@@ -97,10 +97,6 @@ public: // virtual methods
   virtual double length() const
   { return length_; }
 
-  /// Return temperature units scaling factor (derived)
-  virtual double temperature() const
-  { return (cello::mass_hydrogen)*std::pow(velocity(),2)/(cello::kboltz); }
-
   /// Return velocity units scaling factor (derived)
   virtual double velocity() const
   { return length() / time(); }

--- a/src/Cello/problem_Units.hpp
+++ b/src/Cello/problem_Units.hpp
@@ -97,6 +97,14 @@ public: // virtual methods
   virtual double length() const
   { return length_; }
 
+  virtual double temperature() const
+  {
+    // don't compute temperature units here since we need physical constants
+    // that are not defined in this layer
+    ERROR("Units::temperature",
+          "the base class doesn't support calculation of temperature units.");
+  }
+
   /// Return velocity units scaling factor (derived)
   virtual double velocity() const
   { return length() / time(); }

--- a/src/Enzo/_enzo.hpp
+++ b/src/Enzo/_enzo.hpp
@@ -158,7 +158,7 @@ extern "C" {
 
 #include "fortran_types.h" /* included so scons knowns to install fortran.h */
 
-#include "enzo_constants.h"
+#include "enzo_constants.hpp"
 
 #include "enzo_EnzoPhysicsCosmology.hpp"
 

--- a/src/Enzo/_enzo.hpp
+++ b/src/Enzo/_enzo.hpp
@@ -158,6 +158,8 @@ extern "C" {
 
 #include "fortran_types.h" /* included so scons knowns to install fortran.h */
 
+#include "enzo_constants.h"
+
 #include "enzo_EnzoPhysicsCosmology.hpp"
 
 #include "enzo_EnzoUnits.hpp"

--- a/src/Enzo/enzo_EnzoConfig.cpp
+++ b/src/Enzo/enzo_EnzoConfig.cpp
@@ -744,7 +744,7 @@ void EnzoConfig::read_initial_collapse_(Parameters * p)
   initial_collapse_particle_ratio =
     p->value_float("Initial:collapse:particle_ratio",0.0);
   initial_collapse_mass =
-    p->value_float("Initial:collapse:mass",cello::mass_solar);
+    p->value_float("Initial:collapse:mass",enzo_constants::mass_solar);
   initial_collapse_temperature =
     p->value_float("Initial:collapse:temperature",10.0);
 }
@@ -918,7 +918,7 @@ void EnzoConfig::read_initial_burkertbodenheimer_(Parameters * p)
   initial_burkertbodenheimer_particle_ratio =
     p->value_float("Initial:burkertbodenheimer:particle_ratio",0.0);
   initial_burkertbodenheimer_mass =
-    p->value_float("Initial:burkertbodenheimer:mass",cello::mass_solar);
+    p->value_float("Initial:burkertbodenheimer:mass",enzo_constants::mass_solar);
   initial_burkertbodenheimer_temperature =
     p->value_float("Initial:burkertbodenheimer:temperature",10.0);
   initial_burkertbodenheimer_densityprofile =

--- a/src/Enzo/enzo_EnzoInitialBurkertBodenheimer.cpp
+++ b/src/Enzo/enzo_EnzoInitialBurkertBodenheimer.cpp
@@ -119,7 +119,7 @@ void EnzoInitialBurkertBodenheimer::enforce_block
   const int in = cello::index_static();
 
   const double gamma = EnzoBlock::Gamma[in];
-  //const double energy = (1e-3*(cello::kboltz)*temperature_ / ((gamma - 1.0) * (1.0 * cello::mass_hydrogen)))/enzo_units->energy();
+  //const double energy = (1e-3*(enzo_constants::kboltz)*temperature_ / ((gamma - 1.0) * (1.0 * enzo_constants::mass_hydrogen)))/enzo_units->energy();
   const double energy = (temperature_/enzo_units->temperature()) / ((gamma-1.0)) / enzo_config->ppm_mol_weight;
 
   // fixed for now about 1 / 10 solar
@@ -136,7 +136,7 @@ void EnzoInitialBurkertBodenheimer::enforce_block
   const double rz2i = 1.0/(rz*rz);
 
   // This is the density at the trucation radius
-  const double density = (mass_*cello::mass_solar/enzo_units->mass()) / (4.0/3.0*(cello::pi)*rx*ry*rz);
+  const double density = (mass_*enzo_constants::mass_solar/enzo_units->mass()) / (4.0/3.0*(cello::pi)*rx*ry*rz);
 
 
   // velocity at termination radius (if provided)
@@ -148,7 +148,7 @@ void EnzoInitialBurkertBodenheimer::enforce_block
   CkPrintf("%s: mass = %e\n", __FUNCTION__, mass_);
   CkPrintf("%s: rx = %e\n", __FUNCTION__, rx);
   CkPrintf("%s: calculated mass (assuming uniform density) = %e\n",
-	 __FUNCTION__, (density*(4.0/3.0*(cello::pi)*rx*ry*rz))* (enzo_units->mass())/(cello::mass_solar));
+	 __FUNCTION__, (density*(4.0/3.0*(cello::pi)*rx*ry*rz))* (enzo_units->mass())/(enzo_constants::mass_solar));
 */
   //exit(-99);
 

--- a/src/Enzo/enzo_EnzoInitialCollapse.cpp
+++ b/src/Enzo/enzo_EnzoInitialCollapse.cpp
@@ -107,7 +107,7 @@ void EnzoInitialCollapse::enforce_block
   // Initialize Fields
 
   const double gamma = EnzoBlock::Gamma[cello::index_static()];
-  const double energy = 1e-3*(cello::kboltz)*temperature_ / ((gamma - 1.0) * (1.0 * cello::mass_hydrogen));
+  const double energy = 1e-3*(enzo_constants::kboltz)*temperature_ / ((gamma - 1.0) * (1.0 * enzo_constants::mass_hydrogen));
   
   // ...compute ellipsoid density
 

--- a/src/Enzo/enzo_EnzoInitialFeedbackTest.cpp
+++ b/src/Enzo/enzo_EnzoInitialFeedbackTest.cpp
@@ -237,7 +237,7 @@ void EnzoInitialFeedbackTest::enforce_block
                                                                         CkNumPes(), CkMyPe() + (ParticleData::id_counter[cello::index_static()]) * CkNumPes());
 #endif
       id[ipp] = CkMyPe() + (ParticleData::id_counter[cello::index_static()]++) * CkNumPes();
-      pmass[ipp] = this->mass[i] * cello::mass_solar / enzo_units->mass();
+      pmass[ipp] = this->mass[i] * enzo_constants::mass_solar / enzo_units->mass();
       px[ipp]    = this->position[0][i];
       py[ipp]    = this->position[1][i];
       pz[ipp]    = this->position[2][i];
@@ -246,8 +246,8 @@ void EnzoInitialFeedbackTest::enforce_block
       pvz[ipp]   = 0.0;
 
       pmetal[ipp]    = 0.01;
-      plifetime[ipp] = 1.00E9* cello::yr_s / enzo_units->time();
-      pform[ipp]     = 1.0E-10 * cello::yr_s / enzo_units->time(); // really just needs to be non-zero
+      plifetime[ipp] = 1.00E9* enzo_constants::yr_s / enzo_units->time();
+      pform[ipp]     = 1.0E-10 * enzo_constants::yr_s / enzo_units->time(); // really just needs to be non-zero
 
       is_local[ipp] = 1;
 

--- a/src/Enzo/enzo_EnzoInitialGrackleTest.cpp
+++ b/src/Enzo/enzo_EnzoInitialGrackleTest.cpp
@@ -122,7 +122,7 @@ void EnzoInitialGrackleTest::enforce_block
       for (int ix=0; ix<nx+gx; ix++) { // H Number Density
         int i = INDEX(ix,iy,iz,ngx,ngy);
 
-        grackle_fields_.density[i] = cello::mass_hydrogen *
+        grackle_fields_.density[i] = enzo_constants::mass_hydrogen *
                      pow(10.0, ((H_n_slope * (ix-gx)) + log10(enzo_config->initial_grackle_test_minimum_H_number_density)))/
                      grackle_chemistry->HydrogenFractionByMass / enzo_units->density();
 

--- a/src/Enzo/enzo_EnzoInitialIsolatedGalaxy.cpp
+++ b/src/Enzo/enzo_EnzoInitialIsolatedGalaxy.cpp
@@ -76,24 +76,24 @@ EnzoInitialIsolatedGalaxy::EnzoInitialIsolatedGalaxy
   // Store variables locally with code units for convenience
   //     this is not strictly necessary, but makes routine a little cleaner
 
-  this->scale_height_            = config->initial_IG_scale_height * cello::kpc_cm /
+  this->scale_height_            = config->initial_IG_scale_height * enzo_constants::kpc_cm /
                                    enzo_units->length();
-  this->scale_length_	           = config->initial_IG_scale_length * cello::kpc_cm /
+  this->scale_length_	           = config->initial_IG_scale_length * enzo_constants::kpc_cm /
                                    enzo_units->length();
-  this->disk_mass_               = config->initial_IG_disk_mass * cello::mass_solar /
+  this->disk_mass_               = config->initial_IG_disk_mass * enzo_constants::mass_solar /
                                    enzo_units->mass();
   this->gas_fraction_            = config->initial_IG_gas_fraction;
   this->disk_temperature_        = config->initial_IG_disk_temperature /
                                    enzo_units->temperature();
   this->disk_metal_fraction_     = config->initial_IG_disk_metal_fraction;
-  this->gas_halo_mass_           = config->initial_IG_gas_halo_mass * cello::mass_solar /
+  this->gas_halo_mass_           = config->initial_IG_gas_halo_mass * enzo_constants::mass_solar /
                                    enzo_units->mass();
   this->gas_halo_temperature_    = config->initial_IG_gas_halo_temperature /
                                    enzo_units->temperature();
   this->gas_halo_metal_fraction_ = config->initial_IG_gas_halo_metal_fraction;
   this->gas_halo_density_        = config->initial_IG_gas_halo_density /
                                    enzo_units->density();
-  this->gas_halo_radius_         = config->initial_IG_gas_halo_radius * cello::kpc_cm /
+  this->gas_halo_radius_         = config->initial_IG_gas_halo_radius * enzo_constants::kpc_cm /
                                    enzo_units->length();
 
   // on / off settings for IC
@@ -465,9 +465,9 @@ void EnzoInitialIsolatedGalaxy::InitializeExponentialGasDistribution(Block * blo
 
             double Mvir  = enzo_config->method_background_acceleration_DM_mass;
 
-            rcore = rcore * cello::kpc_cm;
-            rvir  = rvir  * cello::kpc_cm;
-            Mvir  = Mvir  * cello::mass_solar;
+            rcore = rcore * enzo_constants::kpc_cm;
+            rvir  = rvir  * enzo_constants::kpc_cm;
+            Mvir  = Mvir  * enzo_constants::mass_solar;
 
             double conc = rvir  / rcore;
             double   rx = r_cyl / rvir;
@@ -475,7 +475,7 @@ void EnzoInitialIsolatedGalaxy::InitializeExponentialGasDistribution(Block * blo
 
             vcirc = (std::log(1.0 + conc*rx) - (conc*rx)/(1.0+conc*rx))/
                       (std::log(1.0 + conc) - (conc / (1.0 + conc))) / rx;
-            vcirc = std::sqrt(vcirc * cello::grav_constant * Mvir / rvir);
+            vcirc = std::sqrt(vcirc * enzo_constants::grav_constant * Mvir / rvir);
 
           } else {
             vcirc = this->InterpolateVcircTable(r_cyl);
@@ -971,8 +971,8 @@ void EnzoInitialIsolatedGalaxy::ReadParticlesFromFile_(const int &nl,
        // assuming all stars are the same mass
        EnzoUnits * enzo_units = enzo::units();
 
-       const double mass_conv = cello::mass_solar / enzo_units->mass();
-       const double time_conv = cello::Myr_s / enzo_units->time();
+       const double mass_conv = enzo_constants::mass_solar / enzo_units->mass();
+       const double time_conv = enzo_constants::Myr_s / enzo_units->time();
 
        int stars_per_bin = floor((this->recent_SF_SFR * this->recent_SF_bin_size * 1.0E3)/
                     (particleIcMass[ipt][0] / mass_conv)); // SFR in Msun/yr, bins in Myr
@@ -1023,10 +1023,10 @@ void EnzoInitialIsolatedGalaxy::ReadParticlesFromFile(const int& nl,
          "ParticleFile not found", inFile.is_open());
 
   int i = 0;
-  double lu = cello::pc_cm;
-  double mu = cello::mass_solar / enzo_units->mass();
+  double lu = enzo_constants::pc_cm;
+  double mu = enzo_constants::mass_solar / enzo_units->mass();
   if (this->gas_fraction_ <= 0.2){
-    lu = cello::kpc_cm; // HACK AT THE MOMENT - use old units for MW-size galaxy
+    lu = enzo_constants::kpc_cm; // HACK AT THE MOMENT - use old units for MW-size galaxy
     mu = 1.0;
   }
 
@@ -1088,7 +1088,7 @@ void EnzoInitialIsolatedGalaxy::ReadInVcircData(void)
            "Too many lines in circular velocity file",
            i < this->VCIRC_TABLE_LENGTH);
 
-    this->vcirc_radius[i]   *= cello::kpc_cm;   // kpc  -> cm
+    this->vcirc_radius[i]   *= enzo_constants::kpc_cm;   // kpc  -> cm
     this->vcirc_velocity[i] *= 1.0E5; // km/s -> cm/s
     i++;
   }

--- a/src/Enzo/enzo_EnzoMethodBackgroundAcceleration.cpp
+++ b/src/Enzo/enzo_EnzoMethodBackgroundAcceleration.cpp
@@ -29,7 +29,7 @@ EnzoMethodBackgroundAcceleration::EnzoMethodBackgroundAcceleration
    hx_(0), hy_(0), hz_(0)
 {
 
-  this->G_four_pi_ = 4.0 * cello::pi * cello::grav_constant;
+  this->G_four_pi_ = 4.0 * cello::pi * enzo_constants::grav_constant;
 
   FieldDescr * field_descr = cello::field_descr();
 
@@ -157,7 +157,7 @@ void EnzoMethodBackgroundAcceleration::PointMass(enzo_float * ax,
   // just need to define position of each cell
 
   double mass = enzo_config->method_background_acceleration_mass *
-                cello::mass_solar / enzo_units->mass();
+                enzo_constants::mass_solar / enzo_units->mass();
   double rcore = std::max(0.1*hx_,
                      enzo_config->method_background_acceleration_core_radius/enzo_units->length());
   double G = this->G_four_pi_ *
@@ -210,29 +210,29 @@ void EnzoMethodBackgroundAcceleration::GalaxyModel(enzo_float * ax,
                                                    throw() {
 
   double DM_mass     = enzo_config->method_background_acceleration_DM_mass *
-                         cello::mass_solar / enzo_units->mass();
+                         enzo_constants::mass_solar / enzo_units->mass();
   double DM_mass_radius = enzo_config->method_background_acceleration_DM_mass_radius *
-                          cello::kpc_cm / enzo_units->length();
+                          enzo_constants::kpc_cm / enzo_units->length();
   double DM_density  = enzo_config->method_background_acceleration_DM_density /
                          enzo_units->density();
   double stellar_r   = enzo_config->method_background_acceleration_stellar_scale_height_r *
-                         cello::kpc_cm / enzo_units->length();
+                         enzo_constants::kpc_cm / enzo_units->length();
   double stellar_z   = enzo_config->method_background_acceleration_stellar_scale_height_z *
-                         cello::kpc_cm / enzo_units->length();
+                         enzo_constants::kpc_cm / enzo_units->length();
   double stellar_mass = enzo_config->method_background_acceleration_stellar_mass *
-                        cello::mass_solar / enzo_units->mass();
+                        enzo_constants::mass_solar / enzo_units->mass();
   double bulge_mass   = enzo_config->method_background_acceleration_bulge_mass *
-                        cello::mass_solar / enzo_units->mass();
+                        enzo_constants::mass_solar / enzo_units->mass();
   double bulgeradius = enzo_config->method_background_acceleration_bulge_radius *
-                        cello::kpc_cm / enzo_units->length();
+                        enzo_constants::kpc_cm / enzo_units->length();
   const double * amom = enzo_config->method_background_acceleration_angular_momentum;
 
 //  double G = this->G_four_pi_ *
 //             enzo_units->density() * enzo_units->time() * enzo_units->time();
-  double G_code = cello::grav_constant * enzo_units->density() * enzo_units->time() * enzo_units->time();
+  double G_code = enzo_constants::grav_constant * enzo_units->density() * enzo_units->time() * enzo_units->time();
 
   double rcore = enzo_config->method_background_acceleration_core_radius *
-                 cello::kpc_cm / enzo_units->length();
+                 enzo_constants::kpc_cm / enzo_units->length();
 
   if (DM_mass > 0.0){
     double xtemp = DM_mass_radius / rcore;

--- a/src/Enzo/enzo_EnzoMethodDistributedFeedback.cpp
+++ b/src/Enzo/enzo_EnzoMethodDistributedFeedback.cpp
@@ -522,7 +522,7 @@ void EnzoMethodDistributedFeedback::compute_ (Block * block)
         double star_age = 0.0;
         unsigned long long int rand_int;
 
-        const double time_last_sn = 37.7 * cello::Myr_s / enzo_units->time();
+        const double time_last_sn = 37.7 * enzo_constants::Myr_s / enzo_units->time();
 
         if ( (plifetime[ipdl] <= 0.0) ||
              ( (current_time - pcreation[ipdc]) < time_last_sn ) ) {
@@ -617,7 +617,7 @@ void EnzoMethodDistributedFeedback::compute_ (Block * block)
               progenitor_mass = 20.0;
             }
 
-            delay_time   *=  cello::yr_s / enzo_units->time(); // code units
+            delay_time   *=  enzo_constants::yr_s / enzo_units->time(); // code units
             star_age = current_time - pcreation[ipdc]; // code units
             if ((delay_time > star_age) && (delay_time < star_age + enzo_block->dt  )) {
             // AJE: I"m a little confused as to why the above check in original code
@@ -657,7 +657,7 @@ void EnzoMethodDistributedFeedback::compute_ (Block * block)
             } // end check star_age
 
 //          Behavior not yet possible in Enzo-E
-//            if ( star_age < delay_time + 0.1 * cello::Myr_s / enzo_units->time()){
+//            if ( star_age < delay_time + 0.1 * enzo_constants::Myr_s / enzo_units->time()){
 //              // change type to must refine
 //            } else {
 //              change back to star
@@ -681,21 +681,21 @@ void EnzoMethodDistributedFeedback::compute_ (Block * block)
      //           used to compute these rates with starburst 99.  Reduce to account
      //           for the size of the star particle
         wind_mass = wind_mass * enzo_config->method_star_maker_minimum_star_mass * 1.0E-6;
-        wind_mass = wind_mass / cello::yr_s; // in Msun / s
+        wind_mass = wind_mass / enzo_constants::yr_s; // in Msun / s
         wind_mass = (wind_mass * enzo_units->time()) * enzo_block->dt; // Msun this timestep
 
-        double tsoon7      = soonest_explosion * enzo_units->time() / (1.0E7 * cello::yr_s);
+        double tsoon7      = soonest_explosion * enzo_units->time() / (1.0E7 * enzo_constants::yr_s);
         double wind_energy = 0.0;
         if (time_first_sn_ > 0){
           // --- for testing ---
-          wind_energy = 1.0E48 / (8.0 * cello::mass_solar); // non zero erg
+          wind_energy = 1.0E48 / (8.0 * enzo_constants::mass_solar); // non zero erg
         } else{
           wind_energy = s99_wind_energy(td7, tsoon7); // in cm^2/s^2 (i.e. per unit mass in cgs)
         }
-        wind_energy        = wind_energy * wind_mass * cello::mass_solar; // now total E in erg
+        wind_energy        = wind_energy * wind_mass * enzo_constants::mass_solar; // now total E in erg
 
         star_age = current_time - pcreation[ipdc]; // code units
-        td7 = star_age * enzo_units->time() / cello::yr_s / 1.0E7; // time in 10^7 yr
+        td7 = star_age * enzo_units->time() / enzo_constants::yr_s / 1.0E7; // time in 10^7 yr
         double sn_mass = 0.0, sn_energy = 0.0, sn_metal_fraction = 0.0;
         if (explosion_flag > 0){
           if (time_first_sn_ > 0){ // hack here ! for testing
@@ -716,10 +716,10 @@ void EnzoMethodDistributedFeedback::compute_ (Block * block)
         double m_eject = wind_mass + sn_mass;          // total mass in Msun
         double energy  = wind_energy + sn_energy;      // total energy in erg
 
-        if (m_eject*cello::mass_solar / enzo_units->mass() > pmass[ipdm]){
+        if (m_eject*enzo_constants::mass_solar / enzo_units->mass() > pmass[ipdm]){
           CkPrintf("WARNING: S99 Distributed Feedback is loosing too much mass\n");
           CkPrintf("setting particle mass to zero, but continuing anyway\n");
-          CkPrintf(" %g %g %g %g \n",pmass[ipdm],m_eject*cello::mass_solar/enzo_units->mass(),
+          CkPrintf(" %g %g %g %g \n",pmass[ipdm],m_eject*enzo_constants::mass_solar/enzo_units->mass(),
                                      wind_mass, sn_mass);
           CkPrintf(" %i %i \n",will_explode, explosion_flag);
         } // mass will be removed elsewhere
@@ -748,7 +748,7 @@ void EnzoMethodDistributedFeedback::compute_ (Block * block)
                               metal_fraction,
                               pvx[ipdv], pvy[ipdv], pvz[ipdv]);
         // remove mass - error checking on the std::max is handled above with warning
-        pmass[ipdm] = std::max( 0.0, pmass[ipdm] - m_eject*cello::mass_solar/enzo_units->mass());
+        pmass[ipdm] = std::max( 0.0, pmass[ipdm] - m_eject*enzo_constants::mass_solar/enzo_units->mass());
 /*
         this->inject_feedback(block, xpos, ypos, zpos,
                               enzo_config->method_feedback_ejecta_mass,
@@ -883,14 +883,14 @@ void EnzoMethodDistributedFeedback::add_ionization_feedback(
   const float alpha = 2.60E-13; // cm^3 / s
 
   // AE: possibly actually compute mu from species fields
-  double ndens = d[index] * enzo_units->density() / enzo_config->ppm_mol_weight / cello::mass_hydrogen;
+  double ndens = d[index] * enzo_units->density() / enzo_config->ppm_mol_weight / enzo_constants::mass_hydrogen;
 
   double stromgren_radius = std::pow( (3.0 * s49_tot * 1.0E49) /
                             (4.0 * cello::pi * alpha * ndens*ndens),1.0/3.0);
   double stromgren_volume = (4.0/3.0)*cello::pi*stromgren_radius*stromgren_radius*stromgren_radius;
   stromgren_volume        /= (enzo_units->length()*enzo_units->length()*enzo_units->length());
-  double ionized          = cello::kboltz * 1.0E4 / std::min(0.6,enzo_config->ppm_mol_weight) /
-                            cello::mass_hydrogen / (enzo_units->length()*enzo_units->length()) *
+  double ionized          = enzo_constants::kboltz * 1.0E4 / std::min(0.6,enzo_config->ppm_mol_weight) /
+                            enzo_constants::mass_hydrogen / (enzo_units->length()*enzo_units->length()) *
                             enzo_units->time() * enzo_units->time();
 
 
@@ -899,7 +899,7 @@ void EnzoMethodDistributedFeedback::add_ionization_feedback(
   }
 
 #ifdef DEBUG_FEEDBACK
-  CkPrintf("DistributedFeedback (%s): This cell should be getting ionized with radius = %g (pc). volume ratio = %g. will_explode = %i ge = %g ionized = %g\n", enzo_block->name().c_str(), stromgren_radius / cello::pc_cm, stromgren_volume * inv_volume, will_explode, ge[index], ionized);
+  CkPrintf("DistributedFeedback (%s): This cell should be getting ionized with radius = %g (pc). volume ratio = %g. will_explode = %i ge = %g ionized = %g\n", enzo_block->name().c_str(), stromgren_radius / enzo_constants::pc_cm, stromgren_volume * inv_volume, will_explode, ge[index], ionized);
 #endif
 
 
@@ -995,7 +995,7 @@ void EnzoMethodDistributedFeedback::inject_feedback(
   CkPrintf("Injecting feedback in %i cells at mass (Msun) %g and energy (E51) %g\n",number_of_feedback_cells_, m_eject, E_51);
 #endif
   double energy_per_cell = E_51 * 1.0E51 / energy_units;
-  double mass_per_cell   = m_eject * cello::mass_solar / enzo_units->mass();
+  double mass_per_cell   = m_eject * enzo_constants::mass_solar / enzo_units->mass();
 
   mass_per_cell /= ((double) number_of_feedback_cells_);
   energy_per_cell /= ((double) number_of_feedback_cells_);
@@ -1113,7 +1113,7 @@ void EnzoMethodDistributedFeedback::inject_feedback(
     double inv_ncell = 1.0 / ((double) number_of_feedback_cells_);
     const double z_solar = 0.02;   // as assumed for these equations
     avg_z =  (avg_z / avg_d) / z_solar; // mass-weighted metallicity
-    avg_n *= inv_ncell * enzo_units->density() / cello::mass_hydrogen; // in cgs
+    avg_n *= inv_ncell * enzo_units->density() / enzo_constants::mass_hydrogen; // in cgs
     avg_d *= inv_ncell * enzo_units->density(); // in cgs
 
 
@@ -1131,7 +1131,7 @@ void EnzoMethodDistributedFeedback::inject_feedback(
       R_PDS = 18.50 * pow(E_51,2.0/7.0 ) * pow(avg_z,-1.0/7.0 ) * pow(avg_n,-3.0/7.0);
     } // end metallicity check
 
-    double     R_resolve = hx*enzo_units->length() / cello::pc_cm;
+    double     R_resolve = hx*enzo_units->length() / enzo_constants::pc_cm;
     const double  n_resolve = 4.5; // number of cells needed to resolve R
 
     if (R_PDS > n_resolve * R_resolve){
@@ -1139,7 +1139,7 @@ void EnzoMethodDistributedFeedback::inject_feedback(
 
     } else {
 
-      ke_f = 3.97133E-6 * (avg_d / cello::mass_hydrogen) *
+      ke_f = 3.97133E-6 * (avg_d / enzo_constants::mass_hydrogen) *
                    (1.0 / (R_resolve * R_resolve)) *
                    pow(R_PDS,7) * ( 1.0 / (t_PDS*t_PDS)) *
                    (1.0 / E_51);
@@ -1538,6 +1538,6 @@ double EnzoMethodDistributedFeedback::timestep (Block * block) throw()
   // important things happen throughout the star's lifetime.
   EnzoUnits * enzo_units = enzo::units();
 
-//  return 1000.0 * cello::yr_s / enzo_units->time();
+//  return 1000.0 * enzo_constants::yr_s / enzo_units->time();
   return std::numeric_limits<double>::max();
 }

--- a/src/Enzo/enzo_EnzoMethodFeedback.cpp
+++ b/src/Enzo/enzo_EnzoMethodFeedback.cpp
@@ -28,7 +28,7 @@ EnzoMethodFeedback::EnzoMethodFeedback
   Refresh * refresh = cello::refresh(ir_post_);
   refresh->add_all_fields();
 
-  ejecta_mass_   = enzo_config->method_feedback_ejecta_mass * cello::mass_solar /
+  ejecta_mass_   = enzo_config->method_feedback_ejecta_mass * enzo_constants::mass_solar /
                       enzo_units->mass();
 
   ejecta_energy_ = enzo_config->method_feedback_supernova_energy * 1.0E51 /

--- a/src/Enzo/enzo_EnzoMethodFire2Feedback.cpp
+++ b/src/Enzo/enzo_EnzoMethodFire2Feedback.cpp
@@ -66,7 +66,7 @@ int determineSN(float age, int* nSNII, int* nSNIA,
         if (RII > 0){
             srand(seed);
         // printf("Zcpl = %e", zCouple);
-            PII = RII * massmass_solar / cello::Myr_s *TimeUnits*dt;
+            PII = RII * massmass_solar / enzo_constants::Myr_s *TimeUnits*dt;
             // printf("PII =%f\n %f %e %f\n", PII, RII, massmass_solar, age);
             random = float(rand())/float(RAND_MAX);
             if (PII > 1.0 && enzo_config->method_feedback_fire2_unrestricted_SN){
@@ -147,7 +147,7 @@ int determineWinds(float age, float* eWinds, float* mWinds, float* zWinds,
       }
 
       wind_factor *= (enzo_config->method_feedback_fire2_gasreturnfraction *\
-                     0.001 * (dt * (TimeUnits / cello::Myr_s)); // 0.001 converts from Msun/Gyr to Msun/Myr
+                     0.001 * (dt * (TimeUnits / enzo_constants::Myr_s)); // 0.001 converts from Msun/Gyr to Msun/Myr
       wind_factor = 1.0 - exp(-wind_factor);
       wind_factor = std::min(1.0, wind_factor);
       wind_factor *= 1.4 * 0.291175;
@@ -390,7 +390,7 @@ void EnzoMethodFire2Feedback::compute_ (Block * block)
       int ipsn  = ip*dsn; // number of SNe coutner
 
       if (pmass[ipdm] > 0.0 && plifetime[ipdl] > 0.0){
-        const double age = (current_time - pcreation[ipdc]) * enzo_units->time() / cello::Myr_s;
+        const double age = (current_time - pcreation[ipdc]) * enzo_units->time() / enzo_constants::Myr_s;
         count++; // increment particles examined here
 
         // compute coordinates of central feedback cell
@@ -407,7 +407,7 @@ void EnzoMethodFire2Feedback::compute_ (Block * block)
 
         int index = INDEX(ix,iy,iz,mx,my); // 1D cell index of star position
 
-        //if(pmass[ipdm] * enzo_units->mass_units() / cello::mass_solar
+        //if(pmass[ipdm] * enzo_units->mass_units() / enzo_constants::mass_solar
         //       < enzo_config->method_star_maker_minimum_star_mass){
         //
         //}
@@ -421,7 +421,7 @@ void EnzoMethodFire2Feedback::compute_ (Block * block)
 
           /* Determine SN events from rates (currently taken from Hopkins 2018) */
 
-          determineSN(age, &nSNII, &nSNIa, pmass[ipdm] * enzo_units->mass_units() / cello::mass_solar,
+          determineSN(age, &nSNII, &nSNIa, pmass[ipdm] * enzo_units->mass_units() / enzo_constants::mass_solar,
                       enzo_units->time_units(), block->dt());
 
           numSN += nSNII + nSNIa;
@@ -469,7 +469,7 @@ void EnzoMethodFire2Feedback::compute_ (Block * block)
           const double starZ = pmetal[ipdmf] / z_solar;
 
           determineWinds(age, &windEnergy, &windMass, &windMetals,
-                         pmass[ipdm] * pmass[ipdm] * enzo_units->mass_units() / cello::mass_solar,
+                         pmass[ipdm] * pmass[ipdm] * enzo_units->mass_units() / enzo_constants::mass_solar,
                          starZ, enzo_units->time_units(), block->dt());
 
           /* Error messages go here */
@@ -484,7 +484,7 @@ void EnzoMethodFire2Feedback::compute_ (Block * block)
         } // if winds
 
         pmass[ipdm] -= std::max(0.0,
-                       (windMass + SNMassEjected) *enzo_units->mass_units()/cello::mass_solar);
+                       (windMass + SNMassEjected) *enzo_units->mass_units()/enzo_constants::mass_solar);
 
         //
 
@@ -641,7 +641,7 @@ double EnzoMethodFire2Feedback::timestep (Block * block) throw()
   double dtStar = std::numeric_limits<double>::max();
   if (block->level() >= sf_minimum_level_){
     const double pSNmax = 0.0005408 * enzo_config->method_star_maker_minimum_star_mass *
-                          block->dt() * enzo_units->time() / cello::Myr_s * 1.25;
+                          block->dt() * enzo_units->time() / enzo_constants::Myr_s * 1.25;
     if (pSNmax > 1.0) dtStar = dt * 1.0 / pSNmax;
   }
 

--- a/src/Enzo/enzo_EnzoMethodStarMaker.cpp
+++ b/src/Enzo/enzo_EnzoMethodStarMaker.cpp
@@ -224,9 +224,9 @@ int EnzoMethodStarMaker::check_self_gravitating(
 
   // constant for testing. TODO: change to variable
   const double gamma = 5.0 / 3.0;
-  cs2 = (gamma * cello::kboltz * temperature) / mean_particle_mass;
+  cs2 = (gamma * enzo_constants::kboltz * temperature) / mean_particle_mass;
 
-  alpha = (div_v_norm2 + cs2/dx2) / (8 * cello::pi * cello::grav_constant * rho_cgs);
+  alpha = (div_v_norm2 + cs2/dx2) / (8 * cello::pi * enzo_constants::grav_constant * rho_cgs);
   return (alpha < 1);
 
 }
@@ -269,9 +269,9 @@ int EnzoMethodStarMaker::check_jeans_mass(
     return 1;
 
   const double gamma = 5.0 / 3.0;
-  const double minimum_jeans_mass = 1000 * cello::mass_solar;
-  double cs2 = (gamma * cello::kboltz * temperature) / mean_particle_mass;
-  double m_jeans = (cello::pi/6) * pow(cs2, 1.5) / (pow(cello::grav_constant, 1.5) * sqrt(rho_cgs));
+  const double minimum_jeans_mass = 1000 * enzo_constants::mass_solar;
+  double cs2 = (gamma * enzo_constants::kboltz * temperature) / mean_particle_mass;
+  double m_jeans = (cello::pi/6) * pow(cs2, 1.5) / (pow(enzo_constants::grav_constant, 1.5) * sqrt(rho_cgs));
   double m_jcrit = MAX(minimum_jeans_mass, m_jeans);
   return (mass < m_jcrit);
 }

--- a/src/Enzo/enzo_EnzoMethodStarMakerFIRE2.cpp
+++ b/src/Enzo/enzo_EnzoMethodStarMakerFIRE2.cpp
@@ -164,10 +164,10 @@ void EnzoMethodStarMakerStochasticSF::compute ( Block *block) throw()
 
         // need to compute this better for Grackle fields (on to-do list)
         double rho_cgs = density[i] * enzo_units->density();
-        double mean_particle_mass = enzo_config->ppm_mol_weight * cello::mass_hydrogen;
+        double mean_particle_mass = enzo_config->ppm_mol_weight * enzo_constants::mass_hydrogen;
         double ndens = rho_cgs / mean_particle_mass;
 
-        double mass  = density[i] *dx*dy*dz * enzo_units->mass() / cello::mass_solar;
+        double mass  = density[i] *dx*dy*dz * enzo_units->mass() / enzo_constants::mass_solar;
         double metallicity = (metal) ? metal[i]/density[i]/Zsolar : 0.0;
 
         //
@@ -185,7 +185,7 @@ void EnzoMethodStarMakerStochasticSF::compute ( Block *block) throw()
         // Check whether mass in [min_mass, max_range] range and if specified, Jeans unstable
         if (! this->check_mass(mass)) continue;
 
-        double tdyn = sqrt(3.0 * cello::pi / 32.0 / cello::grav_constant /
+        double tdyn = sqrt(3.0 * cello::pi / 32.0 / enzo_constants::grav_constant /
                       (density[i] * enzo_units->density()));
 
         //
@@ -252,7 +252,7 @@ void EnzoMethodStarMakerStochasticSF::compute ( Block *block) throw()
         pform     = (enzo_float *) particle.attribute_array(it, ia_to, ib);
 
         pform[io]     =  enzo_block->time();   // formation time
-        plifetime[io] =  10.0 * cello::Myr_s / enzo_units->time() ; // lifetime
+        plifetime[io] =  10.0 * enzo_constants::Myr_s / enzo_units->time() ; // lifetime
 
         if (metal){
           pmetal     = (enzo_float *) particle.attribute_array(it, ia_metal, ib);

--- a/src/Enzo/enzo_EnzoMethodStarMakerStochasticSF.cpp
+++ b/src/Enzo/enzo_EnzoMethodStarMakerStochasticSF.cpp
@@ -165,10 +165,10 @@ void EnzoMethodStarMakerStochasticSF::compute ( Block *block) throw()
 
         // need to compute this better for Grackle fields (on to-do list)
         double rho_cgs = density[i] * enzo_units->density();
-        double mean_particle_mass = enzo_config->ppm_mol_weight * cello::mass_hydrogen;
+        double mean_particle_mass = enzo_config->ppm_mol_weight * enzo_constants::mass_hydrogen;
         double ndens = rho_cgs / mean_particle_mass;
 
-        double mass  = density[i] *dx*dy*dz * enzo_units->mass() / cello::mass_solar;
+        double mass  = density[i] *dx*dy*dz * enzo_units->mass() / enzo_constants::mass_solar;
         double metallicity = (metal) ? metal[i]/density[i]/Zsolar : 0.0;
 
         //
@@ -200,7 +200,7 @@ void EnzoMethodStarMakerStochasticSF::compute ( Block *block) throw()
         // Check whether mass in [min_mass, max_range] range and if specified, Jeans unstable
         if (! this->check_mass(mass)) continue;
 
-        double tdyn = sqrt(3.0 * cello::pi / 32.0 / cello::grav_constant /
+        double tdyn = sqrt(3.0 * cello::pi / 32.0 / enzo_constants::grav_constant /
                       (density[i] * enzo_units->density()));
 
         //
@@ -287,7 +287,7 @@ void EnzoMethodStarMakerStochasticSF::compute ( Block *block) throw()
         pform     = (enzo_float *) particle.attribute_array(it, ia_to, ib);
 
         pform[io]     =  enzo_block->time();   // formation time
-        plifetime[io] =  tdyn;  // 10.0 * cello::Myr_s / enzo_units->time() ; // lifetime
+        plifetime[io] =  tdyn;  // 10.0 * enzo_constants::Myr_s / enzo_units->time() ; // lifetime
 
         if (metal){
           pmetal     = (enzo_float *) particle.attribute_array(it, ia_metal, ib);

--- a/src/Enzo/enzo_EnzoPhysicsCosmology.hpp
+++ b/src/Enzo/enzo_EnzoPhysicsCosmology.hpp
@@ -193,7 +193,7 @@ public: // interface
   /// Return current length units scaling (requires set_current_time())
   double length_units() const
   {
-    return cello::Mpc_cm*comoving_box_size_/hubble_constant_now_/
+    return enzo_constants::Mpc_cm*comoving_box_size_/hubble_constant_now_/
       (1.0 + current_redshift_);
   }
 

--- a/src/Enzo/enzo_EnzoUnits.hpp
+++ b/src/Enzo/enzo_EnzoUnits.hpp
@@ -92,9 +92,16 @@ public: // virtual methods
   /// Return temperature units scaling factor (virtual)
   virtual double temperature() const
   {
-    double dflt_out = (enzo_constants::mass_hydrogen*std::pow(velocity(),2) /
-                       enzo_constants::kboltz);
-    return (cosmology_ == NULL) ? dflt_out : cosmology_->temperature_units();
+    if (cosmology_ == NULL){
+      // The Units base-class can't compute the temperature code units for the
+      // non-cosmology case because it involves physical constants that are not
+      // defined in the Cello layer
+      double vel_units = velocity();
+      return (enzo_constants::mass_hydrogen * (vel_units * vel_units) /
+              enzo_constants::kboltz);
+    } else {
+      return cosmology_->temperature_units();
+    }
   }
   
   /// Return velocity units scaling factor (virtual)

--- a/src/Enzo/enzo_EnzoUnits.hpp
+++ b/src/Enzo/enzo_EnzoUnits.hpp
@@ -90,7 +90,7 @@ public: // virtual methods
   }
 
   /// Return temperature units scaling factor (virtual)
-  double temperature() const
+  virtual double temperature() const
   {
     double dflt_out = (enzo_constants::mass_hydrogen*std::pow(velocity(),2) /
                        enzo_constants::kboltz);

--- a/src/Enzo/enzo_EnzoUnits.hpp
+++ b/src/Enzo/enzo_EnzoUnits.hpp
@@ -90,10 +90,11 @@ public: // virtual methods
   }
 
   /// Return temperature units scaling factor (virtual)
-  virtual double temperature() const
+  double temperature() const
   {
-    return (cosmology_ == NULL) ?
-      Units::temperature() : cosmology_->temperature_units();
+    double dflt_out = (enzo_constants::mass_hydrogen*std::pow(velocity(),2) /
+                       enzo_constants::kboltz);
+    return (cosmology_ == NULL) ? dflt_out : cosmology_->temperature_units();
   }
   
   /// Return velocity units scaling factor (virtual)

--- a/src/Enzo/enzo_constants.hpp
+++ b/src/Enzo/enzo_constants.hpp
@@ -1,0 +1,61 @@
+// See LICENSE_CELLO file for license and copyright information
+
+/// @file     enzo.hpp
+/// @author   Matthew Abruzzo (matthewabruzzo@gmail.com)
+/// @date     2022-06-14
+/// @brief    Physical constants
+
+#ifndef ENZO_CONSTANTS_HPP
+#define ENZO_CONSTANTS_HPP
+
+/// Namespace for global constants and functions
+namespace enzo_constants {
+
+  // ergs per eV
+  const double erg_eV = 1.60217653E-12;
+
+  // eV per erg
+  const double eV_erg = 6.24150948E11;
+
+  // Boltzman constant in CGS
+  const double kboltz = 1.3806504e-16;
+
+  // Solar mass in CGS
+  const double mass_solar = 1.98841586e33;
+
+  // Hydrogen mass in CGS
+  const double mass_hydrogen = 1.67262171e-24;
+
+  // Electron mass in CGS
+  const double mass_electron = 9.10938291E-28;
+
+  // parsec in CGS
+  const double pc_cm  = 3.0856775809623245E18;
+
+  // Kiloparsec in CGS
+  const double kpc_cm = 3.0856775809623245E21;
+
+  // Megaparsec in CGS
+  const double Mpc_cm = 3.0856775809623245E24;
+
+  // speed of light in CGS
+  const double clight = 29979245800.0;
+
+  // Gravitational constant in CGS
+  const double grav_constant = 6.67384E-8;
+
+  // year in seconds
+  const double yr_s = 3.1556952E7;
+
+  // kyr in seconds
+  const double kyr_s = 3.1556952E10;
+
+  // Myr in seconds
+  const double Myr_s = 3.1556952E13;
+
+  // Approximate mean molecular weight of metals
+  const double mu_metal = 16.0;
+
+};
+
+#endif /* ENZO_CONSTANTS_HPP */


### PR DESCRIPTION
As we discussed this morning I moved the Physics constants from the Cello layer to the `Enzo` layer.

I went a little off script here and put the constants into a new namespace called `enzo_constants`. If people would prefer otherwise, I can easily put them into the existing `enzo` namespace

~EDIT:I didn't compile the code first. There's a few things I need to fix~ It compiles now