### PR TITLE
Fixed the failing docs-build circleci test

### DIFF
--- a/doc/source/conf.py
+++ b/doc/source/conf.py
@@ -25,8 +25,7 @@ sys.path.insert(0, os.path.abspath('./_ext'))
 
 # Add any Sphinx extension module names here, as strings. They can be extensions
 # coming with Sphinx (named 'sphinx.ext.*') or your custom ones.
-extensions = ['sphinx.ext.intersphinx',
-              'sphinx.ext.todo',
+extensions = ['sphinx.ext.todo',
               'breathe',
               'par']
 todo_include_todos=True
@@ -270,9 +269,6 @@ epub_copyright = u'2022, Enzo Development Community'
 
 # Allow duplicate toc entries.
 #epub_tocdup = True
-
-# Example configuration for intersphinx: refer to the Python standard library.
-intersphinx_mapping = {'http://docs.python.org/': None}
 
 # -- Set Breathe parameters and Execute Doxygen -------------------------------
 


### PR DESCRIPTION
In detail, the failing test tries to build the website documentation and fails if any warnings get raised. The test recently started failing (e.g. in PR #280 and PR #263) because the ``sphinx`` developers introduced a new warning to indicate that a configuration option was specified in an outdated format.

In more detail:

  * I believe that when ``sphinx`` originally generated our documentation configuration file, ``doc/source/conf.py``, the ``intersphinx`` extension was enabled by default (for the sake of illustrating how to use extensions).

  * One of the configuration options that was autogenerated for that extension, called ``intersphinx_mapping``, was specified in a format that was used before version 1.0 of ``sphinx``

  * In a recent update to ``sphinx``, the developers introduced a deprecation warning indicating that the format of that parameter is deprecated (and will become invalid in an upcoming release)

To resolve this issue, I disabled the ``intersphinx`` extension since we don't use it at all (to avoid issues like this in the future).