### PR TITLE
rescaling color fields when enforcing color fields

### DIFF
--- a/src/Enzo/enzo_SolveHydroEquations.cpp
+++ b/src/Enzo/enzo_SolveHydroEquations.cpp
@@ -144,7 +144,17 @@ int EnzoBlock::SolveHydroEquations
 
   if (density_floor > 0.0) {
     for (int i=0; i<mx*my*mz; i++) {
-      density[i] = std::max(density[i], density_floor);
+      double d_pre = density[i];
+      density[i] = std::max(d_pre, density_floor);
+
+      // rescale color fields to account for possible change in
+      // baryon mass from enforcing density floor
+      double density_ratio = density[i] / d_pre;
+      for (int ic = 0; ic < ncolor; ic++){
+        enzo_float * cfield = (enzo_float *)
+        field.values(field.groups()->item("color",ic));
+        cfield[i] *= density_ratio;
+      }
     }
   }
 


### PR DESCRIPTION
This is a very small PR that rescales color fields when the density floor is enforced in `enzo_SolveHydroEquations`. When the density floor is enforced, mass is effectively being added to the system. This change makes sure that the various species concentrations are kept the same when this happens.