### PR TITLE
VL+CT test fix

### DIFF
--- a/tools/l1_error_norm.py
+++ b/tools/l1_error_norm.py
@@ -312,7 +312,7 @@ def find_common_fields(ds1, ds2, verbose, fields = None):
     else:
         has_field = lambda field: field[1] in ds2
     for field in coerced_fields:
-        if has_field:
+        if has_field(field):
             shared_fields.append(field)
         else:
             missing_fields.append(field)

--- a/tools/l1_error_norm.py
+++ b/tools/l1_error_norm.py
@@ -1,4 +1,5 @@
 import argparse
+from collections import UserDict
 import os.path
 import warnings
 import numpy as np
@@ -349,28 +350,82 @@ def build_3D_grid(ds, dim_edges):
                                         domain_left_edge, i)
         dims.append(stop_ind-start_ind)
     return ds.covering_grid(0,left_edge = grid_left_edge, dims = dims)
-        
 
-def load_reference_table(fname):
-    
-    skip = 0
+class RefTableDict(UserDict):
+    """
+    A class that is used to hold tabulated 1D reference data.
+
+    This behaves exactly like an ordinary dictionary, but also allows users to
+    specify two-element string tuples as keys when accessing data. When that is
+    done, instances of this class just ignore the first element and uses the
+    second element to identify the requested data (this makes comparisons with
+    simulation data much easier).
+    """
+    def __getitem__(self, key):
+        if isinstance(key, tuple):
+            assert len(key) == 2
+            return self.data[key[1]] # we just ignore the first part of the key
+        return self.data[key]
+
+def load_reference_table(fname, coerce_pos_key = False):
+    """
+    Loads 1D reference data for comparisons with simulation results
+
+    Parameters
+    ----------
+    fname: str
+        Path to the file holding the reference data
+    coerce_pos_key: bool, optional
+        If True, confirm that the table has 1 column specifying position
+        (called "position", "pos", "x", "y", or "z"), ensures that it
+        monotonically increases, and renames it so that it is called "pos"
+
+    Notes
+    -----
+    An underlying assumption has been that the problem is scale-free (i.e. the
+    precise choice of units are unimportant).
+    """
+
+    header_line_count = 0
+
+    # load the meta_data
     meta_data = {}
     with open(fname,"r") as f:
         for line in f.readlines():
             if (line[0]) == "#":
-                skip+=1
+                header_line_count += 1
                 if "=" in line:
                     words = line[1:].split("=")
                     if len(words) == 2:
                         meta_data[words[0].strip()] = words[1].strip()
             else:
                 break
-    rec = np.recfromtxt(fname, skip_header=skip,comments="#",dtype=None,
-                        delimiter=',',names=True,encoding='utf-8')
-    
-    out_data = {}
+
+    # load the actual data
+    rec = np.recfromtxt(fname, skip_header = header_line_count, comments = "#",
+                        dtype = None, delimiter = ',', names = True,
+                        encoding='utf-8')
+    # reformat the actual data
+    out_data = RefTableDict()
     for field in rec.dtype.fields:
         out_data[field] = rec[field]
+
+    if coerce_pos_key:
+        pos_keys = ["position", "pos", "x", "y", "z"]
+        intersect = [val for val in out_data.keys() if val in pos_keys]
+        if len(intersect) == 0:
+            raise ValueError("table does not have a column labelled "
+                             "position, pos, x, y, or z")
+        elif len(intersect) >1:
+            raise ValueError("table must have only one column labelled "
+                             "position, pos, x, y, or z")
+        elif (np.diff(out_data[intersect[0]])<=0).any():
+            raise ValueError(f"the {intersect[0]} column in table must "
+                             "monotonically increase")
+        else:
+            pos = out_data.pop(intersect[0])
+            out_data["pos"] = pos
+
     return meta_data, out_data
 
 def vector_name_iterator(data):
@@ -399,7 +454,7 @@ def vector_name_iterator(data):
         candidates[prefix][ax_map[dim]] = elem
     return candidates.items()
 
-def permute_vector_quantites(data, verbose, permute):
+def permute_vector_quantities(data, verbose, permute):
 
     if permute is None:
         return None
