### PR TITLE
Use gold standard for answer testing.

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -301,7 +301,7 @@ jobs:
 
       - compile-enzoe:
           usedouble: << parameters.usedouble >>
-          tag: tip
+          tag: gold-standard-001
           skipfile: notafile
           usegrackle: << parameters.usegrackle >>
 


### PR DESCRIPTION
Use the latest gold standard tag for answer testing on circleci.