### PR TITLE
STARSS small changes

### DIFF
--- a/doc/source/param/method_feedback.incl
+++ b/doc/source/param/method_feedback.incl
@@ -2,10 +2,10 @@
 
 ----
 
-Parameter:  :p:`Method` : :p:`feedback` : :p:`single_sn`
+Parameter:  :p:`Method` : :p:`feedback` : :p:`supernovae`
 :Summary: :s:`Whether to turn on supernova feedback in EnzoMethodFeedbackSTARSS`
 :Type:   :t:`logical`
-:Default: :d:`false`
+:Default: :d:`true`
 :Scope:     :z:`Enzo`
 
 :e:`Whether to turn on supernova feedback in EnzoMethodFeedbackSTARSS`
@@ -15,7 +15,7 @@ Parameter:  :p:`Method` : :p:`feedback` : :p:`single_sn`
 Parameter:  :p:`Method` : :p:`feedback` : :p:`unrestricted_sn`
 :Summary: :s:`Whether to turn on supernova feedback in EnzoMethodFeedbackSTARSS`
 :Type:   :t:`logical`
-:Default: :d:`false`
+:Default: :d:`true`
 :Scope:     :z:`Enzo`
 
 :e:`Allow for > 1 supernova event per star particle in a timestep.`
@@ -25,7 +25,7 @@ Parameter:  :p:`Method` : :p:`feedback` : :p:`unrestricted_sn`
 Parameter:  :p:`Method` : :p:`feedback` : :p:`stellar_winds`
 :Summary: :s:`Whether to turn on stellar winds in EnzoMethodFeedbackSTARSS`
 :Type:   :t:`logical`
-:Default: :d:`false`
+:Default: :d:`true`
 :Scope:     :z:`Enzo`
 
 :e:`Whether to turn on stellar wind feedback in EnzoMethodFeedbackSTARSS`
@@ -35,7 +35,7 @@ Parameter:  :p:`Method` : :p:`feedback` : :p:`stellar_winds`
 Parameter:  :p:`Method` : :p:`feedback` : :p:`analytic_SNR_shell_mass`
 :Summary: :s:`Calculates supernova remnant shell mass via analytic formulae`
 :Type:   :t:`logical`
-:Default: :d:`false`
+:Default: :d:`true`
 :Scope:     :z:`Enzo`
 
 :e:`Calculates supernova remnant shell mass via analytic formulae`
@@ -45,7 +45,7 @@ Parameter:  :p:`Method` : :p:`feedback` : :p:`analytic_SNR_shell_mass`
 Parameter:  :p:`Method` : :p:`feedback` : :p:`fade_SNR`
 :Summary: :s:`Allow coupling to fading phase of SNe in EnzoMethodFeedbackSTARSS`
 :Type:   :t:`logical`
-:Default: :d:`false`
+:Default: :d:`true`
 :Scope:     :z:`Enzo`
 
 :e:`Allow coupling to fading phase of SNe in EnzoMethodFeedbackSTARSS if cell width is greater than fading radius.`
@@ -58,6 +58,6 @@ Parameter:  :p:`Method` : :p:`feedback` : :p:`NEvents`
 :Default: :d:`-1`
 :Scope:     :z:`Enzo`
 
-:e:`If -1, will probabilistically model supernova. If "NEvents" > 1, will set off N-supernovae per particle, (1 per timestep). Mostly for testing purposes`
+:e:`If -1, will probabilistically model supernova. If "NEvents" > 0, will set off N-supernovae per particle, (1 per timestep for each particle). If NEvents = 0, no supernovae will go off. Mostly for testing purposes.`
 
 ----

--- a/doc/source/param/method_feedback.incl
+++ b/doc/source/param/method_feedback.incl
@@ -60,4 +60,3 @@ Parameter:  :p:`Method` : :p:`feedback` : :p:`NEvents`
 
 :e:`If -1, will probabilistically model supernova. If "NEvents" > 0, will set off N-supernovae per particle, (1 per timestep for each particle). If NEvents = 0, no supernovae will go off. Mostly for testing purposes.`
 
-----

--- a/doc/source/param/method_star_maker.incl
+++ b/doc/source/param/method_star_maker.incl
@@ -28,7 +28,7 @@
 :Default: :d:`false`
 :Scope:     :z:`Enzo`
 
