### PR TITLE
Test documentation updated #177 and fixing #222

### DIFF
--- a/doc/source/tests/adapt-cmake.rst
+++ b/doc/source/tests/adapt-cmake.rst
@@ -1,0 +1,15 @@
+
+-----------
+Adapt Tests
+-----------
+
+Tests run 2D implosion problem on a slope mesh refinement with square initial values at different ``max_level``. This specifies the most highly defined block in the mesh hierarchy. 
+
+
+adapt-L5-P1
+===========
+
+tests adapt at ``max_level=5``
+
+
+

--- a/doc/source/tests/array-cmake.rst
+++ b/doc/source/tests/array-cmake.rst
@@ -1,0 +1,13 @@
+
+----------
+Array Test
+----------
+
+Under construction
+
+test_cello_array
+================
+
+Under construction
+
+

--- a/doc/source/tests/balance.rst
+++ b/doc/source/tests/balance.rst
@@ -10,3 +10,10 @@ Runs 2D implosion problem on slope adaptive mesh. Tests the load balancing on di
 
 mesh-balanced
 =============
+
+Under construction
+
+mesh-unbalanced
+===============
+
+Under construction

--- a/doc/source/tests/boundary-cmake.rst
+++ b/doc/source/tests/boundary-cmake.rst
@@ -1,0 +1,42 @@
+------------------------
+Boundary Condition Tests
+------------------------
+
+Runs an implosion problem on various boundary conditions in 2D and 3D. 
+
+
+boundary_outflow-2d
+===================
+
+Tests boundary ``type=outflow`` in a 2D enviroment
+
+boundary_outflow-3d
+===================
+
+Tests boundary ``type=outflow`` in a 3D enviroment
+
+
+boundary_periodic-2d
+====================
+
+Tests boundary ``type=periodic`` in a 2D enviroment
+
+
+
+boundary_periodic-3d
+====================
+
+Tests boundary ``type=periodic`` in a 3D enviroment
+
+
+
+boundary_reflecting-2d
+======================
+
+Tests boundary ``type=reflecting`` in a 2D enviroment
+
+
+boundary_reflecting-3d
+======================
+
+Tests boundary ``type=reflecting`` in a 3D enviroment

--- a/doc/source/tests/checkpoint.rst
+++ b/doc/source/tests/checkpoint.rst
@@ -5,14 +5,33 @@ Checkpoint Tests
 Tests for restart checkpoints. Runs 2D implosion using PPM method with slope mesh refinement. 
 
 
-checkpoint_ppm-1.in
-===================
+checkpoint_ppm-1
+================
 
 Tests checkpoint/restart for serial run methods
 
 
-checkpoint_ppm-8.in
-===================
+checkpoint_ppm-8
+================
 
 Tests checkpoint/restart for parallel run methods
+
+
+checkpoint_boundary
+===================
+
+Under construction
+
+
+checkpoint_grackle
+==================
+
+Under construction
+
+
+checkpoint_vlct
+===============
+
+Under construction
+
 

--- a/doc/source/tests/error-cmake.rst
+++ b/doc/source/tests/error-cmake.rst
@@ -1,0 +1,13 @@
+
+----------
+Error Test
+----------
+
+Under construction
+
+test_error
+==========
+
+Under construction
+
+

--- a/doc/source/tests/fluxcorrect-cmake.rst
+++ b/doc/source/tests/fluxcorrect-cmake.rst
@@ -1,0 +1,15 @@
+-----------------
+FluxCorrect tests
+-----------------
+
+Tests for FluxCorrect method. This currently runs a 3D simulation with
+a pure-hydro inclined entropy/contact wave and checks how well the
+various fields are conserved.
+
+inclined_contact_smr_ppm
+========================
+Integrates the entropy/contact wave using the PPM method. This effectively uses static mesh refinement.
+
+inclined_contact_smr_vl
+=======================
+Integrates the entropy/contact wave using the VL+CT method in hydro mode. This effectively uses static mesh refinement.

