### PR TITLE
[BUGFIX] Isolated galaxy velocity calculation

### DIFF
--- a/input/IsolatedGalaxy/WLM_small.in
+++ b/input/IsolatedGalaxy/WLM_small.in
@@ -133,7 +133,6 @@
       #    also can have background stellar bulge and / or stellar disk potential
       background_acceleration {
           flavor = "GalaxyModel";
-          DM_density     = -1.0   ;  # specify this OR mass - not both - mass_radius must be virial if this is used
           DM_mass        = 1.0E10;   # mass interior to below radius (in Msun) -  (this particular value is virial mass)
           DM_mass_radius = 45.0;     # radius (kpc) corresponding to above mass (this is virial)
           core_radius    = 3.0;      # r_c in kpc  (c = r_c / R_vir)

--- a/input/IsolatedGalaxy/method_isolatedgalaxy-particles.in
+++ b/input/IsolatedGalaxy/method_isolatedgalaxy-particles.in
@@ -102,8 +102,7 @@
 
       background_acceleration {
           flavor = "GalaxyModel";
-          DM_density     = 3.07199E-25 ;   # cgs - central density for 1E10 Msun NFW halo
-          DM_mass        = -1.0 ;# 1.0E10; # set < 0 to use density, > 0 uses this instead of density
+          DM_mass        = 1.0E10;   # mass interior to below radius (in Msun) -  (this particular value is virial mass)
           DM_mass_radius = 45.0;           # kpc virial radius (or radius within which above mass refers to)
           core_radius    = 3.0;            # kpc core radius
           bulge_mass     = 0.0;            # stellar bulge mass (Msun)

--- a/input/IsolatedGalaxy/method_isolatedgalaxy.in
+++ b/input/IsolatedGalaxy/method_isolatedgalaxy.in
@@ -102,8 +102,7 @@
 
       background_acceleration {
           flavor = "GalaxyModel";
-          DM_density     = 3.07199E-25 ;   # cgs - central density for 1E10 Msun NFW halo
-          DM_mass        = -1.0 ;# 1.0E10; # set < 0 to use density, > 0 uses this instead of density
+          DM_mass        = 1.0E10;   # mass interior to below radius (in Msun) -  (this particular value is virial mass)
           DM_mass_radius = 45.0;           # kpc virial radius (or radius within which above mass refers to)
           core_radius    = 3.0;            # kpc core radius
           bulge_mass     = 0.0;            # stellar bulge mass (Msun)

--- a/src/Enzo/enzo_EnzoConfig.cpp
+++ b/src/Enzo/enzo_EnzoConfig.cpp
@@ -247,7 +247,6 @@ EnzoConfig::EnzoConfig() throw ()
   method_background_acceleration_flavor(""),
   method_background_acceleration_mass(0.0),
   method_background_acceleration_DM_mass(0.0),
-  method_background_acceleration_DM_density(0.0),
   method_background_acceleration_bulge_mass(0.0),
   method_background_acceleration_core_radius(1.0E-10),
   method_background_acceleration_bulge_radius(1.0E-10),
@@ -574,7 +573,6 @@ void EnzoConfig::pup (PUP::er &p)
   p | method_background_acceleration_flavor;
   p | method_background_acceleration_mass;
   p | method_background_acceleration_DM_mass;
-  p | method_background_acceleration_DM_density;
   p | method_background_acceleration_bulge_mass;
   p | method_background_acceleration_core_radius;
   p | method_background_acceleration_bulge_radius;
@@ -1469,9 +1467,6 @@ void EnzoConfig::read_method_background_acceleration_(Parameters * p)
 
   method_background_acceleration_DM_mass = p->value_float
    ("Method:background_acceleration:DM_mass",-1.0);
-
-  method_background_acceleration_DM_density = p->value_float
-   ("Method:background_acceleration:DM_density", -1.0);
 
   method_background_acceleration_bulge_mass = p->value_float
     ("Method:background_acceleration:bulge_mass", 0.0);

--- a/src/Enzo/enzo_EnzoConfig.hpp
+++ b/src/Enzo/enzo_EnzoConfig.hpp
@@ -350,7 +350,6 @@ public: // interface
       method_background_acceleration_flavor(""),
       method_background_acceleration_mass(0.0),
       method_background_acceleration_DM_mass(0.0),
-      method_background_acceleration_DM_density(0.0),
       method_background_acceleration_bulge_mass(0.0),
       method_background_acceleration_core_radius(0.0),
       method_background_acceleration_bulge_radius(0.0),
@@ -758,7 +757,6 @@ public: // attributes
   std::string                method_background_acceleration_flavor;
   double                     method_background_acceleration_mass;
   double                     method_background_acceleration_DM_mass;
-  double                     method_background_acceleration_DM_density;
   double                     method_background_acceleration_bulge_mass;
   double                     method_background_acceleration_core_radius;
   double                     method_background_acceleration_bulge_radius;

--- a/src/Enzo/enzo_EnzoInitialIsolatedGalaxy.cpp
+++ b/src/Enzo/enzo_EnzoInitialIsolatedGalaxy.cpp
@@ -457,19 +457,20 @@ void EnzoInitialIsolatedGalaxy::InitializeExponentialGasDistribution(Block * blo
 
           double vcirc = 0.0;
           if (this->analytic_velocity_){
-//            double rhodm = enzo_config->method_background_acceleration_DM_density;
-            double rcore = enzo_config->method_background_acceleration_core_radius;
-            double rvir  = enzo_config->method_background_acceleration_DM_mass_radius;
-
-            double Mvir  = enzo_config->method_background_acceleration_DM_mass;
-
-            rcore = rcore * enzo_constants::kpc_cm;
-            rvir  = rvir  * enzo_constants::kpc_cm;
-            Mvir  = Mvir  * enzo_constants::mass_solar;
+            double rhodm = enzo_config->method_background_acceleration_DM_density; //g/cm3
+            double rcore = enzo_config->method_background_acceleration_core_radius * enzo_constants::kpc_cm;
+            double rvir  = enzo_config->method_background_acceleration_DM_mass_radius * enzo_constants::kpc_cm;
+            double Mvir  = enzo_config->method_background_acceleration_DM_mass * enzo_constants::mass_solar;
+            // If Mass is negative, the halo mass is specified by 
+            // the central density
+            if (Mvir < 0) {
+              double xtemp = rvir / rcore;
+              Mvir = 4.0 * cello::pi / 3.0 * (std::pow(rcore, 3) * rhodm) *
+                3.0 * (std::log(1.0 + xtemp) - xtemp/(1.0+xtemp));
+            }
 
             double conc = rvir  / rcore;
             double   rx = r_cyl / rvir;
-
 
             vcirc = (std::log(1.0 + conc*rx) - (conc*rx)/(1.0+conc*rx))/
                       (std::log(1.0 + conc) - (conc / (1.0 + conc))) / rx;

--- a/src/Enzo/enzo_EnzoInitialIsolatedGalaxy.cpp
+++ b/src/Enzo/enzo_EnzoInitialIsolatedGalaxy.cpp
@@ -457,24 +457,24 @@ void EnzoInitialIsolatedGalaxy::InitializeExponentialGasDistribution(Block * blo
 
           double vcirc = 0.0;
           if (this->analytic_velocity_){
-            double rhodm = enzo_config->method_background_acceleration_DM_density; //g/cm3
-            double rcore = enzo_config->method_background_acceleration_core_radius * enzo_constants::kpc_cm;
-            double rvir  = enzo_config->method_background_acceleration_DM_mass_radius * enzo_constants::kpc_cm;
-            double Mvir  = enzo_config->method_background_acceleration_DM_mass * enzo_constants::mass_solar;
+            double rhodm_cgs = enzo_config->method_background_acceleration_DM_density; //g/cm3
+            double rcore_cgs = enzo_config->method_background_acceleration_core_radius * enzo_constants::kpc_cm;
+            double rvir_cgs = enzo_config->method_background_acceleration_DM_mass_radius * enzo_constants::kpc_cm;
+            double Mvir_cgs = enzo_config->method_background_acceleration_DM_mass * enzo_constants::mass_solar;
             // If Mass is negative, the halo mass is specified by 
             // the central density
-            if (Mvir < 0) {
-              double xtemp = rvir / rcore;
-              Mvir = 4.0 * cello::pi / 3.0 * (std::pow(rcore, 3) * rhodm) *
+            if (Mvir_cgs < 0) {
+              double xtemp = rvir_cgs / rcore_cgs;
+              Mvir_cgs = 4.0 * cello::pi / 3.0 * (std::pow(rcore_cgs, 3) * rhodm_cgs) *
                 3.0 * (std::log(1.0 + xtemp) - xtemp/(1.0+xtemp));
             }
 
-            double conc = rvir  / rcore;
-            double   rx = r_cyl / rvir;
+            double conc = rvir_cgs  / rcore_cgs;
+            double   rx = r_cyl / rvir_cgs;
 
             vcirc = (std::log(1.0 + conc*rx) - (conc*rx)/(1.0+conc*rx))/
                       (std::log(1.0 + conc) - (conc / (1.0 + conc))) / rx;
-            vcirc = std::sqrt(vcirc * enzo_constants::grav_constant * Mvir / rvir);
+            vcirc = std::sqrt(vcirc * enzo_constants::grav_constant * Mvir_cgs / rvir_cgs);
 
           } else {
             vcirc = this->InterpolateVcircTable(r_cyl);

--- a/src/Enzo/enzo_EnzoMethodBackgroundAcceleration.cpp
+++ b/src/Enzo/enzo_EnzoMethodBackgroundAcceleration.cpp
@@ -213,8 +213,6 @@ void EnzoMethodBackgroundAcceleration::GalaxyModel(enzo_float * ax,
                          enzo_constants::mass_solar / enzo_units->mass();
   double DM_mass_radius = enzo_config->method_background_acceleration_DM_mass_radius *
                           enzo_constants::kpc_cm / enzo_units->length();
-  double DM_density  = enzo_config->method_background_acceleration_DM_density /
-                         enzo_units->density();
   double stellar_r   = enzo_config->method_background_acceleration_stellar_scale_height_r *
                          enzo_constants::kpc_cm / enzo_units->length();
   double stellar_z   = enzo_config->method_background_acceleration_stellar_scale_height_z *
@@ -234,20 +232,12 @@ void EnzoMethodBackgroundAcceleration::GalaxyModel(enzo_float * ax,
   double rcore = enzo_config->method_background_acceleration_core_radius *
                  enzo_constants::kpc_cm / enzo_units->length();
 
-  if (DM_mass > 0.0){
-    double xtemp = DM_mass_radius / rcore;
+  ASSERT1("Enzo::MethodBackgroundAcceleration", "DM halo mass (=%e code_units) must be positive and in units of solar masses", DM_mass, (DM_mass > 0));
 
-    // compute the density constant for an NFW halo (rho_o)
-    DM_density = (DM_mass / (4.0 * cello::pi * std::pow(rcore,3))) /
-                       (std::log(1.0+xtemp)-xtemp/(1.0+xtemp));
+  double xtemp = DM_mass_radius / rcore;
 
-  } else {
-    double xtemp = DM_mass_radius / rcore;
-
-    DM_mass = 4.0 * cello::pi / 3.0 * (std::pow(rcore,3) * DM_density) *
-                 3.0 * (std::log(1.0 + xtemp) - xtemp/(1.0+xtemp));
-  }
-
+  // compute the density constant for an NFW halo (rho_o)
+  double DM_density = (DM_mass / (4.0 * cello::pi * std::pow(rcore,3))) / (std::log(1.0+xtemp)-xtemp/(1.0+xtemp));
 
   double x = 0.0, y = 0.0, z = 0.0;
 
@@ -277,7 +267,6 @@ void EnzoMethodBackgroundAcceleration::GalaxyModel(enzo_float * ax,
 
          // need to multiple all of the below by the gravitational constants
          double xtemp     = radius/rcore;
-         double Rtemp     = DM_mass_radius / rcore;
 
          //double
          accel_sph = G_code * bulge_mass / pow(radius + bulgeradius,2) +    // bulge
@@ -315,8 +304,6 @@ void EnzoMethodBackgroundAcceleration::GalaxyModel(enzo_float * ax,
   Grouping * particle_groups = particle_descr->groups();
 
   int num_is_grav = particle_groups->size("is_gravitating");
-
-  double dt_shift = 0.5 * dt;
 
   // Loop through particles to apply this to
   for (int ipt = 0; ipt < num_is_grav; ipt++){
@@ -372,7 +359,6 @@ void EnzoMethodBackgroundAcceleration::GalaxyModel(enzo_float * ax,
 
           // need to multiple all of the below by the gravitational constants
           double xtemp     = radius/rcore;
-          double Rtemp     = DM_mass_radius / rcore;
 
           //double
           accel_sph = G_code * bulge_mass / pow(radius + bulgeradius,2) +    // bulge


### PR DESCRIPTION
In the original version of the initializer, the halo mass can be derived from the central DM density. This is triggered by giving a negative halo mass and a non-zero DM density. However, there was one calculation in the initializer that wasn't checking whether the halo mass was negative, resulting in a NaN after a sqrt. This PR fixes this issue.