-:e:`Set number density threshold for star formation. Requires "use_density_threshold"=true.`
+:e:`Set number density threshold for star formation in units of cm^-3. Requires "use_density_threshold"=true.`
 
 ----
 
@@ -38,7 +38,7 @@ Parameter:  :p:`Method` : :p:`star_maker` : :p:`use_overdensity_threshold`
 :Default: :d:`false`
 :Scope:     :z:`Enzo`
 
-:e:`Flag to enable overdensity threshold for star formation.`
+:e:`Flag to enable overdensity threshold for star formation. Currently only valid for cosmology simulations.`
 
 ----
 
@@ -98,7 +98,7 @@ Parameter:  :p:`Method` : :p:`star_maker` : :p:`use_self_gravitating`
 :Default: :d:`false`
 :Scope:     :z:`Enzo`
 
-:e:`Checks that alpha < 1, where alpha is the virial parameter calculated using the FIRE2 prescription.`
+:e:`Checks that alpha < 1, where alpha is the virial parameter calculated using the FIRE-2 prescription. See Appendix C of `Hopkins et al. (2018) <https://academic.oup.com/mnras/article/480/1/800/5046474>`_.`
 
 ----
 
@@ -108,7 +108,7 @@ Parameter:  :p:`Method` : :p:`star_maker` : :p:`use_altAlpha`
 :Default: :d:`false`
 :Scope:     :z:`Enzo`
 
-:e:`Checks that alpha < 1, where alpha is the virial parameter calculated as "potential/total_energy". Currently only accessed by EnzoMethodStarMakerSTARSS. Requires DEBUG_COPY_POTENTIAL flag to be set in EnzoMethodGravity.cpp`
+:e:`Checks that alpha < 1, where alpha is the virial parameter calculated as "potential/total_energy". Currently only accessed by EnzoMethodStarMakerSTARSS.`
 
 ----
 
@@ -118,7 +118,7 @@ Parameter:  :p:`Method` : :p:`star_maker` : :p:`use_h2_self_shielding`
 :Default: :d:`false`
 :Scope:     :z:`Enzo`
 
-:e:`Checks that f_shield < 0, f_shield is calculated using fits from Krumholz & Gnedin (2011).'
+:e:`Checks that f_shield < 0, where f_shield is the H2 self-shielded fraction calculated using fits from Krumholz & Gnedin (2011).'
 
 ----
 
@@ -128,7 +128,7 @@ Parameter:  :p:`Method` : :p:`star_maker` : :p:`use_jeans_mass`
 :Default: :d:`false`
 :Scope:     :z:`Enzo`
 
-:e:`Checks that cell_mass > jeans_mass in a cell'
+:e:`Checks that cell_mass > max(jeans_mass, 1000 Msun) in a cell. '
 
 ----
 
@@ -145,7 +145,7 @@ Parameter:  :p:`Method` : :p:`star_maker` : :p:`critical_metallicity`
 Parameter:  :p:`Method` : :p:`star_maker` : :p:`maximum_mass_fraction`
 :Summary: :s:`Max fraction of gas in a cell that can be converted into a star particle per formation event.`
 :Type:   :t:`float`
-:Default: :d:`0.5`
+:Default: :d:`0.05`
 :Scope:     :z:`Enzo`
 
 :e:`Max fraction of gas in a cell that can be converted into a star particle per formation event.`
@@ -175,7 +175,7 @@ Parameter:  :p:`Method` : :p:`star_maker` : :p:`minimum_star_mass`
 Parameter:  :p:`Method` : :p:`star_maker` : :p:`maximum_star_mass`
 :Summary: :s:`Maximum star particle mass`
 :Type:   :t:`float`
-:Default: :d:`1e4`
+:Default: :d:`-1.0`
 :Scope:     :z:`Enzo`
 
 :e:`Set maximum star particle mass. For no limit, set "maximum_star_mass" < 0.`
@@ -185,7 +185,7 @@ Parameter:  :p:`Method` : :p:`star_maker` : :p:`maximum_star_mass`
 Parameter:  :p:`Method` : :p:`star_maker` : :p:`turn_off_probability`
 :Summary: :s:`Turn off probablistic elements of EnzoMethodStarMakerSTARSS.`
 :Type:   :t:`logical`
