### PR TITLE
Update the version number recordered in CMakeLists.txt 

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -17,8 +17,7 @@ if (DEFINED Enzo-E_CONFIG)
 endif()
 
 #Define project and languages
-# TODO set proper version before merge
-project(Enzo-E VERSION 0.9.0 LANGUAGES C CXX Fortran)
+project(Enzo-E VERSION 1.0.0 LANGUAGES C CXX Fortran)
 
 set(CMAKE_EXPORT_COMPILE_COMMANDS ON)
 


### PR DESCRIPTION
This sets the version number recorded in the output hdf5 files.

We might want to make a test to make sure these this stays synchronized with the git tag (if it's not a gold standard test). But that's a problem for a different day