--- a/doc/source/tests/grackle-cmake.rst
+++ b/doc/source/tests/grackle-cmake.rst
@@ -1,0 +1,37 @@
+----------------
+Grackle Tests
+----------------
+
+Tests for the method that invokes Grackle. These tests set up a
+cooling test without hydrodynamics to run many one-zone models in
+Grackle, fully sampling the density, temperature, and metallicity
+parameter space over which the chemistry and cooling/heating tables
+are valid.
+
+method_grackle_general
+======================
+
+This test compares the summary statistics computed for several grackle
+fields after a certain period of time to previously archived values.
+
+The simulation timesteps are much larger that the cooling/heating.
+This makes it more likely that separate processing elements will
+execute grackle routines at the same time (thus increasing the chances
+of exposing hypothetical problems related to Grackle & SMP mode).
+
+This test is somewhat fragile given that upgrading Grackle versions could
+conceivably alter the field values. In the future it would be better to
+replace this with a test that:
+
+1. checks out and builds a previous commit of Enzo-E
+2. runs the simulation and saves the exact field values after running the simulations
+3. checks out and builds a newer commit of Enzo-E (while leaving the build of Grackle unchanged)
+4. runs the simulation and confirms that the Grackle related field values are identical to the field values from the earlier simulation.
+
+method_grackle_cooling_dt
+=========================
+
+This test runs Grackle for a fixed number of cycles, and compares the
+final simulation time to a reference value. Each simulation timestep
+is set fraction of the minimum magnitude of the cooling/heating
+timestep.

--- a/doc/source/tests/gravity-cmake.rst
+++ b/doc/source/tests/gravity-cmake.rst
@@ -1,0 +1,16 @@
+-------------
+Gravity Tests
+-------------
+
+Tests for gravity methods. Runs gravity method using cg solver. Outputs mesh, phi, rho, x acceleration, y acceleration image files.
+
+method_gravity_cg-1
+===================
+
+Tests ``EnzoMethodGravityCg`` at P=1 in 2D.
+
+
+method_gravity_cg-8
+===================
+
+Tests ``EnzoMethodGravityCg`` at P=8 in 2D.

--- a/doc/source/tests/heat-cmake.rst
+++ b/doc/source/tests/heat-cmake.rst
@@ -1,0 +1,16 @@
+----------
+Heat Tests
+----------
+
+Tests for heat methods
+
+
+method_heat-1
+=============
+
+2D Heat Diffusion problem with P=1
+
+method_heat-8
+=============
+
+2D Heat Diffusion problem with P=8

--- a/doc/source/tests/helloworld-cmake.rst
+++ b/doc/source/tests/helloworld-cmake.rst
@@ -1,0 +1,10 @@
+----------
+HelloWorld
+----------
+
+Tests of full code to demonstrate functionality. These are done as a demostration of enzo's capabilities.
+
+initial_png
+===========
+
+Evolves high-pressure region Hello World using Cello.png mask file

--- a/doc/source/tests/hydro.rst
+++ b/doc/source/tests/hydro.rst
@@ -22,6 +22,11 @@ test_implosion
 
 Runs a 2D implosion problem. Tests Initial:<field>:value. Test outputs density image file and mesh image file. 
 
+test_implosion-code
+===================
+
+Runs a 2D implosion problem. Tests Initial:code.
+
 test_kelvin_helmholtz
 =====================
 

--- a/doc/source/tests/index.rst
+++ b/doc/source/tests/index.rst
@@ -13,6 +13,7 @@ This testing section describes tests on enzo-e program
    checkpoint
    collapse
    cosmology
+   fluxcorrect
    gravity
    grackle
    heat

--- a/doc/source/tests/index.rst
+++ b/doc/source/tests/index.rst
@@ -14,18 +14,22 @@ This testing section describes tests on enzo-e program
    collapse
    cosmology
    fluxcorrect
-   gravity
    grackle
+   gravity
    heat
    helloworld
    hierarchy
    hydro
    initialmusic
+   isolatedgalaxy
    mergesinks
    methods
    output
+   parse
    particle
    performance
    ppm
    ppml
    sedov
+   vlct
+   others