-:Default: :d:`fapse`
+:Default: :d:`false`
 :Scope:     :z:`Enzo`
 
 :e:`Turn off probablistic elements of EnzoMethodStarMakerSTARSS. Mostly meant for debugging.`

--- a/doc/source/param/method_star_maker.incl
+++ b/doc/source/param/method_star_maker.incl
@@ -189,3 +189,4 @@ Parameter:  :p:`Method` : :p:`star_maker` : :p:`turn_off_probability`
 :Scope:     :z:`Enzo`
 
 :e:`Turn off probablistic elements of EnzoMethodStarMakerSTARSS. Mostly meant for debugging.`
+

--- a/input/STARSS/SF_FB.incl
+++ b/input/STARSS/SF_FB.incl
@@ -38,7 +38,6 @@ Method {
      
        use_self_gravitating     = true;  # check that virial parameter < 1
        use_altAlpha             = false; # replace virial parameter calculation with total_energy/potential
-                                         # requires DEBUG_COPY_POTENTIAL to be set in EnzoMethodGravity
        use_h2_self_shielding    = false;
        use_temperature_threshold= false;
        use_critical_metallicity = false;
@@ -56,14 +55,14 @@ Method {
 
   feedback {
     flavor = "STARSS";
-    single_sn = 1;       # whether to have SNe at all
-    unrestricted_sn = 1; # Allow > 1 SN per particle in a timestep
-    stellar_winds = 1;   # whether to have stellar winds
-    analytic_SNR_shell_mass = 1; # calculate shell mass and subtract this from blast interior
+    supernovae = true;       # whether to have SNe at all
+    unrestricted_sn = true; # Allow > 1 SN per particle in a timestep
+    stellar_winds = true;   # whether to have stellar winds
+    analytic_SNR_shell_mass = true; # calculate shell mass and subtract this from blast interior
                                  # during feedback deposition
 
-    fade_SNR = 1; # Allow coupling of FB out to the fading phase, where expansion of the SNR
-                  # is comparable to the local sound speed.
+    fade_SNR = true; # Allow coupling of FB out to the fading phase, where expansion of the SNR
+                     # is comparable to the local sound speed.
 
     NEvents = -1; # Use this to manually set off SN events in ideal tests.
                   # if -1, SN rates are calculated for the particles to determine when

--- a/input/STARSS/method_feedback_starss.in
+++ b/input/STARSS/method_feedback_starss.in
@@ -75,11 +75,11 @@ Method {
 
   feedback {
     flavor = "STARSS";
-    single_sn = 1;
-    unrestricted_sn = 1;
-    stellar_winds = 1;
-    analytic_SNR_shell_mass = 1;
-    fade_SNR = 1;
+    supernovae = true;
+    unrestricted_sn = true;
+    stellar_winds = true;
+    analytic_SNR_shell_mass = true;
+    fade_SNR = true;
     NEvents = 1;
   };
 

--- a/src/Enzo/enzo_EnzoConfig.cpp
+++ b/src/Enzo/enzo_EnzoConfig.cpp
@@ -242,14 +242,13 @@ EnzoConfig::EnzoConfig() throw ()
   method_feedback_use_ionization_feedback(false),
   method_feedback_time_first_sn(-1), // in Myr
   // EnzoMethodFeedbackSTARSS,
-  method_feedback_single_sn(0),
-  method_feedback_unrestricted_sn(0),
-  method_feedback_stellar_winds(0),
-  method_feedback_gas_return_fraction(0.0),
+  method_feedback_supernovae(true),
+  method_feedback_unrestricted_sn(true),
+  method_feedback_stellar_winds(true),
   method_feedback_min_level(0),
-  method_feedback_analytic_SNR_shell_mass(0),
-  method_feedback_fade_SNR(0),
-  method_feedback_NEvents(0),
+  method_feedback_analytic_SNR_shell_mass(true),
+  method_feedback_fade_SNR(true),
+  method_feedback_NEvents(-1),
   // EnzoMethodStarMaker,
   method_star_maker_flavor(""),                              // star maker type to use
   method_star_maker_use_altAlpha(false),
@@ -266,10 +265,10 @@ EnzoConfig::EnzoConfig() throw ()
   method_star_maker_overdensity_threshold(0.0),
   method_star_maker_critical_metallicity(0.0),
   method_star_maker_temperature_threshold(1.0E4),
-  method_star_maker_maximum_mass_fraction(0.5),            // maximum cell mass fraction to convert to stars
+  method_star_maker_maximum_mass_fraction(0.05),            // maximum cell mass fraction to convert to stars
   method_star_maker_efficiency(0.01),            // star maker efficiency per free fall time
-  method_star_maker_minimum_star_mass(1.0E4),    // minimum star particle mass in solar masses
-  method_star_maker_maximum_star_mass(1.0E4),    // maximum star particle mass in solar masses
+  method_star_maker_minimum_star_mass(0.0),    // minimum star particle mass in solar masses
+  method_star_maker_maximum_star_mass(-1.0),    // maximum star particle mass in solar masses
   method_star_maker_min_level(0), // minimum AMR level for star formation
   method_star_maker_turn_off_probability(false),
   // EnzoMethodTurbulence
@@ -640,10 +639,9 @@ void EnzoConfig::pup (PUP::er &p)
   p | method_feedback_use_ionization_feedback;
   p | method_feedback_time_first_sn;
 
-  p | method_feedback_single_sn;
+  p | method_feedback_supernovae;
   p | method_feedback_unrestricted_sn;
   p | method_feedback_stellar_winds;
-  p | method_feedback_gas_return_fraction;
   p | method_feedback_min_level;
   p | method_feedback_analytic_SNR_shell_mass;
   p | method_feedback_fade_SNR;
@@ -1663,26 +1661,23 @@ void EnzoConfig::read_method_feedback_(Parameters * p)
     ("Method:feedback:use_ionization_feedback", false);
 
   // MethodFeedbackSTARSS parameters
-  method_feedback_single_sn = p->value_integer
-    ("Method:feedback:single_sn",0);
+  method_feedback_supernovae = p->value_logical
+    ("Method:feedback:supernovae",true);
 
-  method_feedback_unrestricted_sn = p->value_integer
-    ("Method:feedback:unrestricted_sn",0);
+  method_feedback_unrestricted_sn = p->value_logical
+    ("Method:feedback:unrestricted_sn",true);
 
-  method_feedback_stellar_winds = p->value_integer
-    ("Method:feedback:stellar_winds",0);
-
-  method_feedback_gas_return_fraction = p->value_float
-    ("Method:feedback:gas_return_fraction",0.0);
+  method_feedback_stellar_winds = p->value_logical
+    ("Method:feedback:stellar_winds",true);
 
   method_feedback_min_level = p->value_integer
     ("Method:feedback:min_level",0);
 
-  method_feedback_analytic_SNR_shell_mass = p->value_integer
-    ("Method:feedback:analytic_SNR_shell_mass",0);
+  method_feedback_analytic_SNR_shell_mass = p->value_logical
+    ("Method:feedback:analytic_SNR_shell_mass",true);
 
-  method_feedback_fade_SNR = p->value_integer
-    ("Method:feedback:fade_SNR",0);
+  method_feedback_fade_SNR = p->value_logical
+    ("Method:feedback:fade_SNR",true);
 
   method_feedback_NEvents = p->value_integer
     ("Method:feedback:NEvents",-1);
@@ -1742,16 +1737,16 @@ void EnzoConfig::read_method_star_maker_(Parameters * p)
     ("Method:star_maker:critical_metallicity",0.0);
 
   method_star_maker_maximum_mass_fraction = p->value_float
-    ("Method:star_maker:maximum_mass_fraction",0.5);
+    ("Method:star_maker:maximum_mass_fraction",0.05);
 
   method_star_maker_efficiency = p->value_float
     ("Method:star_maker:efficiency",0.01);
 
   method_star_maker_minimum_star_mass = p->value_float
-    ("Method:star_maker:minimum_star_mass",1.0E4);
+    ("Method:star_maker:minimum_star_mass",0.0);
 
   method_star_maker_maximum_star_mass = p->value_float
-    ("Method:star_maker:maximum_star_mass",1.0E4);
+    ("Method:star_maker:maximum_star_mass",-1.0);
   
   method_star_maker_min_level = p->value_integer
     ("Method:star_maker:min_level",0);

--- a/src/Enzo/enzo_EnzoConfig.hpp
+++ b/src/Enzo/enzo_EnzoConfig.hpp
@@ -346,14 +346,13 @@ public: // interface
       method_feedback_use_ionization_feedback(false),
       method_feedback_time_first_sn(-1.0), // in Myr
       /// EnzoMethodFeedbackSTARSS
-      method_feedback_single_sn(0),
-      method_feedback_unrestricted_sn(0),
-      method_feedback_stellar_winds(0),
-      method_feedback_gas_return_fraction(0.0),
+      method_feedback_supernovae(true),
+      method_feedback_unrestricted_sn(true),
+      method_feedback_stellar_winds(true),
       method_feedback_min_level(0),
-      method_feedback_analytic_SNR_shell_mass(0),
-      method_feedback_fade_SNR(0),
-      method_feedback_NEvents(0),
+      method_feedback_analytic_SNR_shell_mass(true),
+      method_feedback_fade_SNR(true),
+      method_feedback_NEvents(-1),
       /// EnzoMethodStarMaker
       method_star_maker_flavor(""),
       method_star_maker_use_density_threshold(false),           // check above density threshold before SF
@@ -370,10 +369,10 @@ public: // interface
       method_star_maker_critical_metallicity(0.0),
       method_star_maker_temperature_threshold(1.0E4),
       method_star_maker_number_density_threshold(0.0),      // Number density threshold in cgs
-      method_star_maker_maximum_mass_fraction(0.5),            // maximum cell mass fraction to convert to stars
+      method_star_maker_maximum_mass_fraction(0.05),            // maximum cell mass fraction to convert to stars
       method_star_maker_efficiency(0.01),            // star maker efficiency
-      method_star_maker_minimum_star_mass(1.0E4),    // minium star particle mass in solar masses
-      method_star_maker_maximum_star_mass(1.0E4),    // maximum star particle mass in solar masses
+      method_star_maker_minimum_star_mass(0.0),    // minium star particle mass in solar masses
+      method_star_maker_maximum_star_mass(-1.0),    // maximum star particle mass in solar masses
       method_star_maker_min_level(0), // minimum refinement level for star formation
       method_star_maker_turn_off_probability(false),
       // EnzoMethodTurbulence
@@ -823,14 +822,14 @@ public: // attributes
 
   /// EnzoMethodFeedbackSTARSS
   
-  int                       method_feedback_single_sn;
-  int                       method_feedback_unrestricted_sn;
-  int                       method_feedback_stellar_winds;
-  double                    method_feedback_gas_return_fraction;
-  int                       method_feedback_min_level;
-  int                       method_feedback_analytic_SNR_shell_mass;
-  int                       method_feedback_fade_SNR;
-  int                       method_feedback_NEvents;
+  bool                       method_feedback_supernovae;
+  bool                       method_feedback_unrestricted_sn;
+  bool                       method_feedback_stellar_winds;
+  int                        method_feedback_min_level;
+  bool                       method_feedback_analytic_SNR_shell_mass;
+  bool                       method_feedback_fade_SNR;
+  int                        method_feedback_NEvents;
+ 
   /// EnzoMethodStarMaker
 
   std::string               method_star_maker_flavor;

--- a/src/Enzo/enzo_EnzoMethodFeedbackSTARSS.cpp
+++ b/src/Enzo/enzo_EnzoMethodFeedbackSTARSS.cpp
@@ -41,7 +41,7 @@ int EnzoMethodFeedbackSTARSS::determineSN(double age_Myr, int* nSNII, int* nSNIA
     *nSNII = 0;
     *nSNIA = 0;
     double RII=0, RIA=0, PII=0, PIA=0, random = 0;
-    if (enzo_config->method_feedback_single_sn && NEvents < 0)
+    if (enzo_config->method_feedback_supernovae && NEvents < 0)
     {
         /* age-dependent rates */
         if (age_Myr < 3.401)
@@ -271,7 +271,7 @@ EnzoMethodFeedbackSTARSS::EnzoMethodFeedbackSTARSS
   refresh->add_all_fields();
   
   sf_minimum_level_ = enzo_config->method_star_maker_min_level;
-  single_sn_        = enzo_config->method_feedback_single_sn;
+  supernovae_        = enzo_config->method_feedback_supernovae;
 
   // Initialize temporary fields
   i_d_dep  = cello::field_descr()->insert_temporary();
@@ -344,7 +344,7 @@ void EnzoMethodFeedbackSTARSS::pup (PUP::er &p)
   Method::pup(p);
 
   p | sf_minimum_level_;
-  p | single_sn_;
+  p | supernovae_;
   p | NEvents;
   p | ir_feedback_;
 
@@ -673,7 +673,7 @@ void EnzoMethodFeedbackSTARSS::compute_ (Block * block)
         int nSNII = 0, nSNIa = 0;
         double SNMassEjected = 0.0, SNMetalEjected = 0.0;
 
-        if (single_sn_){ 
+        if (supernovae_){ 
 
           /* Determine number of SN events from rates (currently taken from Hopkins 2018) */
 

--- a/src/Enzo/enzo_EnzoMethodFeedbackSTARSS.cpp
+++ b/src/Enzo/enzo_EnzoMethodFeedbackSTARSS.cpp
@@ -19,7 +19,7 @@
 
 //#ifdef NOTDEFINED // for now... since not done coding
 
-#define DEBUG_FEEDBACK_STARSS
+//#define DEBUG_FEEDBACK_STARSS
 //#define DEBUG_FEEDBACK_STARSS_SN
 
 // =============================================================================

--- a/src/Enzo/enzo_EnzoMethodFeedbackSTARSS.hpp
+++ b/src/Enzo/enzo_EnzoMethodFeedbackSTARSS.hpp
@@ -123,7 +123,7 @@ protected: // methods
 protected:
 
   int sf_minimum_level_;
-  int single_sn_;
+  int supernovae_;
   int NEvents;
 
   // Refresh ID

--- a/src/Enzo/enzo_EnzoMethodStarMaker.cpp
+++ b/src/Enzo/enzo_EnzoMethodStarMaker.cpp
@@ -212,7 +212,7 @@ int EnzoMethodStarMaker::check_overdensity_threshold(const double &rho)
 }
 
 
-int EnzoMethodStarMaker::check_self_gravitating_new(const double total_energy, const double potential)
+int EnzoMethodStarMaker::check_self_gravitating_alt(const double total_energy, const double potential)
 {
 
   if (!this->use_self_gravitating_)

--- a/src/Enzo/enzo_EnzoMethodStarMaker.cpp
+++ b/src/Enzo/enzo_EnzoMethodStarMaker.cpp
@@ -321,7 +321,7 @@ int EnzoMethodStarMaker::check_jeans_mass(
   #ifdef DEBUG_SF
     CkPrintf("MethodStarMaker -- jeans_mass = %f\n",m_jeans); 
   #endif
-  return (mass*munit < m_jcrit);
+  return (mass*munit > m_jcrit);
 }
 
 int EnzoMethodStarMaker::check_velocity_divergence(

--- a/src/Enzo/enzo_EnzoMethodStarMaker.hpp
+++ b/src/Enzo/enzo_EnzoMethodStarMaker.hpp
@@ -85,7 +85,7 @@ protected: // methods
     const int &index, const int &dix, const int &diy, const int &diz,
     const double dx, const double dy, const double dz);
 
-  int check_self_gravitating_new(const double total_energy, const double potential);
+  int check_self_gravitating_alt(const double total_energy, const double potential);
   double h2_self_shielding_factor(
     enzo_float *rho, const double metallicity,
     const double dunit, const double lunit,


### PR DESCRIPTION
This PR makes some very minor changes to the STARSS methods -- mostly just resetting the default parameters for `EnzoMethodFeedbackSTARSS` and updating the documentation. 

I also noticed that `EnzoMethodStarMaker::check_jeans_mass()` was written to return `true` if the cell mass is **less** than the Jeans mass, so I corrected it to be the other way around (`return true` if `Mcell > Mjeans`).