@@ -445,22 +500,9 @@ def compare_to_1D_reference(ds, tab_fname, problem_ax, verbose, op_func = None,
     # if op_func is None, returns the total L1 Error Norm
     # otherwise op_func is applied on all parallel L1 Error Norms
 
-    meta_data, ref_data = load_reference_table(tab_fname)
-
-    pos_keys = ["position","pos", "x", "y", "z"]
-    intersect = [val for val in ref_data.keys() if val in pos_keys]
-    if len(intersect) == 0:
-        raise ValueError("table does not have a column labelled "
-                         "position, pos, x, y, or z")
-    elif len(intersect) >1:
-        raise ValueError("table must have only one column labelled "
-                         "position, pos, x, y, or z")
-    else:
-        if (np.diff(ref_data[intersect[0]])<=0).any():
-            msg = 'the {} column in table must monotonically increase'
-            raise ValueError(msg.format(intersect[0]))
-        pos = ref_data.pop(intersect[0])
-        ref_data["pos"] = pos
+    meta_data, ref_data = load_reference_table(tab_fname,
+                                               coerce_pos_key = True)
+    pos = ref_data["pos"]
 
     # if offset_soln was specified, modify the position values
     cell_width = np.diff(pos)[0]
@@ -504,25 +546,17 @@ def compare_to_1D_reference(ds, tab_fname, problem_ax, verbose, op_func = None,
         ax_ind = 0
         kwargs["Nx"] = len(pos)
 
-    # adjust the shape of the reference arrays
-    # and determine limits along problem_ax that we are interested in
-    temp = []
-    sub_grid_edges = []
-    for i in range(3):
-        if i != ax_ind:
-            temp.append(np.newaxis)
-            sub_grid_edges.append(None)
-        else:
-            temp.append(slice(None,None))
-            sub_grid_edges.append([left_edge,right_edge])
+    # adjust the shape of the reference data so that it is 3D
+    idx = tuple(slice(None) if i == ax_ind else np.newaxis
+                for i in range(3))
+    ref = RefTableDict( (field, arr[idx]) for field,arr in ref_data.items() )
 
-    idx = tuple(temp)
-    ref = {}
-    for field,arr in ref_data.items():
-        ref[field] = arr[idx]
+    # determine limits along problem_ax that we are interested in comparing
+    sub_grid_edges = [[left_edge,right_edge] if i == ax_ind else None
+                      for i in range(3)]
 
     # optionally permute some vector quantities
-    permute_vector_quantites(ref, verbose, permute)
+    permute_vector_quantities(ref, verbose, permute)
 
     # optionally add some fixed background velocities
     if bkd_velocity != []:


### PR DESCRIPTION
This fixes some failing tests of the VL+CT integrator, that arose because of a recent change in `yt` that affected the python script for computing the L1 Error Norm. I also did some light refactoring.

When accessing field data, the script used a single string to specify the name of the field. Recent versions of `yt` now require that we fully specify the two part names of fields. For more context, I provide a concrete example below:
-  we could previously access density data by specifying  `data['density']`. 
- In reality, `yt` didn't directly track a field called `'density'`. Instead it tracked a field called `'enzoe', 'density'` (this field is specific to enzo-e, corresponds to the data stored on disk, and is in code units) and a field called `'gas', 'density'` (this is a field derived from `'enzoe', 'density'` and has cgs units). Previously, `yt` would translate `density` into one of these two choices under-the-hood
- the latest version of `yt` requires that we directly access density by specifying `data['gas','density']` or `data['enzoe','density']`. This removes some ambiguity.

This PR is meant to provide a short-term fix so that these failing tests don't interfere with the review of other PRs (like PR #199).

With that said, the script is a bit of a mess. A lot of complexity arises from the fact that it supports compute the L1 Error Norm when comparing 2 different snapshots and when comparing a snapshot with a tabulated solution (like for a shock tube). Cleaning this script up is definitely on my ToDo list (I also want to migrate the tests using this script to the pytest framework and add the ability to compute the l1 error norm for simulation that use AMR)