### PR TITLE
Fix CircleCi so that it runs VL+CT tests again

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -179,10 +179,17 @@ commands:
                 cd build
                 # Run all tests excluding VLCT, shu_collapse, and bb_test
                 ctest -E "(vlct)|(shu_collapse)|(bb_test)" --output-on-failure
-                # Run VLCT tests if using double prec (currently required)
-                # Don't run shu_collapse or bb_test since these take a long time to run
-                if [[ $USE_DOUBLE == 1 ]]; then
+                # Don't run shu_collapse or bb_test since these take a long
+                # time to run
+
+                # Only run VLCT tests if using double prec (since test answers
+                # are not currently defined for single prec).
+                USE_DOUBLE=`grep USE_DOUBLE_PREC CMakeCache.txt | cut -d = -f 2`
+                if [ "${USE_DOUBLE}" = "ON" ]; then
                   ctest -R vlct --output-on-failure
+                elif [ "${USE_DOUBLE}" != "OFF" ]; then
+                  echo "ERROR while checking precision of enzo_float"
+                  exit 1
                 fi
 
                 ninja process_test_results


### PR DESCRIPTION
When PR #244 refactored the configuration file to break compilation and executing the ctest framework into separate build-steps, this was accidentally broken.

It's still my intention to port the VL+CT tests to the answer testing framework, but I don't have time right now. This will ensure that the tests continue running in the short-term.