### PR TITLE
Bugfix: Cosmology units with Grackle

### DIFF
--- a/src/Enzo/enzo_EnzoInitialCosmology.cpp
+++ b/src/Enzo/enzo_EnzoInitialCosmology.cpp
@@ -19,6 +19,18 @@ EnzoInitialCosmology::EnzoInitialCosmology
     gamma_(gamma),
     temperature_(temperature)
 {
+  EnzoPhysicsCosmology * cosmology = enzo::cosmology();
+  EnzoUnits * units = enzo::units();
+
+  // set units to cosmology
+  units->set_cosmology(cosmology);
+
+  // set initial redshift
+  double r0 = cosmology->initial_redshift();
+  cosmology->set_current_redshift(r0);
+
+  // set initial time based on redshift
+  enzo::simulation()->set_time(cosmology->time_from_redshift(r0));
 }
 
 //----------------------------------------------------------------------
@@ -35,12 +47,8 @@ void EnzoInitialCosmology::enforce_block
     temperature_ = 550.0 *
       pow((1.0 + cosmology->initial_redshift())/(1.0 + 200.00), 2.0);
   }
-
-  // Set initial time based on initial redshift
-  double r0 = cosmology->initial_redshift();
-  double t0 = cosmology->time_from_redshift(r0);
-  block->set_time(t0);
-  enzo::simulation()->set_time(t0);
+  
+  block->set_time(enzo::simulation()->time());
   
   const double default_mu = 0.6;
 

--- a/src/Enzo/enzo_EnzoMethodGrackle.cpp
+++ b/src/Enzo/enzo_EnzoMethodGrackle.cpp
@@ -238,16 +238,7 @@ void EnzoMethodGrackle::setup_grackle_units (double current_time,
     enzo_float cosmo_dt = 0.0;
 
     EnzoPhysicsCosmology * cosmology = enzo::cosmology();
-
-    // Have to explicitly initialize current_time and current_redshift here because 
-    // this function is called in the constructor, and cosmology units are not initialized 
-    // until after Simulation::initialize() completes (see EnzoSimulation::r_startup_begun()). 
-
-    if (current_time == 0) {
-       current_time = cosmology->time_from_redshift(enzo::config()->physics_cosmology_initial_redshift);
-       cosmology->set_current_redshift(cosmology->redshift_from_time(current_time));
-    }
-
+ 
     grackle_units->density_units  = cosmology->density_units(); 
     grackle_units->length_units = cosmology->length_units();
     grackle_units->time_units  = cosmology->time_units();

--- a/src/Enzo/enzo_EnzoProblem.cpp
+++ b/src/Enzo/enzo_EnzoProblem.cpp
@@ -609,7 +609,7 @@ Method * EnzoProblem::create_method_
 
     method = new EnzoMethodGrackle
       (enzo_config->physics_cosmology_initial_redshift,
-       enzo_config->initial_time);
+       enzo::simulation()->time());
 
 #endif /* CONFIG_USE_GRACKLE */
 

--- a/src/Enzo/enzo_EnzoSimulation.cpp
+++ b/src/Enzo/enzo_EnzoSimulation.cpp
@@ -114,19 +114,6 @@ void EnzoSimulation::r_startup_begun (CkReductionMsg *msg)
   initialize_config_();
 
   initialize();
-
-  // Initialize Units::cosmology if needed
-
-  EnzoPhysicsCosmology * cosmology = (EnzoPhysicsCosmology *)
-    problem()->physics("cosmology");
-  
-  if (cosmology) {
-    EnzoUnits * units = (EnzoUnits *) problem()->units();
-    units->set_cosmology(cosmology);
-
-    // Set current time to be initial time
-    cosmology->set_current_redshift(cosmology->initial_redshift());
-  }
   
 #ifdef TRACE_PARAMETERS
   CkPrintf ("%d END   r_startup_begun()\n",CkMyPe());


### PR DESCRIPTION
This is a small PR that fixes a bug that I tried to address in PR #143, but the bug came back after PR #234 for some reason. I think I've found a more permanent fix. 

The issue is that for cosmology simulations, redshift, simulation time, and units aren't set until after all of the methods, initializers, etc. are initialized (see `EnzoSimulation::r_startup_begun`). `EnzoMethodGrackle` currently calls `initialize_grackle_chemistry_data()` in the constructor. `initialize_grackle_chemistry_data()` references `setup_grackle_units()`, which stores all of our code units into an object called `grackle_units` that gets passed into all of the Grackle-related functions throughout the course of the simulation. Since cosmology units haven't been properly initialized by the time `initialize_grackle_chemistry_data()` is first called, then the numbers stored in `grackle_units` will be garbage. This essentially prevents us from running cosmology simulations with multispecies chemistry.

To fix this, I moved the initialization of cosmology units, redshift, and time into the constructor of `EnzoInitialCosmology`. `Problem::initialize_initial()`is called before `Problem::initialize_method()`, so with this these quantities are guaranteed to be initialized before any of the method constructors are executed. I also made the change of passing `enzo::simulation->time()` into `EnzoMethodGrackle` instead of `enzo_config->initial_time` so that `EnzoMethodGrackle` is aware of the updated simulation time. `Simulation::time_` is initialized to `enzo_config->initial_time` beforehand in `Problem::initialize_simulation()`, so this change shouldn't screw anything up for non-cosmology simulations.