### PR TITLE
Removed all mentions of `"gamma"` field from input files.

### DIFF
--- a/input/Checkpoint/checkpoint_grackle.in
+++ b/input/Checkpoint/checkpoint_grackle.in
@@ -57,8 +57,7 @@
               "metal_density",
               "cooling_time",  
               "temperature",
-              "pressure",
-              "gamma"
+              "pressure"
      ];
 
      padding = 0;
@@ -89,11 +88,7 @@
               "DII_density",
               "HDI_density",
               "e_density",
-              "metal_density",
-              "cooling_time",
-              "temperature",
-              "pressure",
-              "gamma" ];
+              "metal_density"];
     }
 
 # derived fields grouping enables Enzo-E to ensure
@@ -202,9 +197,7 @@
               "metal_density",
               "cooling_time",
               "temperature",
-              "pressure",
-              "gamma"
-               ];
+              "pressure"];
 
          dir   = ["GRACKLE_TEST_%03d","cycle"];
          name = [ "method_grackle-1-%03d-%03d.h5","cycle", "proc" ];

--- a/input/test_cosmo-dd-multispecies.in
+++ b/input/test_cosmo-dd-multispecies.in
@@ -10,8 +10,7 @@ Field {
 	   "e_density",
            "metal_density",
 	   "cooling_time",
-	   "temperature",
-	   "gamma"];
+	   "temperature"];
 }
 
 Group {
@@ -24,11 +23,7 @@ Group {
               "HeII_density",
               "HeIII_density",
               "e_density",
-              "metal_density",
-              "cooling_time",
-              "temperature",
-              "pressure",
-              "gamma" ];
+              "metal_density"];
     }
 
     derived {
@@ -51,8 +46,7 @@ Method {
 	                 "e_density",
                          "metal_density",
 	                 "cooling_time",
-	                 "temperature",
-	                 "gamma"]; 
+	                 "temperature"]; 
      } 
      grackle {
         courant = 0.50; # meaningless unless use_cooling_timestep = true;
@@ -89,8 +83,7 @@ Output {
 	                 "e_density",
                          "metal_density",
 	                 "cooling_time",
-	                 "temperature",
-	                 "gamma"];
+	                 "temperature"];
         }
      de   { dir = [ "Dir_COSMO_MULTI_%04d", "cycle" ]; }
      depa { dir = [ "Dir_COSMO_MULTI_%04d", "cycle" ]; }


### PR DESCRIPTION
The "gamma" field first appeared in the input files during an earlier version of Enzo-E. However back in PR #1, it was removed (Grackle no longer uses it). If we wanted, it would be straightforward to output it as a derived quantity, but for the short-term, it's better not to include it (to avoid confusing new users).

While I was doing this, I fixed a couple of cases where the "temperature", "pressure", "cooling_time" fields were all listed as part of the "color" field. This also crept in as part of an older version of a Grackle input file and could definitely cause problems (since these fields are not passively advected scalars).