### PR TITLE
Parameters tweaks

### DIFF
--- a/src/Cello/parameters_Parameters.cpp
+++ b/src/Cello/parameters_Parameters.cpp
@@ -1055,7 +1055,16 @@ int Parameters::readline_
 Param * Parameters::param (std::string parameter, int index)
 {
   if (index == -1) {
-    return parameter_map_[parameter_name_(parameter)];
+    std::string full_name = parameter_name_(parameter);
+    // this branch was previously equivalent to:
+    //     return parameter_map_[full_name];
+    // however, when full_name wasn't a key within parameter_map_, that
+    // implicity inserted the key-value pair (full_name, nullptr) within
+    // parameter_map_
+    //
+    // The modern implementation avoids mutating parameter_map_
+    auto search = parameter_map_.find(full_name);
+    return (search != parameter_map_.end()) ? search->second : nullptr;
   } else {
     Param * list = this->param(parameter);
     Param * param = NULL;

--- a/src/Cello/parameters_Parameters.hpp
+++ b/src/Cello/parameters_Parameters.hpp
@@ -207,8 +207,16 @@ public: // interface
   /// Clear all groups
   void group_clear() throw();
 
+  /// Returns a vector holding the names of all leaf parameters in the
+  /// specified parameter group
+  std::vector<std::string> leaf_parameter_names
+  (const std::string& full_group_name) const throw();
+
   /// Returns a vector holding the names of all leaf parameters in the current
   /// group
+  ///
+  /// this overload of the function is deprecated, but exists to maintain
+  /// backwards compatibility
   std::vector<std::string> leaf_parameter_names() const throw();
 
   /// Return the full name of the parameter including group


### PR DESCRIPTION
Modified the `Parameters::param` to have better behavior when the method is passed an unknown parameter name. For an unknown parameter name `"<param>"`, the method would previously insert the `{"<param>", nullptr}` key-value pair into the `parameter_map_` attribute of `Parameters` before returning a `nullptr`. Now, this method never directly mutates the `parameter_map_` attribute (but it still returns a `nullptr`).

I was motivated to make this change now because the old behavior resulted in unexpected behavior when calling `Parameters::leaf_parameter_names`.

I also checked the other methods of the `Parameters` class and confirmed that none of them actually depended on the old behavior of `Parameters::param`. In fact, many of them included special handling to ignore entries in the `parameter_map_` that contained a `nullptr` (which could only be inserted via calls to `Parameters::param`). I have modified those methods now to explicitly raise an error if they encounter a `nullptr`