--- a/doc/source/tests/initialmusic-cmake.rst
+++ b/doc/source/tests/initialmusic-cmake.rst
@@ -1,0 +1,53 @@
+-------------------
+Initial MUSIC Tests
+-------------------
+
+Tests for reading MUSIC HDF5 initial conditions at different mesh root_blocks
+
+Solves simple cosmology problem using initial conditions from MUSIC HDF5 initial condition geneerator
+
+initial_music-111
+=================
+
+Tests reading MUSIC HDF5 initial conditions at ``mesh`` `root_blocks = [1,1,1]`
+
+initial_music-112
+=================
+
+Tests reading MUSIC HDF5 initial conditions at ``mesh`` `root_blocks = [1,1,2]`
+
+initial_music-114
+=================
+
+Tests reading MUSIC HDF5 initial conditions at ``mesh`` `root_blocks = [1,1,4]`
+
+initial_music-121
+=================
+
+Tests reading MUSIC HDF5 initial conditions at ``mesh`` `root_blocks = [1,2,1]`
+
+initial_music-141
+=================
+
+Tests reading MUSIC HDF5 initial conditions at ``mesh`` `root_blocks = [1,4,1]`
+
+initial_music-211
+=================
+
+Tests reading MUSIC HDF5 initial conditions at ``mesh`` `root_blocks = [2,1,1]`
+
+initial_music-222
+=================
+
+Tests reading MUSIC HDF5 initial conditions at ``mesh`` `root_blocks = [2,2,2]`
+
+initial_music-411
+=================
+
+Tests reading MUSIC HDF5 initial conditions at ``mesh`` `root_blocks = [4,1,1]`
+
+initial_music-444
+=================
+
+Tests reading MUSIC HDF5 initial conditions at ``mesh`` `root_blocks = [4,4,4]`
+

--- a/doc/source/tests/isolatedgalaxy.rst
+++ b/doc/source/tests/isolatedgalaxy.rst
@@ -1,0 +1,26 @@
+
+---------------------
+Isolated Galaxy Tests
+---------------------
+
+Under construction
+
+
+method_isolatedgalaxy
+=====================
+
+Under construction
+
+
+method_isolatedgalaxy-particles
+===============================
+
+Under construction
+
+
+WLM_small
+=========
+
+Under construction
+
+

--- a/doc/source/tests/memory-cmake.rst
+++ b/doc/source/tests/memory-cmake.rst
@@ -1,0 +1,13 @@
+
+-----------
+Memory Test
+-----------
+
+Under construction
+
+test_memory
+===========
+
+Under construction
+
+

--- a/doc/source/tests/mergesinks-cmake.rst
+++ b/doc/source/tests/mergesinks-cmake.rst
@@ -1,0 +1,40 @@
+------------------
+Merge Sinks Tests
+------------------
+
+Four tests of the enzo-e "merge sinks" method.
+
+- the stationary serial test
+
+- the stationary parallel test
+    
+- the drifting serial test
+
+- the stationary parallel test
+    
+All the files necessary for running the tests can be found in input/merge_sinks,
+and the tests can be run by executing test/run_merge_sinks_tests.sh from the
+top-level directory of the repository.
+
+
+Each test involves setting up initial conditions with 1000 sink particles randomly
+distributed in a sphere, with velocities directed towards the centre of the sphere.
+In the "drifting" tests, an additional uniform velocity is added to all the
+particles, and in the "stationary" tests, there is no additional velocity.
+
+For the serial tests, Enzo-E runs in serial mode.
+
+For the parallel tests, Enzo-E is run in parallel on four PEs.
+
+The methods used are "pm update" and "merge sinks", so that the particles all
+move with constant velocity until they are merged together.
+
+The python script input/merge_sinks/mass_momentum_conservation.py then tests if
+mass and momentum are conserved across all the output snapshots, to within some
+tolerance, which depends on the precision specified by the $CELLO_PREC environment
+variable (1.0e-4 for single precision, 1.0e-6 for double precision).
+If all quantities are indeed conserved, the test passes, if not, the test fails.
+See input/merge_sinks/README for further details on running the tests.
+
+These tests can be executed by running "ctest -R merge_sinks_*" in the build directory.
+See input/merge_sinks/README for further information on these tests.

--- a/doc/source/tests/monitor-cmake.rst
+++ b/doc/source/tests/monitor-cmake.rst
@@ -1,0 +1,13 @@
+
+------------
+Monitor Test
+------------
+
+Under construction
+
+test_monitor
+============
+
+Under construction
+
+

