### PR TITLE
[BUGFIX] Removed line of code which caused compilation to fail

### DIFF
--- a/src/Enzo/enzo_EnzoSolverJacobi.cpp
+++ b/src/Enzo/enzo_EnzoSolverJacobi.cpp
@@ -104,7 +104,6 @@ EnzoSolverJacobi::EnzoSolverJacobi
   cello::simulation()->refresh_set_name(ir_smooth_,name+":smooth");
   
   refresh_smooth->add_field (ix_);
-  refresh_smooth->set_solver_id(index());
   refresh_smooth->set_min_face_rank(2);
 #ifdef DEBUG_NEW_REFRESH
   CkPrintf ("DEBUG_NEW_REFRESH %s:%d id_solver=%d\n",__FILE__,__LINE__,index());


### PR DESCRIPTION
Simple bugfix, which came down to removing a call to a function that no longer exists, which somehow came about when PR #126 was merged into `main`.

I presume it is safe to remove, since none of the other `Solver` classes call the function in their constructor methods, but perhaps @jobordner should confirm.