### PR TITLE
Enforcing density floor in EnzoMethodPpm

### DIFF
--- a/src/Enzo/enzo_SolveHydroEquations.cpp
+++ b/src/Enzo/enzo_SolveHydroEquations.cpp
@@ -135,6 +135,24 @@ int EnzoBlock::SolveHydroEquations
 	    "Grid::SetMinimumSupport() returned ENZO_FAIL");
     }
   }
+
+  /* Set density floor. */
+  const EnzoFluidFloorConfig& fluid_floor_config
+               = fluid_props->fluid_floor_config();
+  enzo_float density_floor = fluid_floor_config.has_density_floor() ?
+                 fluid_floor_config.density() : 0.0;
+
+  if (density_floor > 0.0) {
+    for (int i=0; i<mx*my*mz; i++) {
+       if (density[i] < density_floor) {
+         density[i] = density_floor;
+       }
+    }
+  }
+
+  enzo_float pressure_floor = fluid_floor_config.has_pressure_floor() ?
+                 fluid_floor_config.pressure() : 0.0;
+
   /* allocate space for fluxes */
 
   int NumberOfSubgrids = 1;
@@ -315,7 +333,7 @@ int EnzoBlock::SolveHydroEquations
      istart, iend, jstart, jend,
      flux_array, dindex, Eindex, uindex, vindex, windex,
      geindex, temp,
-     &ncolor, colorpt, coloff, colindex,
+     &ncolor, colorpt, coloff, colindex, &pressure_floor, &density_floor,
      &error, ie_error_x,ie_error_y,ie_error_z,&num_ie_error
      );
 

--- a/src/Enzo/enzo_SolveHydroEquations.cpp
+++ b/src/Enzo/enzo_SolveHydroEquations.cpp
@@ -144,9 +144,7 @@ int EnzoBlock::SolveHydroEquations
 
   if (density_floor > 0.0) {
     for (int i=0; i<mx*my*mz; i++) {
-       if (density[i] < density_floor) {
-         density[i] = density_floor;
-       }
+      density[i] = std::max(density[i], density_floor);
     }
   }
 

--- a/src/Enzo/enzo_fortran.hpp
+++ b/src/Enzo/enzo_fortran.hpp
@@ -85,7 +85,7 @@ extern "C" void FORTRAN_NAME(ppm_de)
    int uindex[], int vindex[], int windex[],
    int geindex[], enzo_float *temp,
    int *ncolor, enzo_float *colorpt, int *coloff,
-   int colindex[], int *error,
+   int colindex[], enzo_float *pressure_floor, enzo_float *density_floor, int *error,
    int *ie_error_x,
    int *ie_error_y,
    int *ie_error_z,

--- a/src/Enzo/ppm_de.F
+++ b/src/Enzo/ppm_de.F
@@ -16,7 +16,8 @@ c
      &     fistart, fiend, fjstart, fjend,
      &     array, dindex, eindex,
      &     uindex, vindex, windex, geindex, tmp,
-     &     ncolor, colorpt, coloff, colindex, error,
+     &     ncolor, colorpt, coloff, colindex,
+     &     pmin, dmin, error,
      &     ie_error_x,ie_error_y,ie_error_z,num_ie_error)
 c     
 c  PERFORMS PPM (DIRECT EULERIAN) UPDATE FOR ONE TIMESTEP (WRAPPER)
@@ -98,7 +99,7 @@ c
      &     v(in,jn,kn), w(in,jn,kn),ge(in,jn,jn),
      &     gr_xacc(in,jn,kn), gr_yacc(in,jn,kn), gr_zacc(in,jn,kn),
      &        dx(in),dy(jn),dz(kn)
-      ENZO_REAL dt, eta1, eta2, gamma, pmin
+      ENZO_REAL dt, eta1, eta2, gamma, pmin, dmin
       ENZO_REAL array(1), colorpt(1)
 c
 c  Parameters
@@ -146,10 +147,6 @@ c
       k1 = 1
       k2 = kn
 c
-c  Set minimum pressure (better if it were a parameter)
-c
-      pmin = tiny
-c
 c  Loop over directions, using a Strang-type splitting
 c
       ixyz = mod(nhy,rank)
