### PR TITLE
fix charm++ SMP detection - take 2

### DIFF
--- a/cmake/FindCharm.cmake
+++ b/cmake/FindCharm.cmake
@@ -176,33 +176,50 @@ if(AMPI_C_COMPILER AND AMPI_CXX_COMPILER)
   message(STATUS "Charm++ built with AMPI")
 endif()
 
-if(CHARM_COMPILER)
-  include(CheckIncludeFiles)
-  CHECK_INCLUDE_FILES("${CHARM_INCLUDE_DIR}/conv-mach-opt.h"
-                      HAVE_CHARM_CONV_MACH_OPT)
 
-  if (HAVE_CHARM_CONV_MACH_OPT)
-    include(CheckSymbolExists)
-    CHECK_SYMBOL_EXISTS(CMK_SMP "${CHARM_INCLUDE_DIR}/conv-mach-opt.h"
-                        CHARM_SMP)
+include(CheckIncludeFiles)
+include(CheckCXXSourceCompiles)
 
-    if ("${CHARM_SMP}" STREQUAL "")
-      # newer versions of charm++ don't store CMK_SMP in conv-mach-opt.h. Check
-      # other location
-      CHECK_INCLUDE_FILES("${CHARM_INCLUDE_DIR}/conv-autoconfig.h"
-                          HAVE_CHARM_CONV_AUTOCONFIG)
-      if (HAVE_CHARM_CONV_AUTOCONFIG)
-        unset(CHARM_SMP CACHE)
-        CHECK_SYMBOL_EXISTS(CMK_SMP "${CHARM_INCLUDE_DIR}/conv-autoconfig.h"
-                            CHARM_SMP)
-      endif()
+if(CHARM_COMPILER AND NOT DEFINED CHARM_SMP)
+  # Check whether Charm++ was built in SMP mode. Restructuring of Charm++ (that
+  # seems to have occured around the release of charm++ 7.0) makes this test
+  # somewhat non-trivial
+  #
+  # - in earlier versions, the CMK_SMP macro is only defined in the
+  #   "conv-mach-opt.h" header if charm++ was built in SMP mode (we could use
+  #   CHECK_SYMBOL_EXISTS to query if it was defined) Note: when the macro
+  #   is defined, it has a value of 1.
+  # - in modern versions, the CMK_SMP macro is ALWAYS defined in the
+  #   "conv-autoconfig.h" header. When built in SMP mode, it has a value of 1.
+  #   Otherwise, it has a value of 0.
+
+  # construct the include statements for the test program
+  set(CHARM_SMP_INCLUDE_STATEMENTS "")
+  foreach(header in ITEMS "conv-mach-opt.h" "conv-autoconfig.h")
+    CHECK_INCLUDE_FILES("${CHARM_INCLUDE_DIR}/${header}"
+                        HAVE_CHARM_SMP_HEADER)
+    if (HAVE_CHARM_SMP_HEADER)
+      string(APPEND CHARM_SMP_INCLUDE_STATEMENTS
+             "#include \"${CHARM_INCLUDE_DIR}/${header}\"\n")
     endif()
+    unset(HAVE_CHARM_SMP_HEADER CACHE)
+  endforeach()
 
-    if (CHARM_SMP)
-      message(STATUS "Charm++ built in SMP mode")
-    else()
-      message(STATUS "Charm++ built in non-SMP mode")
-    endif()
+  # run the test program to determine whether SMP mode is used
+  CHECK_CXX_SOURCE_COMPILES("
+    ${CHARM_SMP_INCLUDE_STATEMENTS}
+
+    #ifdef CMK_SMP
+    #if CMK_SMP > 0
+    int main(void) { return 0; }
+    #endif
+    #endif
+    " CHARM_SMP)
+
+  if (CHARM_SMP)
+    message(STATUS "Charm++ built in SMP mode")
+  else()
+    message(STATUS "Charm++ built in non-SMP mode")
   endif()
 
 endif()


### PR DESCRIPTION
Overview
--------

In PR #256 I attempted to fix a bug in the FindCharm CMake module that arises while checking if charm++ was built in SMP mode for newer versions of charm++.

I made a minor oversight and those changes caused CMake to always conclude that (newer versions of) charm++ always use SMP mode.

I must have forgetten to rebuild Enzo-E from scratch using non-SMP builds of charm++. Sorry about that.

Problem Descriptions
--------------------

In older versions of charm++, the CMK_SMP macro was only defined in SMP builds. Thus, we used CMake's CHECK_SYMBOL_EXISTS macro to check whether the macro was defined. As an aside, when the macro is defined, it has a value of 1.

In newer versions of charm++, the CMK_SMP is now defined in a different header. Additionaly, the macro is now ALWAYS defined, and the value is set as follows:
- 1 when using SMP mode (this was the case previously)
- 0 when not using SMP mode

My changes in PR #256 just checked if CMK_SMP was defined.

Note: the version cutoff seems to occur around version 7.0 of charm++, so we probably don't need to worry about supporting the check for the older version (but I kept it for now).

Solution
--------

CMake now queries the existence and value of the CMK_SMP (via a test program) to determine whether charm++ was built in SMP mode.

I have also confirmed that CMake draws the correct conclusion for both SMP and non-SMP versions of CMake.