### PR TITLE
Fix documentation markup issues

### DIFF
--- a/doc/source/_static/roles.css
+++ b/doc/source/_static/roles.css
@@ -1,0 +1,36 @@
+
+/*
+  Styles implementing markup in roles.incl used mainly in param files 
+*/
+.p{
+  font-family: "Courier";
+  font-weight: bold; 
+  color: #000066;
+}
+.g{
+  font-weight: bold;
+  font-style: italic;
+  color: #660099;
+}
+.s{
+  font-style: italic;
+/*  color: #006600; */
+}
+.t{
+  color: #660000;
+  font-family: courier;
+  font-weight: bold;
+}
+.d{
+  font-weight: bold;
+  font-family: courier;
+   color: #006600; 
+}
+.e{
+/*  font-style: italic; */
+/*  color: #006600; */
+}
+.o{
+  font-weight: bold;
+  color: #ff0000;
+}

--- a/doc/source/conf.py
+++ b/doc/source/conf.py
@@ -44,7 +44,7 @@ master_doc = 'index'
 
 # General information about the project.
 project = u'Enzo-E / Cello'
-copyright = u'2019, James Bordner'
+copyright = u'2022, Enzo Development Community'
 
 # The version info for the project you're documenting, acts as replacement for
 # |version| and |release|, also used in various other places throughout the
@@ -125,7 +125,17 @@ html_theme_path = ["."]
 # Add any paths that contain custom static files (such as style sheets) here,
 # relative to this directory. They are copied after the builtin static files,
 # so a file named "default.css" will overwrite the builtin "default.css".
-#html_static_path = ['_static']
+html_static_path = ['_static']
+
+html_css_files = {
+   'theme_overrides.css',  # overrides for wide tables in RTD theme
+    #                        taken from
+    #                        https://github.com/readthedocs/sphinx_rtd_theme/issues/117
+    #                        to solve the issue related to the tables
+    #                        not wrapping
+   'roles.css'
+}
+
 
 # If not '', a 'Last updated on:' timestamp is inserted at every page bottom,
 # using the given strftime format.
@@ -184,7 +194,7 @@ htmlhelp_basename = 'Enzo-ECellodoc'
 # (source start file, target name, title, author, documentclass [howto/manual]).
 latex_documents = [
   ('index', 'Enzo-ECello.tex', u'Enzo-E / Cello Documentation',
-   u'James Bordner', 'manual'),
+   u'Enzo Development Community', 'manual'),
 ]
 
 # The name of an image file (relative to this directory) to place at the top of
@@ -217,7 +227,7 @@ latex_documents = [
 # (source start file, name, description, authors, manual section).
 man_pages = [
     ('index', 'enzo-ecello', u'Enzo-E / Cello Documentation',
-     [u'James Bordner'], 1)
+     [u'Enzo Development Community'], 1)
 ]
 
 