--- a/doc/source/tests/others.rst
+++ b/doc/source/tests/others.rst
@@ -1,0 +1,224 @@
+
+-----------
+Other Tests
+-----------
+
+Under construction
+
+
+bb_unigrid_SF_FB
+================
+
+Under construction
+
+
+method_feedback
+===============
+
+Under construction
+
+
+test_collapse-bcg2
+==================
+
+Under construction
+
+
+test_collapse-bcg3
+==================
+
+Under construction
+
+
+test_collapse-dd2
+=================
+
+Under construction
+
+
+test_collapse-dd3
+=================
+
+Under construction
+
+
+test_collapse-gas-bcg2
+======================
+
+Under construction
+
+
+test_collapse-gas-dd2
+=====================
+
+Under construction
+
+
+test_collapse-gas-hg2
+=====================
+
+Under construction
+
+
+test_collapse-hg2
+=================
+
+Under construction
+
+
+test_collapse-hg3
+=================
+
+Under construction
+
+
+test_cosmo-bcg-fc0
+==================
+
+Under construction
+
+
+test_cosmo-bcg-fc1
+==================
+
+Under construction
+
+
+test_cosmo-bcg
+==============
+
+Under construction
+
+
+test_cosmo-cg-fc0
+=================
+
+Under construction
+
+
+test_cosmo-cg-fc1
+=================
+
+Under construction
+
+
+test_cosmo-cg
+=============
+
+Under construction
+
+
+test_cosmo-dd-fc0
+=================
+
+Under construction
+
+
+test_cosmo-dd-fc1
+=================
+
+Under construction
+
+
+test_cosmo-dd
+=============
+
+Under construction
+
+
+test_cosmo-hg-fc0
+=================
+
+Under construction
+
+
+test_cosmo-hg-fc1
+=================
+
+Under construction
+
+
+test_cosmo-hg
+=============
+
+Under construction
+
+
+test_cosmo-mg-fc0
+=================
+
+Under construction
+
+
+test_cosmo-mg-fc1
+=================
+
+Under construction
+
+
+test_cosmo-mg
+=============
+
+Under construction
+
+
+test-flux2-xm
+=============
+
+Under construction
+
+
+test-flux2-xp
+=============
+
+Under construction
+
+
+test-flux2-ym
+=============
+
+Under construction
+
+
+test-flux2-yp
+=============
+
+Under construction
+
+
+test-flux3-xm
+=============
+
+Under construction
+
+
+test-flux3-xp
+=============
+
+Under construction
+
+
+test-flux3-ym
+=============
+
+Under construction
+
+
+test-flux3-yp
+=============
+
+Under construction
+
+
+test-flux3-zm
+=============
+
+Under construction
+
+
+test-flux3-zp
+=============
+
+Under construction
+
+

--- a/doc/source/tests/output-cmake.rst
+++ b/doc/source/tests/output-cmake.rst
@@ -10,7 +10,6 @@ output-header
 
 Under construction
 
-
 output-stride-1
 ===============
 
@@ -27,7 +26,3 @@ output-stride-4
 Similar to above test but on four physical processors where ``stride_write = 4``
 
 
-output-data
-===========
-
-Output test of 2D implosion problem

--- a/doc/source/tests/parse.rst
+++ b/doc/source/tests/parse.rst
@@ -1,0 +1,44 @@
+
+-----------
+Parse Tests
+-----------
+
+Under construction
+
+
+parse_groups
+============
+
+Under construction
+
+
+parse_include
+=============
+
+Under construction
+
+
+parse_integer
+=============
+
+Under construction
+
+
+parse_list
+==========
+
+Under construction
+
+
+parse_logical
+=============
+
+Under construction
+
+
+parse_scalar
+============
+
+Under construction
+
+

--- a/doc/source/tests/particle-cmake.rst
+++ b/doc/source/tests/particle-cmake.rst
@@ -1,0 +1,39 @@
+--------------
+Particle Tests
+--------------
+
+Tests on particle motion. Uses tracer particles.
+
+
+test_particle-x
+===============
+
+Tests particle motion in x direction only
+
+test_particle-y
+===============
+
+Tests particle motion in y direction only
+
+test_particle-xy
+================
+
+Tests particle motion in x and y directions together
+
+test_particle-circle
+====================
+
+Tests circular particle motion
+
+test_particle-amr-static
+========================
+
+Tests static particle in adaptive mesh refinement
+
+
+test_particle-amr-dynamic
+=========================
+
+Tests dynamic particle in adaptive mesh refinement
+
+

