### PR TITLE
Write the version number as a file-level attribute of output hdf5 files

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -109,6 +109,8 @@ else()
 endif()
 add_compile_definitions(SMALL_INTS)
 
+add_compile_definitions(CELLO_VERSION="${CMAKE_PROJECT_VERSION}")
+
 # Whether to bypass passing MsgRefine directly to Block constructor,
 # or request it from a separate entry method to bypass a Charm++
 # memory leak. This should only be set to 0 after (and if) the bug is
@@ -342,4 +344,4 @@ endif()
 # extract compile defs from from Cello to populate config
 get_directory_property( CELLO_CPPDEFINES DIRECTORY src/Cello COMPILE_DEFINITIONS )
 # now generate the the config
-configure_file(auto_config.def.in auto_config.def @ONLY)
+configure_file(auto_config.def.in auto_config.def ESCAPE_QUOTES @ONLY)

--- a/src/Cello/_io.hpp
+++ b/src/Cello/_io.hpp
@@ -26,6 +26,35 @@ enum meta_type {
 };
 
 //----------------------------------------------------------------------
+// Global functions
+//----------------------------------------------------------------------
+
+/// Namespace for global constants and functions
+namespace cello {
+  namespace io {
+
+    /// Writes the version string to an output file
+    inline void write_version_metadata(File* file)
+    {
+      ASSERT("cello::write_version_metadata()", "File object must not be null",
+             file != nullptr);
+
+      // define a variable to ensure CELLO_VERSION is actually defined and that
+      // it is replaced with a string
+      const char* version_str = CELLO_VERSION;
+
+      // length intentionally excludes the terminating null character
+      // (note: this is the default behvaior of strlen).
+      int length = static_cast<int>(std::strlen(version_str));
+
+      ASSERT("cello::write_version_metadata()", // sanity check!
+             "version string must have at least 1 character", length > 0);
+      file->file_write_meta(version_str, "version", type_char, length);
+    }
+  }
+}
+
+//----------------------------------------------------------------------
 // Component class includes
 //----------------------------------------------------------------------
 

--- a/src/Cello/io_Output.hpp
+++ b/src/Cello/io_Output.hpp
@@ -254,6 +254,9 @@ protected:
     return dir;
   }
 
+  /// write version metadata to disk
+  void write_version_metadata() { cello::io::write_version_metadata(file_); }
+
 private:
 
   /// "Loop" over writing the Hierarchy in the Simulation

--- a/src/Cello/io_OutputData.cpp
+++ b/src/Cello/io_OutputData.cpp
@@ -109,7 +109,11 @@ void OutputData::write_hierarchy ( const Hierarchy  * hierarchy ) throw()
 {
 #ifdef TRACE_OUTPUT
     CkPrintf ("%d TRACE_OUTPUT OutputData::write_hierarchy()\n",CkMyPe());
-#endif    
+#endif
+
+  // although it's a little hacky, this seems like the best place to stick this
+  Output::write_version_metadata();
+
   IoHierarchy io_hierarchy(hierarchy);
 
   write_meta (&io_hierarchy);

--- a/src/Cello/monitor_Monitor.cpp
+++ b/src/Cello/monitor_Monitor.cpp
@@ -96,6 +96,7 @@ void Monitor::header () const
   print ("Define","BUILD DIR           %s",CELLO_DIR);
   // print ("Define","BUILD DATE (UTC)    %s",CELLO_DATE);
   // print ("Define","BUILD TIME (UTC)    %s",CELLO_TIME);
+  print ("Define","CELLO_VERSION       %s", CELLO_VERSION);
 #ifdef CONFIG_HAVE_VERSION_CONTROL
   print ("Define","CHANGESET           %s",CELLO_CHANGESET);
 #endif

--- a/src/Cello/problem_MethodOutput.cpp
+++ b/src/Cello/problem_MethodOutput.cpp
@@ -185,6 +185,9 @@ void MethodOutput::compute_continue(Block * block)
   // Get its block_trace object
   BlockTrace * block_trace = msg_output->block_trace();
 
+  // write the version number to file
+  cello::io::write_version_metadata(file);
+
   // write hierarchy meta-data to file
   file_write_hierarchy_(file);
 


### PR DESCRIPTION
We talked about doing this last week. It should help with handling new-features in the yt-frontend as we go forward. The version number comes from the `CMakeLists.txt` file. The way I have implemented this is not necessarily the cleanest way to do it, but I tried to make it easy to also add to the new checkpoint outputs when that gets merged in. We may eventually want to differentiate between Cello and Enzo-E versions, but this seemed like a good start.

I have confirmed that this works properly when we use the old output approach (specifying outputs in the output section of the parameter file) and with the new output approach (specifying outputs in the Method section of the parameter file). I have not added a test, but I can probably do so if you think that would be helpful.

You can easily confirms this works yourself by running the following from the root of your repository:
```sh
/path/to/enzo-e input/vlct/passive_advect_sound_wave/method_vlct_x_passive_sound.in
```
and then executing the following from the python interpreter:
```python
>>> import h5py
>>> f = h5py.File('./method_vlct-1-x_passive_soundN16-1.0/data-0000.h5', 'r')
>>> f.attrs["version"].tobytes()
b'0.9.0'
```
This matches the value currently specified by `project(Enzo-E VERSION 0.9.0 ...)` in the `CMakeLists.txt` file