@@ -225,9 +235,9 @@ man_pages = [
 
 # Bibliographic Dublin Core info.
 epub_title = u'Enzo-E / Cello'
-epub_author = u'James Bordner'
-epub_publisher = u'James Bordner'
-epub_copyright = u'2019, James Bordner'
+epub_author = u'Enzo Development Community'
+epub_publisher = u'Enzo Development Community'
+epub_copyright = u'2022, Enzo Development Community'
 
 # The language of the text. It defaults to the language option
 # or en if the language is not set.
@@ -262,16 +272,6 @@ epub_copyright = u'2019, James Bordner'
 
 # Example configuration for intersphinx: refer to the Python standard library.
 intersphinx_mapping = {'http://docs.python.org/': None}
-
-# taken from https://github.com/readthedocs/sphinx_rtd_theme/issues/117
-# to solve the issue related to the tables not wrapping
-html_static_path = ['_static']
-
-html_context = {
-    'css_files': [
-        '_static/theme_overrides.css',  # overrides for wide tables in RTD theme
-        ],
-    }
 
 # -- Set Breathe parameters and Execute Doxygen -------------------------------
 

--- a/doc/source/param/method.incl
+++ b/doc/source/param/method.incl
@@ -111,6 +111,11 @@ at all subsequent times.`
 
 :e:`This parameter specifies the maximum fraction of mass which can be accreted from a cell in one timestep. This value of this parameter must be between 0 and 1.`
 
+feedback
+--------
+
+.. include:: method_feedback.incl
+
 flux_correct
 ------------
 
@@ -257,6 +262,17 @@ timestep is independent of how the acceleration vectors are oriented relative
 to the mesh.`
 
 
+
+heat
+----
+
+:Parameter:  :p:`Method` : :p:`heat` : :p:`alpha`
+:Summary:    :s:`Parameter for the forward euler heat equation solver`
+:Type:       :t:`float`
+:Default:    :d:`1.0`
+:Scope:     :z:`Enzo`
+
+:e:`Thermal diffusivity parameter for the heat equation.`
 
 grackle
 -------
@@ -696,27 +712,6 @@ most up-to-date description of Grackle parameters, see the `Grackle parameters <
 :Todo: :o:`write`
 :Status:  **Not accessed**
 
-star_maker
-----------
-
-..include:: method_star_maker.incl
-
-feedback
---------
-
-..include:: method_feedback.incl
-
-heat
-----
-
-:Parameter:  :p:`Method` : :p:`heat` : :p:`alpha`
-:Summary:    :s:`Parameter for the forward euler heat equation solver`
-:Type:       :t:`float`
-:Default:    :d:`1.0`
-:Scope:     :z:`Enzo`
-
-:e:`Thermal diffusivity parameter for the heat equation.`
-
 merge_sinks
 -----------
 
@@ -847,6 +842,11 @@ this parameter multiplied by the cell width along the x/y/z axis.`
 :e:`When computing the random offset for the initial position of a sink particle, we compute
 an unsigned 64 bit integer value from the cycle number, the block index, and the cell
 index, and then add on this value to give the seed for the random number generator.`
+
+star_maker
+----------
+
+.. include:: method_star_maker.incl
 
 	     
 turbulence

--- a/doc/source/param/method.incl
+++ b/doc/source/param/method.incl
@@ -186,94 +186,6 @@ value is assumed to be the expected minimum number of digits conserved
 by the` ``"density"`` :e:`field.` *(Support for this type of parameter
 may be removed in the future)*
 
-gravity
--------
-
-:Parameter:  :p:`Method` : :p:`gravity` : :p:`solver`
-:Summary: :s:`Name of the linear solver to use`
-:Type:    :t:`string`
-:Default: :d:`"unknown"`
-:Scope:     :z:`Enzo`
-
-:e:`Identifier for the linear solver to use, which must be included in the "Solver:list" parameter.`
-
-----
-
-:Parameter:  :p:`Method` : :p:`gravity` : :p:`grav_const`
-:Summary: :s:`Gravitational constant`
-:Type:    :t:`float`
-:Default: :d:`6.67384e-8`
-:Scope:     :z:`Enzo`
-
-Gravitational constant used in place of G.  The default is G in cgs units.
-For non-cosmological simulations, if the user wants to use
-the standard value for the gravitational constant, the user must set a
-value which is consistent with their choice of units; i.e.,
-its value must be :math:`G_{cgs}\times M \times T^2 \times L^{-3}`, or equivalently,
-:math:`G_{cgs}\times D \times T^2`, where :math:`M, D, T, L` are the mass, density, time,
-and length units, and :math:`G_{cgs}` is the value of the gravitational constant in cgs units.
-
-In cosmological simulations, this parameter is ignored.
-
-
-----
-
-:Parameter:  :p:`Method` : :p:`gravity` : :p:`order`
-:Summary: :s:`Order of accuracy discretization to use for the discrete Laplacian`
-:Type:    :t:`integer`
-:Default: :d:`4`
-:Scope:     :z:`Enzo`
-
-:e:`Second, fourth, and sixth order discretizations of the Laplacian
-are available; valid values are 2, 4, or 6.`
-
-----
-
-:Parameter:  :p:`Method` : :p:`gravity` : :p:`accumulate`
-:Summary: :s:`Whether to add one layer of ghost zones when refreshing particle density`
-:Type:    :t:`logical`
-:Default: :d:`true`
-:Scope:     :z:`Enzo`
-
-:e:`This should be true for all runs with particles, since particle
-mass deposited in the "density_particle" field may bleed into the
-first layer of ghost zones.  This parameter ensures that that mass
-will be included in "density_total".`
-
-----
-
-:Parameter:  :p:`Method` : :p:`gravity` : :p:`dt_max`
-:Summary: :s:`The maximum timestep returned by EnzoMethodGravity::timestep`
-:Type:    :t:`float`
-:Default: :d:`1.0e10`
-:Scope:     :z:`Enzo`
-
-:e:`The timestep returned by EnzoMethodGravity::timestep (when called on a
-block) is calculated as follows. First, the geometric mean of the cell-widths
-in all dimensions is found, which we call the "mean cell width". Next, the
-quantity "epsilon" is calculated, as the mean cell width divided by the square
-of dt_max. Then, the maximum acceleration magnitude across all cells in the
-block is found, which we call "a_mag_max". We then calculate the
-mean cell width divided by the sum of a_mag_max and epsilon. The timestep is
-then the square root of this quantity. This means that if all the accelerations
-are zero (such as at the first time step), the timestep is equal to dt_max.
-Defining the timestep in this way also means that the value of the
-timestep is independent of how the acceleration vectors are oriented relative
-to the mesh.`
-
-
-
-heat
-----
-
-:Parameter:  :p:`Method` : :p:`heat` : :p:`alpha`
-:Summary:    :s:`Parameter for the forward euler heat equation solver`
-:Type:       :t:`float`
-:Default:    :d:`1.0`
-:Scope:     :z:`Enzo`
-
-:e:`Thermal diffusivity parameter for the heat equation.`
-
 grackle
 -------
 
@@ -711,6 +623,93 @@ most up-to-date description of Grackle parameters, see the `Grackle parameters <
 :Scope:     :z:`Enzo`
 :Todo: :o:`write`
 :Status:  **Not accessed**
+
+gravity
+-------
+
+:Parameter:  :p:`Method` : :p:`gravity` : :p:`solver`
+:Summary: :s:`Name of the linear solver to use`
+:Type:    :t:`string`
+:Default: :d:`"unknown"`
+:Scope:     :z:`Enzo`
+
+:e:`Identifier for the linear solver to use, which must be included in the "Solver:list" parameter.`
+
+----
+
+:Parameter:  :p:`Method` : :p:`gravity` : :p:`grav_const`
+:Summary: :s:`Gravitational constant`
+:Type:    :t:`float`
+:Default: :d:`6.67384e-8`
+:Scope:     :z:`Enzo`
+
+Gravitational constant used in place of G.  The default is G in cgs units.
+For non-cosmological simulations, if the user wants to use
+the standard value for the gravitational constant, the user must set a
+value which is consistent with their choice of units; i.e.,
+its value must be :math:`G_{cgs}\times M \times T^2 \times L^{-3}`, or equivalently,
+:math:`G_{cgs}\times D \times T^2`, where :math:`M, D, T, L` are the mass, density, time,
+and length units, and :math:`G_{cgs}` is the value of the gravitational constant in cgs units.
+
+In cosmological simulations, this parameter is ignored.
+
+
+----
+
+:Parameter:  :p:`Method` : :p:`gravity` : :p:`order`
+:Summary: :s:`Order of accuracy discretization to use for the discrete Laplacian`
+:Type:    :t:`integer`
+:Default: :d:`4`
+:Scope:     :z:`Enzo`
+
+:e:`Second, fourth, and sixth order discretizations of the Laplacian
+are available; valid values are 2, 4, or 6.`
+
+----
+
+:Parameter:  :p:`Method` : :p:`gravity` : :p:`accumulate`
+:Summary: :s:`Whether to add one layer of ghost zones when refreshing particle density`
+:Type:    :t:`logical`
+:Default: :d:`true`
+:Scope:     :z:`Enzo`
+
+:e:`This should be true for all runs with particles, since particle
+mass deposited in the "density_particle" field may bleed into the
+first layer of ghost zones.  This parameter ensures that that mass
+will be included in "density_total".`
+
+----
+
+:Parameter:  :p:`Method` : :p:`gravity` : :p:`dt_max`
+:Summary: :s:`The maximum timestep returned by EnzoMethodGravity::timestep`
+:Type:    :t:`float`
+:Default: :d:`1.0e10`
+:Scope:     :z:`Enzo`
+
+:e:`The timestep returned by EnzoMethodGravity::timestep (when called on a
+block) is calculated as follows. First, the geometric mean of the cell-widths
+in all dimensions is found, which we call the "mean cell width". Next, the
+quantity "epsilon" is calculated, as the mean cell width divided by the square
+of dt_max. Then, the maximum acceleration magnitude across all cells in the
+block is found, which we call "a_mag_max". We then calculate the
+mean cell width divided by the sum of a_mag_max and epsilon. The timestep is
+then the square root of this quantity. This means that if all the accelerations
+are zero (such as at the first time step), the timestep is equal to dt_max.
+Defining the timestep in this way also means that the value of the
+timestep is independent of how the acceleration vectors are oriented relative
+to the mesh.`
+
+
+heat
+----
+
+:Parameter:  :p:`Method` : :p:`heat` : :p:`alpha`
+:Summary:    :s:`Parameter for the forward euler heat equation solver`
+:Type:       :t:`float`
+:Default:    :d:`1.0`
+:Scope:     :z:`Enzo`
+
+:e:`Thermal diffusivity parameter for the heat equation.`
 
 merge_sinks
 -----------

--- a/doc/source/param/method_mhd_vlct.incl
+++ b/doc/source/param/method_mhd_vlct.incl
@@ -26,8 +26,8 @@ specified. Valid choices include:`
 future. For more details see`
 :ref:`vlct_overview`
 
-:e:`For debugging purposes, there is technically one last choice,
-``"unsafe_constant_uniform"``. :e:`This is NOT meant for science runs.
+:e:`For debugging purposes, there is technically one last choice,`
+``"unsafe_constant_uniform".`` :e:`This is NOT meant for science runs.
 When this option is selected, the magnetic field is treated as a
 cell-centered conserved quantity and the magnetic fluxes computed in
 the Riemann solver are directly added to to the magnetic fields

--- a/doc/source/param/method_star_maker.incl
+++ b/doc/source/param/method_star_maker.incl
@@ -1,4 +1,4 @@
-:p: `Method:star_maker` parameters.
+:p:`Method:star_maker` parameters.
 
 ----
 
@@ -32,7 +32,7 @@
 
 ----
 
-Parameter:  :p:`Method` : :p:`star_maker` : :p:`use_overdensity_threshold`
+:Parameter:  :p:`Method` : :p:`star_maker` : :p:`use_overdensity_threshold`
 :Summary: :s:`Use overdensity threshold`
 :Type:   :t:`logical`
 :Default: :d:`false`
@@ -52,7 +52,7 @@ Parameter:  :p:`Method` : :p:`star_maker` : :p:`use_overdensity_threshold`
 
 ----
 
-Parameter:  :p:`Method` : :p:`star_maker` : :p:`use_velocity_divergence`
+:Parameter:  :p:`Method` : :p:`star_maker` : :p:`use_velocity_divergence`
 :Summary: :s:`Use converging flow criterion for star formation`
 :Type:   :t:`logical`
 :Default: :d:`false`
@@ -62,7 +62,7 @@ Parameter:  :p:`Method` : :p:`star_maker` : :p:`use_velocity_divergence`
 
 ----
 
-Parameter:  :p:`Method` : :p:`star_maker` : :p:`use_cooling_time`
+:Parameter:  :p:`Method` : :p:`star_maker` : :p:`use_cooling_time`
 :Summary: :s:`Check if cooling_time < dynamical_time for star formation`
 :Type:   :t:`logical`
 :Default: :d:`false`
@@ -72,7 +72,7 @@ Parameter:  :p:`Method` : :p:`star_maker` : :p:`use_cooling_time`
 
 ----
 
-Parameter:  :p:`Method` : :p:`star_maker` : :p:`use_temperature_threshold`
+:Parameter:  :p:`Method` : :p:`star_maker` : :p:`use_temperature_threshold`
 :Summary: :s:`Use temperature threshold for star formation`
 :Type:   :t:`logical`
 :Default: :d:`false`
@@ -82,7 +82,7 @@ Parameter:  :p:`Method` : :p:`star_maker` : :p:`use_temperature_threshold`
 
 ----
 
-Parameter:  :p:`Method` : :p:`star_maker` : :p:`temperature_threshold`
+:Parameter:  :p:`Method` : :p:`star_maker` : :p:`temperature_threshold`
 :Summary: :s:`Temperature threshold for star formation`
 :Type:   :t:`float`
 :Default: :d:`1e4`
@@ -92,17 +92,17 @@ Parameter:  :p:`Method` : :p:`star_maker` : :p:`temperature_threshold`
 
 ----
 
-Parameter:  :p:`Method` : :p:`star_maker` : :p:`use_self_gravitating`
+:Parameter:  :p:`Method` : :p:`star_maker` : :p:`use_self_gravitating`
 :Summary: :s:`Use FIRE2 virial parameter criterion for star formation`
 :Type:   :t:`logical`
 :Default: :d:`false`
 :Scope:     :z:`Enzo`
 
-:e:`Checks that alpha < 1, where alpha is the virial parameter calculated using the FIRE-2 prescription. See Appendix C of `Hopkins et al. (2018) <https://academic.oup.com/mnras/article/480/1/800/5046474>`_.`
+:e:`Checks that alpha < 1, where alpha is the virial parameter calculated using the FIRE-2 prescription. See Appendix C of` `Hopkins et al. (2018) <https://academic.oup.com/mnras/article/480/1/800/5046474>`_.
 
 ----
 
-Parameter:  :p:`Method` : :p:`star_maker` : :p:`use_altAlpha`
+:Parameter:  :p:`Method` : :p:`star_maker` : :p:`use_altAlpha`
 :Summary: :s:`Use alternate virial parameter criterion for star formation`
 :Type:   :t:`logical`
 :Default: :d:`false`
@@ -112,27 +112,27 @@ Parameter:  :p:`Method` : :p:`star_maker` : :p:`use_altAlpha`
 
 ----
 
-Parameter:  :p:`Method` : :p:`star_maker` : :p:`use_h2_self_shielding`
+:Parameter:  :p:`Method` : :p:`star_maker` : :p:`use_h2_self_shielding`
 :Summary: :s:`Use H2 self-shielding criterion for star formation`
 :Type:   :t:`logical`
 :Default: :d:`false`
 :Scope:     :z:`Enzo`
 
-:e:`Checks that f_shield < 0, where f_shield is the H2 self-shielded fraction calculated using fits from Krumholz & Gnedin (2011).'
+:e:`Checks that f_shield < 0, where f_shield is the H2 self-shielded fraction calculated using fits from Krumholz & Gnedin (2011).`
 
 ----
 
-Parameter:  :p:`Method` : :p:`star_maker` : :p:`use_jeans_mass`
+:Parameter:  :p:`Method` : :p:`star_maker` : :p:`use_jeans_mass`
 :Summary: :s:`Use Jeans mass criterion for star formation`
 :Type:   :t:`logical`
 :Default: :d:`false`
 :Scope:     :z:`Enzo`
 
-:e:`Checks that cell_mass > max(jeans_mass, 1000 Msun) in a cell. '
+:e:`Checks that cell_mass > max(jeans_mass, 1000 Msun) in a cell.`
 
 ----
 
-Parameter:  :p:`Method` : :p:`star_maker` : :p:`critical_metallicity`
+:Parameter:  :p:`Method` : :p:`star_maker` : :p:`critical_metallicity`
 :Summary: :s:`Metallicity threshold for star formation`
 :Type:   :t:`float`
 :Default: :d:`0.0`
@@ -142,7 +142,7 @@ Parameter:  :p:`Method` : :p:`star_maker` : :p:`critical_metallicity`
 
 ----
 
-Parameter:  :p:`Method` : :p:`star_maker` : :p:`maximum_mass_fraction`
+:Parameter:  :p:`Method` : :p:`star_maker` : :p:`maximum_mass_fraction`
 :Summary: :s:`Max fraction of gas in a cell that can be converted into a star particle per formation event.`
 :Type:   :t:`float`
 :Default: :d:`0.05`
@@ -152,7 +152,7 @@ Parameter:  :p:`Method` : :p:`star_maker` : :p:`maximum_mass_fraction`
 
 ----
 
-Parameter:  :p:`Method` : :p:`star_maker` : :p:`min_level`
+:Parameter:  :p:`Method` : :p:`star_maker` : :p:`min_level`
 :Summary: :s:`Minimum AMR level required for star formation.`
 :Type:   :t:`integer`
 :Default: :d:`0`
@@ -162,7 +162,7 @@ Parameter:  :p:`Method` : :p:`star_maker` : :p:`min_level`
 
 ----
 
-Parameter:  :p:`Method` : :p:`star_maker` : :p:`minimum_star_mass`
+:Parameter:  :p:`Method` : :p:`star_maker` : :p:`minimum_star_mass`
 :Summary: :s:`Minimum star particle mass`
 :Type:   :t:`float`
 :Default: :d:`0.0`
@@ -172,7 +172,7 @@ Parameter:  :p:`Method` : :p:`star_maker` : :p:`minimum_star_mass`
 
 ----
 
-Parameter:  :p:`Method` : :p:`star_maker` : :p:`maximum_star_mass`
+:Parameter:  :p:`Method` : :p:`star_maker` : :p:`maximum_star_mass`
 :Summary: :s:`Maximum star particle mass`
 :Type:   :t:`float`
 :Default: :d:`-1.0`
@@ -182,7 +182,7 @@ Parameter:  :p:`Method` : :p:`star_maker` : :p:`maximum_star_mass`
 
 ----
 
-Parameter:  :p:`Method` : :p:`star_maker` : :p:`turn_off_probability`
+:Parameter:  :p:`Method` : :p:`star_maker` : :p:`turn_off_probability`
 :Summary: :s:`Turn off probablistic elements of EnzoMethodStarMakerSTARSS.`
 :Type:   :t:`logical`
 :Default: :d:`false`


### PR DESCRIPTION
This PR:

- fixes some RST markup issues in the parameters section, including ones that prevented `method_star_maker.incl` and `method_feedback.incl` from being included
- addresses a compatibility issue with newer Linux distributions related to including style sheets,
- orders method parameter subsections to be alphabetical,
- re-adds a long-gone style sheet for implementing `roles.incl` markup in parameter headers, and
- replaces my name with "Enzo Development Community" in copyright notices

See http://client64-71.sdsc.edu/~bordner/enzo-e.jobordner.fix-docs/doc/build/html/ for rendered version.

A more thorough documentation review will be forthcoming.