--- a/doc/source/tests/ppm-cmake.rst
+++ b/doc/source/tests/ppm-cmake.rst
@@ -1,0 +1,15 @@
+---------
+PPM tests
+---------
+
+Tests for PPM method. Runs a 2D implosion problem using ppm method and outputs density image file and a density data file.
+
+method_ppm-1
+============
+
+Tests PPM method at P=1
+
+method_ppm-8
+============
+
+Tests PPM method at P=8

--- a/doc/source/tests/testing_environment.rst
+++ b/doc/source/tests/testing_environment.rst
@@ -36,11 +36,35 @@ If an integration test fails in start-up this implies that there is something wr
 
 In order to see what happened during the test, you can look at the output directory of the test, which is located in a subdirectory (named after the test) in the ``test`` directory of the build directory, for example ``method_cosmology-1.in`` the test results are stored in ``test/MethodCosmology/Cosmology-8``. This directory also contains all outputs (image and data files).
 
-
 What Tests are Currently Included
 =================================
 
 Currently the Enzo-e testing infrastructure tests:
+
+.. toctree::
+   array-cmake
+   error-cmake
+   memory-cmake
+   monitor-cmake
+   adapt-cmake
+   boundary-cmake
+   fluxcorrect-cmake
+   grackle-cmake
+   gravity-cmake
+   heat-cmake
+   helloworld-cmake
+   initialmusic-cmake
+   mergesinks-cmake
+   output-cmake
+   particle-cmake
+   ppm-cmake
+   vlct-cmake
+
+
+What Tests are Available
+========================
+
+Currently the Enzo-e has the following tests in the input folder:
 
 .. toctree::
    adapt
@@ -50,20 +74,25 @@ Currently the Enzo-e testing infrastructure tests:
    collapse
    cosmology
    fluxcorrect
+   grackle
    gravity
    heat
    helloworld
    hierarchy
    hydro
    initialmusic
-   methods
+   isolatedgalaxy
    mergesinks
+   methods
    output
+   parse
    particle
    performance
    ppm
    ppml
    sedov
+   vlct
+   others
   
 How to Add Your Own Test
 ========================

--- a/doc/source/tests/vlct-cmake.rst
+++ b/doc/source/tests/vlct-cmake.rst
@@ -1,0 +1,45 @@
+
+----------
+VLCT Tests
+----------
+
+Under construction
+
+
+dual_energy_cloud
+=================
+
+Under construction
+
+
+dual_energy_shock_tube
+======================
+
+Under construction
+
+
+HD_linear_wave
+==============
+
+Under construction
+
+
+MHD_linear_wave
+===============
+
+Under construction
+
+
+MHD_shock_tube
+==============
+
+Under construction
+
+
+passive_advect_sound_wave
+=========================
+
+Under construction
+
+
+

--- a/doc/source/tests/vlct.rst
+++ b/doc/source/tests/vlct.rst
@@ -1,0 +1,51 @@
+
+----------
+VLCT Tests
+----------
+
+Under construction
+
+
+dual_energy_cloud
+=================
+
+Under construction
+
+
+dual_energy_shock_tube
+======================
+
+Under construction
+
+
+HD_linear_wave
+==============
+
+Under construction
+
+
+MHD_linear_wave
+===============
+
+Under construction
+
+
+MHD_shock_tube
+==============
+
+Under construction
+
+
+orszang-tang
+============
+
+Under construction
+
+
+passive_advect_sound_wave
+=========================
+
+Under construction
+
+
+


### PR DESCRIPTION
In the testing environment page, we updated the list of tests that are currently included in the ctest and created a new subsection for all the available tests in the input folder (#177) . The pages are created but explanations for the tests are left as "Under construction".

We also fixed the issue in #222.  

**Note: We didn't check how does it look in the browser.**

Vanesa and @buketbenek 