@@ -173,7 +170,7 @@ c$DOACROSS LOCAL(k)
               call xeuler_sweep(k, d, e, u, v, w, ge, in, jn, kn,
      &             gravity, gr_xacc, idual, eta1, eta2,
      &             is, ie, js, je, ks, ke,
-     &             gamma, pmin, dt, dx, dy, dz,
+     &             gamma, pmin, dmin, dt, dx, dy, dz,
      &             idiff, iflatten, isteepen,
      &             iconsrec, iposrec,
      &             ipresfree,  nsubgrids, lface, rface,
@@ -210,7 +207,7 @@ c$DOACROSS LOCAL(i)
               call yeuler_sweep(i, d, e, u, v, w, ge, in, jn, kn,
      &             gravity, gr_yacc, idual, eta1, eta2,
      &             is, ie, js, je, ks, ke,
-     &             gamma, pmin, dt, dx, dy, dz,
+     &             gamma, pmin, dmin, dt, dx, dy, dz,
      &             idiff, iflatten, isteepen,
      &             iconsrec, iposrec,
      &             ipresfree,
@@ -249,7 +246,7 @@ c$DOACROSS LOCAL(j)
               call zeuler_sweep(j, d, e, u, v, w, ge, in, jn, kn,
      &             gravity, gr_zacc, idual, eta1, eta2,
      &             is, ie, js, je, ks, ke,
-     &             gamma, pmin, dt, dx, dy, dz,
+     &             gamma, pmin, dmin, dt, dx, dy, dz,
      &             idiff, iflatten, isteepen,
      &             iconsrec, iposrec,
      &             ipresfree,

--- a/src/Enzo/xeuler_sweep.F
+++ b/src/Enzo/xeuler_sweep.F
@@ -8,7 +8,7 @@ c
       subroutine xeuler_sweep (k, d, e, u, v, w, ge, in, jn, kn,
      &     gravity, gr_acc, idual, eta1, eta2,
      &     is, ie, js, je, ks, ke, 
-     &     gamma, pmin, dt, dx, dy, dz,
+     &     gamma, pmin, dmin, dt, dx, dy, dz,
      &     idiff, iflatten, isteepen,
      &     iconsrec, iposrec,
      &     ipresfree,
@@ -63,6 +63,7 @@ c    is,js,ks - field active zone start index
 c    isteepen - steepening flag (0 = off)
 c    k        - current slice position in direction 3
 c    pmin   - minimum pressure
+c    dmin   - minimum density
 c    u      - x-velocity field
 c    v      - y-velocity field
 c    w      - z-velocity field
@@ -132,15 +133,12 @@ c-----------------------------------------------------------------------
 c
 c  argument declarations
 c
-      ENZO_REAL SmallRho
-      parameter (SmallRho = 1e-30)
-      
       integer gravity, idiff, idual, iflatten, isteepen, ipresfree,
      &        in, jn, kn, is, ie, js, je, ks, ke, k, nsubgrids,
      &     ncolor, coloff(ncolor)
       integer  iconsrec, iposrec
 
-      ENZO_REAL dt, eta1, eta2, gamma, pmin
+      ENZO_REAL dt, eta1, eta2, gamma, pmin, dmin
       ENZO_REAL d(in,jn,kn), e(in,jn,kn), u(in,jn,kn), v(in,jn,kn), 
      &        w(in,jn,kn),ge(in,jn,kn), gr_acc(in,jn,kn),
      &        dx(in),dy(jn),dz(kn)
@@ -327,7 +325,7 @@ c
      &     in, jn, is, ie, j1, j2, dt, 
      &     gamma, idiff, gravity, idual, eta1, eta2,
      &     df, ef, uf, vf, wf, gef, ges,
-     &     ncolor, colslice, colf, SmallRho,ierror)
+     &     ncolor, colslice, colf, dmin, ierror)
 c     
 c  If necessary, recompute the pressure to correctly set ge and e
 c

--- a/src/Enzo/yeuler_sweep.F
+++ b/src/Enzo/yeuler_sweep.F
@@ -8,7 +8,7 @@ c
       subroutine yeuler_sweep(i, d, e, u, v, w, ge, in, jn, kn,
      &     gravity, gr_acc, idual, eta1, eta2,
      &     is, ie, js, je, ks, ke,
-     &     gamma, pmin, dt, dx, dy, dz,
+     &     gamma, pmin, dmin, dt, dx, dy, dz,
      &     idiff, iflatten, isteepen,
      &     iconsrec, iposrec,
      &     ipresfree,
@@ -63,6 +63,7 @@ c    ipresfree - pressure free flag (0 = off, 1 = on, i.e. p=0)
 c    is,js,ks - field active zone start index
 c    isteepen - steepening flag (0 = off)
 c    pmin   - minimum pressure
+c    dmin   - minimum density
 c    u      - x-velocity field
 c    v      - y-velocity field
 c    w      - z-velocity field
@@ -122,14 +123,11 @@ c-----------------------------------------------------------------------
 c
 c  argument declarations
 c
-      ENZO_REAL SmallRho
-      parameter (SmallRho = 1e-30)
-      
       integer gravity, idiff, idual, iflatten, ipresfree, isteepen, 
      &        i, in, jn, kn, is, ie, js, je, ks, ke, nsubgrids,
      &     ncolor, coloff(ncolor)
       integer  iconsrec, iposrec
-      ENZO_REAL dt, eta1, eta2, gamma, pmin
+      ENZO_REAL dt, eta1, eta2, gamma, pmin, dmin
       ENZO_REAL d(in,jn,kn), e(in,jn,kn), u(in,jn,kn), v(in,jn,kn), 
      &        w(in,jn,kn),ge(in,jn,kn), gr_acc(in,jn,kn),
      &        dx(in),dy(jn),dz(kn)
@@ -316,7 +314,7 @@ c
      &     jn, kn, js, je, k1, k2, dt, 
      &     gamma, idiff, gravity, idual, eta1, eta2,
      &     df, ef, uf, vf, wf, gef, ges,
-     &     ncolor, colslice, colf, SmallRho,ierror)
+     &     ncolor, colslice, colf, dmin, ierror)
 c
 c  If necessary, recompute the pressure to correctly set ge and e
 c

--- a/src/Enzo/zeuler_sweep.F
+++ b/src/Enzo/zeuler_sweep.F
@@ -8,7 +8,7 @@ c
       subroutine zeuler_sweep(j, d, e, u, v, w, ge, in, jn, kn,
      &     gravity, gr_acc, idual, eta1, eta2,
      &     is, ie, js, je, ks, ke,
-     &     gamma, pmin, dt, dx, dy, dz,
+     &     gamma, pmin, dmin, dt, dx, dy, dz,
      &     idiff, iflatten, isteepen,
      &     iconsrec, iposrec,
      &     ipresfree,
@@ -63,6 +63,7 @@ c    is,js,ks - field active zone start index
 c    isteepen - steepening flag (0 = off)
 c    j      - current slice position in y-direction
 c    pmin   - minimum pressure
+c    dmin   - minimum density
 c    u      - x-velocity field
 c    v      - y-velocity field
 c    w      - z-velocity field
@@ -122,13 +123,11 @@ c-----------------------------------------------------------------------
 c
 c  argument declarations
 c
-      ENZO_REAL SmallRho
-      parameter (SmallRho = 1e-30)
       integer gravity, idiff, idual, iflatten, isteepen, ipresfree,
      &        in, jn, kn, is, ie, j, js, je, ks, ke, nsubgrids,
      &        ncolor, coloff(ncolor)
       integer  iconsrec, iposrec
-      ENZO_REAL dt, eta1, eta2, gamma, pmin
+      ENZO_REAL dt, eta1, eta2, gamma, pmin, dmin
       ENZO_REAL d(in,jn,kn), e(in,jn,kn), u(in,jn,kn), v(in,jn,kn), 
      &        w(in,jn,kn),ge(in,jn,kn), gr_acc(in,jn,kn)
       ENZO_REAL dx(in),dy(jn),dz(kn)
@@ -316,7 +315,7 @@ c
      &     kn, in, ks, ke, i1, i2, dt, 
      &     gamma, idiff, gravity, idual, eta1, eta2,
      &     df, ef, uf, vf, wf, gef, ges,
-     &     ncolor, colslice, colf, SmallRho, ierror)
+     &     ncolor, colslice, colf, dmin, ierror)
 c     
 c  If necessary, recompute the pressure to correctly set ge and e
 c


### PR DESCRIPTION
This is a small PR that adds the ability to set a density floor in EnzoMethodPpm, since the method doesn't currently check `enzo_fluid_floor_config.density()` anywhere.
 
I've also made the small change of passing density and pressure floors into `ppm_de` as parameters. In the main branch, these are currently hard-coded to be arbitrarily small numbers in `ppm_de` (for pressure_floor) and `<x/y/z>euler_sweep` (for density_floor). 