### PR TITLE
Improve ergonomics of pytest machinery

### DIFF
--- a/doc/source/tests/pytest_framework.rst
+++ b/doc/source/tests/pytest_framework.rst
@@ -9,6 +9,9 @@ simulation is run with two versions of ``enzo-e`` and their results are compared
 This is useful for testing problems with no analytical solution or generally
 verifying that results from commonly run simulations don't drift.
 
+It is also useful for testing property of simulation runs beyond the exit-time/cycle of the simulation.
+(While such tests do exist in the ctest-framework, they often involve more boiler-plate code).
+
 `pytest <https://docs.pytest.org/>`__ is a Python-based framework for detecting
 and running a series of tests within a source code repository. When running
 ``pytest``, the user can provide a directory in which ``pytest`` will look for
@@ -41,6 +44,8 @@ other useful answer testing functionality are located in the source in
 `test/answer_tests/answer_testing.py`. All answer tests are located in the
 other files within the `test/answer_tests` directory.
 
+Some other functionallity, that may be reused in other unrelated scripts provided in the Enzo-E repository, are provided in the ``test_utils`` subdirectory.
+
 Running the Answer Test Suite
 -----------------------------
 
@@ -60,16 +65,49 @@ To generate test answers, use the highest numbered gold standard tag.
 Configuring the Answer Test Suite
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
-Before the answer tests can be run, a few environment variables must be set to
-configure behavior.
+The behavior of the test can be configured by passing command line arguments to ``pytest`` or by setting environment variables (or by mixing both).
 
- * ``TEST_RESULTS_DIR``: points to a directory in which answers will be stored
- * ``CHARM_PATH``: points to the directory in which ``charmrun`` is located
- * ``ENZO_PATH``: points to the ``enzo-e`` binary to use.
-   If this is not specified, this defaults to the ``<PATH/TO/ENZO-E/REPO>/build/bin/enzo-e``
- * ``GENERATE_TEST_RESULTS``: "true" to generate test results, "false" to compare with existing results.
- * ``GRACKLE_INPUT_DATA_DIR``: points to the directory where ``Grackle`` input files are installed.
-   If not specified, then all tests involving ``Grackle`` will be skipped.
+When invoking ``pytest``, the command line flags discussed here should be passed **after** the path to the `test/answer_tests` directory has been provided.
+For the sake of example (the meaning of flags are explained below), one might invoke:
+
+.. code-block:: bash
+
+   $ pytest test/answer_tests  \
+            --build-dir ./build \
+            --answer-store
+
+The following table lists command line flags, and where applicable, the environment variables that they are interchangable with.
+In cases where both are set, the command line argument is given precedence.
+
+.. list-table:: Configuring pytest behavior
+   :widths: 10 10 30
+   :header-rows: 1
+
+   * - flag
+     - env var
+     - description
+   * - ``--build-dir``
+     - N/A
+     - points to the build-directory where the target enzo-e binary was built (that binary has the path: BUILD_DIR/bin/enzo-e).
+       The path to the charmrun launcher will be inferred from the `BUILD_DIR/CMakeCache.txt` file, but can be overwritten by the ``--charm`` flag or the ``CHARM_PATH`` environment variable.
+       This precedence was chosen in case a user causes a change to relevant cached build-variables, but have not rebuilt Enzo-E (i.e. `CMakeCache.txt` may not be valid for the binary).
+       When this flag isn't specified, the test infrastructure searches for the enzo-e binary at ENZOE_ROOT/build/bin/enzo-e, but does'nt try to infer charmrun's location from `CMakeCache.txt`.
+   * - ``--local-dir``
+     - ``TEST_RESULTS_DIR``
+     - points to a directory in which answers will be stored/loaded
+   * - ``--charm``
+     - ``CHARM_PATH``
+     - points to the directory in which ``charmrun`` is located
+   * - ``--answer-store``
+     - ``GENERATE_TEST_RESULTS``
+     - When the command line flag is specified, test results are generated. Otherwise, results are compared against existing results (unless the environment variable is specified).
+       The environment variable can be be set to ``"true"`` to generate test results or ``"false"`` to compare with existing results.
+   * - ``--grackle-input-data-dir``
+     - ``GRACKLE_INPUT_DATA_DIR``
+     - points to the directory where ``Grackle`` input files are installed.
+       If not specified, then all tests involving ``Grackle`` will be skipped.
+
+Earlier versions of the tests also required the ``"USE_DOUBLE"`` environment variable to be set to ``"true"`` or ``"false"`` to indicate whether the code had been compiled in double or single precision.
 
 .. code-block:: bash
 
@@ -86,18 +124,12 @@ First, check out the highest numbered gold standard tag and compile ``enzo-e``.
    $ git checkout gold-standard-1
    $ ...compile enzo-e
 
-Then, configure the test suite to generate answers by setting 
-GENERATE_TEST_RESULTS to true.
+Then, run the test suite by calling ``pytest`` with the answer test directory (make sure to configure behavior correctly with command-line arguments or environment variables).
+In the following snippet, we assume you are currently at the root of the Enzo-E repository and that you will replace ``<build-dir>`` with the directory where you build enzo-e (this is commonly ``./build``)
 
 .. code-block:: bash
 
-   $ export GENERATE_TEST_RESULTS=true
-
-Finally, run the test suite by calling ``pytest`` with the answer test directory.
-
-.. code-block:: bash
-
-   $ pytest test/answer_tests
+   $ pytest test/answer_tests --local-dir=~/enzoe_tests --build-dir=<build-dir> --answer-store
    ========================== test session starts ===========================
    platform linux -- Python 3.9.13, pytest-7.1.2, pluggy-1.0.0
    rootdir: /home/circleci/enzo-e
@@ -116,19 +148,16 @@ Comparing Test Answers
 
 Once test answers have been generated, the above steps need not be repeated until
 the gold standard tag has been updated. Now, any later version of the code can be
-run with the test suite to check for problems. Set the GENERATE_TEST_RESULTS
-environment variable to false to configure the test suite to compare with existing
-answers.
+run with the test suite to check for problems. To configure the test suite to compare with existing answers, omit the ``--answer-store`` flag and ensure that the ``GENERATE_TEST_RESULTS`` variable is either unset or set to ``"false"``.
 
 .. code-block:: bash
 
    $ git checkout main
    $ ...compile enzo-e
-   $ export GENERATE_TEST_RESULTS=false
-   $ pytest test/answer_tests
+   $ pytest test/answer_tests --local-dir=~/enzoe_tests --build-dir=<build-dir>
 
-Getting More Output from Pytest
-^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+Helpful Tips
+^^^^^^^^^^^^
 
 By default, most output printed by ``enzo-e`` or the test scripts will be swallowed
 by ``pytest``. When tests fail, the Python traceback may be shown, but not much
@@ -139,7 +168,18 @@ variables when this flag is given.
 
 .. code-block:: bash
 
-   $ pytest -s test/answer_tests
+   $ pytest -s test/answer_tests # other args...
+
+When debugging an issue it's sometimes helpful to force pytest to run a subset of tests.
+This can be accomplished with the ``-k`` flag.
+For example, to only run a subset of tests with ``"grackle"`` in the test name, one might execute
+
+.. code-block:: bash
+
+   $ pytest test/answer_tests -k "grackle" # other args...
+
+When investigating a failing test or prototyping a brand-new test, it can sometimes be helpful to run the tests against multiple versions of enzo-e.
+Rather than rebuilding Enzo-E each time you want to do that, you can instead build the different versions of Enzo-E in separate build-directories, and direct ``pytest`` to use the different builds with the ``--build-dir`` flag.
 
 Creating New Answer Tests
 -------------------------
@@ -290,6 +330,17 @@ in single or double precision, and adjust the tolerance on the tests accordingly
    @ytdataset_test(assert_array_rel_equal, decimals=decimals)
    def test_hllc_cloud(self):
        ...
+
+.. note::
+
+   The above code is primarily for the sake of example.
+   In practice, we now automatically detect the code's precision from the enzo-e executable.
+
+Alternatively, additional configuration options can be configured through new command-line flags, which are introduced and parsed by the `conftest.py` file in the `answer_test` directory.
+This is generally more robust than adding environment variables (since the flags are more easily discovered and are more explicit).
+But, in practice it's made slightly more complicated by the fact that flags are parsed with pytest hooks.
+Flags added in this way work best with ``pytest`` fixtures, while our tests mostly leverage features from `Python's unittest module <https://docs.python.org/3/library/unittest.html>`_.
+
 
 Caveats
 ^^^^^^^

--- a/doc/source/tests/pytest_framework.rst
+++ b/doc/source/tests/pytest_framework.rst
@@ -44,7 +44,7 @@ other useful answer testing functionality are located in the source in
 `test/answer_tests/answer_testing.py`. All answer tests are located in the
 other files within the `test/answer_tests` directory.
 
-Some other functionallity, that may be reused in other unrelated scripts provided in the Enzo-E repository, are provided in the ``test_utils`` subdirectory.
+Some other functionality, that may be reused in other unrelated scripts provided in the Enzo-E repository, are provided in the ``test_utils`` subdirectory.
 
 Running the Answer Test Suite
 -----------------------------
@@ -91,7 +91,7 @@ In cases where both are set, the command line argument is given precedence.
      - points to the build-directory where the target enzo-e binary was built (that binary has the path: BUILD_DIR/bin/enzo-e).
        The path to the charmrun launcher will be inferred from the `BUILD_DIR/CMakeCache.txt` file, but can be overwritten by the ``--charm`` flag or the ``CHARM_PATH`` environment variable.
        This precedence was chosen in case a user causes a change to relevant cached build-variables, but have not rebuilt Enzo-E (i.e. `CMakeCache.txt` may not be valid for the binary).
-       When this flag isn't specified, the test infrastructure searches for the enzo-e binary at ENZOE_ROOT/build/bin/enzo-e, but does'nt try to infer charmrun's location from `CMakeCache.txt`.
+       When this flag isn't specified, the test infrastructure searches for the enzo-e binary at ENZOE_ROOT/build/bin/enzo-e, but doesn't try to infer charmrun's location from `CMakeCache.txt`.
    * - ``--local-dir``
      - ``TEST_RESULTS_DIR``
      - points to a directory in which answers will be stored/loaded

--- a/doc/source/tests/pytest_framework.rst
+++ b/doc/source/tests/pytest_framework.rst
@@ -9,8 +9,8 @@ simulation is run with two versions of ``enzo-e`` and their results are compared
 This is useful for testing problems with no analytical solution or generally
 verifying that results from commonly run simulations don't drift.
 
-It is also useful for testing property of simulation runs beyond the exit-time/cycle of the simulation.
-(While such tests do exist in the ctest-framework, they often involve more boiler-plate code).
+It is also useful in for testing problems that do have analytic solutions (the answer test might quantify how close a simulation result is to the analytic expected solution).
+While such tests do exist in the ctest-framework, they often involve more boiler-plate code.
 
 `pytest <https://docs.pytest.org/>`__ is a Python-based framework for detecting
 and running a series of tests within a source code repository. When running
@@ -121,7 +121,8 @@ First, check out the highest numbered gold standard tag and compile ``enzo-e``.
 
 .. code-block:: bash
 
-   $ git checkout gold-standard-1
+   # in the future, you will need to subsitute 004 for a higher number
+   $ git checkout gold-standard-004
    $ ...compile enzo-e
 
 Then, run the test suite by calling ``pytest`` with the answer test directory (make sure to configure behavior correctly with command-line arguments or environment variables).

--- a/test/answer_tests/answer_testing.py
+++ b/test/answer_tests/answer_testing.py
@@ -20,6 +20,7 @@ _base_file = os.path.basename(__file__)
 @dataclass(frozen = True)
 class TestOptions:
     enzoe_driver: EnzoEDriver
+    uses_double_prec: bool
     generate_results: bool
     test_results_dir: str
     grackle_input_data_dir : Optional[str]
@@ -49,6 +50,9 @@ def set_cached_opts(**kwargs):
             "grackle input data dir not found: "
             f"{_CACHED_OPTS.grackle_input_data_dir}")
 
+    yt.mylog.info(
+        f"{_base_file}: use_double = {_CACHED_OPTS.uses_double_prec}")
+
 def cached_opts():
     if _CACHED_OPTS is None:
         raise RuntimeError("set_cached_opts was never called")
@@ -59,7 +63,6 @@ src_path = os.path.abspath(os.path.join(os.path.dirname(__file__), "../.."))
 input_dir = "input"
 
 _grackle_tagged_tests = set()
-_has_grackle = cached_opts().enzoe_driver.query_has_grackle()
 
 def uses_grackle(cls):
     """
@@ -70,14 +73,15 @@ def uses_grackle(cls):
     """
     _grackle_tagged_tests.add(cls.__name__)
 
+    has_grackle = cached_opts().enzoe_driver.query_has_grackle()
     has_grackle_inputs = cached_opts().grackle_input_data_dir is not None
 
     skip_reason = "Enzo-E is not built with Grackle"
-    if _has_grackle and (not has_grackle_inputs):
+    if has_grackle and (not has_grackle_inputs):
         skip_reason = "the grackle input data dir was not specified"
 
     wrapper_factory = pytest.mark.skipif(
-        (not _has_grackle) or (not has_grackle_inputs), reason = skip_reason
+        (not has_grackle) or (not has_grackle_inputs), reason = skip_reason
     )
     return wrapper_factory(cls)
 

--- a/test/answer_tests/answer_testing.py
+++ b/test/answer_tests/answer_testing.py
@@ -1,13 +1,11 @@
 import copy
+from dataclasses import dataclass
 import numpy as np
 import os
 import pytest
 import shutil
-import signal
-import subprocess
-import sys
 import tempfile
-import time
+from typing import Optional
 import yt
 
 from numpy.testing import assert_array_equal
@@ -15,55 +13,50 @@ from unittest import TestCase
 from yt.funcs import ensure_dir
 from yt.testing import assert_rel_equal
 
+from test_utils.enzoe_driver import EnzoEDriver
+
 _base_file = os.path.basename(__file__)
 
-# If GENERATE_TEST_RESULTS="true", just generate test results.
-generate_results = os.environ.get("GENERATE_TEST_RESULTS", "false").lower() == "true"
-yt.mylog.info(f"{_base_file}: generate_results = {generate_results}")
+@dataclass(frozen = True)
+class TestOptions:
+    enzoe_driver: EnzoEDriver
+    generate_results: bool
+    test_results_dir: str
+    grackle_input_data_dir : Optional[str]
 
-_results_dir = os.environ.get("TEST_RESULTS_DIR", "~/enzoe_test_results")
-test_results_dir = os.path.abspath(os.path.expanduser(_results_dir))
-yt.mylog.info(f"{_base_file}: test_results_dir = {test_results_dir}")
-if generate_results:
-    ensure_dir(test_results_dir)
-else:
-    if not os.path.exists(test_results_dir):
+_CACHED_OPTS = None
+
+def set_cached_opts(**kwargs):
+    global _CACHED_OPTS
+    if _CACHED_OPTS is not None:
+        raise RuntimeError("Can't call set_cached_opts more than once")
+
+    _CACHED_OPTS = TestOptions(**kwargs)
+    yt.mylog.info(
+        f"{_base_file}: generate_results = {_CACHED_OPTS.generate_results}")
+
+    yt.mylog.info(
+        f"{_base_file}: test_results_dir = {_CACHED_OPTS.test_results_dir}")
+    if _CACHED_OPTS.generate_results:
+        ensure_dir(_CACHED_OPTS.test_results_dir)
+    elif not os.path.exists(_CACHED_OPTS.test_results_dir):
         raise RuntimeError(
-            f"Test results directory not found: {test_results_dir}.")
+            f"Test results dir not found: {_CACHED_OPTS.test_results_dir}.")
 
-# Set the path to charmrun
-_charm_path = os.environ.get("CHARM_PATH", "")
-if not _charm_path:
-    raise RuntimeError(
-        f"Specify path to charm with CHARM_PATH environment variable.")
-charmrun_path = os.path.join(_charm_path, "charmrun")
-yt.mylog.info(f"{_base_file}: charmrun_path = {charmrun_path}")
-if not os.path.exists(charmrun_path):
-    raise RuntimeError(
-        f"No charmrun executable found in {_charm_path}.")
+    if ((_CACHED_OPTS.grackle_input_data_dir is not None) and
+        (not os.path.exists(_CACHED_OPTS.grackle_input_data_dir))):
+        raise RuntimeError(
+            "grackle input data dir not found: "
+            f"{_CACHED_OPTS.grackle_input_data_dir}")
+
+def cached_opts():
+    if _CACHED_OPTS is None:
+        raise RuntimeError("set_cached_opts was never called")
+    return _CACHED_OPTS
 
 src_path = os.path.abspath(os.path.join(os.path.dirname(__file__), "../.."))
 
-# Set the path to the enzo-e binary
-_enzo_path = os.environ.get("ENZO_PATH", "")
-if _enzo_path:
-    enzo_path = os.path.abspath(_enzo_path)
-else:
-    enzo_path = os.path.join(src_path, "build/bin/enzo-e")
-yt.mylog.info(f"{_base_file}: enzo_path = {enzo_path}")
-if not os.path.exists(enzo_path):
-    raise RuntimeError(
-        f"No enzo-e executable found in {enzo_path}.")
-
 input_dir = "input"
-
-# check for data path to grackle
-_grackle_input_data_dir = os.environ.get("GRACKLE_INPUT_DATA_DIR", None)
-if ((_grackle_input_data_dir is not None) and
-    (not os.path.exists(_grackle_input_data_dir))):
-    raise RuntimeError("GRACKLE_INPUT_DATA_DIR points to a non-existent "
-                       f"directory: {_grackle_input_data_dir}")
-
 
 _grackle_tagged_tests = set()
 
@@ -77,7 +70,7 @@ def uses_grackle(cls):
     _grackle_tagged_tests.add(cls.__name__)
 
     wrapper_factory = pytest.mark.skipif(
-        _grackle_input_data_dir is None,
+        cached_opts().grackle_input_data_dir is None,
         reason = "GRACKLE_INPUT_DATA_DIR is not defined"
     )
     return wrapper_factory(cls)
@@ -94,32 +87,11 @@ class EnzoETest(TestCase):
 
         if self.__class__.__name__ in _grackle_tagged_tests:
             # make symlinks to each grackle input file
-            with os.scandir(_grackle_input_data_dir) as it:
+            with os.scandir(cached_opts().grackle_input_data_dir) as it:
                 for entry in it:
                     if not entry.is_file():
                         continue
                     os.symlink(entry.path,os.path.join(self.tmpdir, entry.name))
-
-    def run_simulation(self):
-        pfile = os.path.join(input_dir, self.parameter_file)
-        command = f"{charmrun_path} ++local +p{self.ncpus} {enzo_path} {pfile}"
-        proc = subprocess.Popen(
-            command, shell=True, close_fds=True,
-            preexec_fn=os.setsid)
-
-        stime = time.time()
-        while proc.poll() is None:
-            if time.time() - stime > self.max_runtime:
-                os.killpg(proc.pid, signal.SIGUSR1)
-                raise RuntimeError(
-                    f"Simulation {self.__class__.__name__} exceeded max runtime of "
-                    f"{self.max_runtime} seconds.")
-            time.sleep(1)
-
-        if proc.returncode != 0:
-            raise RuntimeError(
-                f"Simulation {self.__class__.__name__} exited with nonzero return "
-                f"code {proc.returncode}.")
 
     def setUp(self):
         self.curdir = os.getcwd()
@@ -127,7 +99,10 @@ class EnzoETest(TestCase):
 
         self.setup_symlinks()
         os.chdir(self.tmpdir)
-        self.run_simulation()
+        cached_opts().enzoe_driver.run(
+            parameter_fname = os.path.join(input_dir, self.parameter_file),
+            max_runtime = self.max_runtime, ncpus = self.ncpus,
+            sim_name = f"Simulation {self.__class__.__name__}")
 
     def tearDown(self):
         os.chdir(self.curdir)
@@ -145,10 +120,11 @@ def ytdataset_test(compare_func, **kwargs):
         def wrapper(*args):
             # name the file after the function
             filename = "%s.h5" % func.__name__
-            result_filename = os.path.join(test_results_dir, filename)
+            result_filename = os.path.join(cached_opts().test_results_dir,
+                                           filename)
 
             # check that answers exist
-            if not generate_results:
+            if not cached_opts().generate_results:
                 assert os.path.exists(result_filename), \
                   "Result file, %s, not found!" % result_filename
 
@@ -156,7 +132,7 @@ def ytdataset_test(compare_func, **kwargs):
             fn = yt.save_as_dataset({}, filename=filename, data=data)
 
             # if generating, move files to results dir
-            if generate_results:
+            if cached_opts().generate_results:
                 shutil.move(filename, result_filename)
             # if comparing, run the comparison
             else:

--- a/test/answer_tests/answer_testing.py
+++ b/test/answer_tests/answer_testing.py
@@ -59,6 +59,7 @@ src_path = os.path.abspath(os.path.join(os.path.dirname(__file__), "../.."))
 input_dir = "input"
 
 _grackle_tagged_tests = set()
+_has_grackle = cached_opts().enzoe_driver.query_has_grackle()
 
 def uses_grackle(cls):
     """
@@ -69,9 +70,14 @@ def uses_grackle(cls):
     """
     _grackle_tagged_tests.add(cls.__name__)
 
+    has_grackle_inputs = cached_opts().grackle_input_data_dir is not None
+
+    skip_reason = "Enzo-E is not built with Grackle"
+    if _has_grackle and (not has_grackle_inputs):
+        skip_reason = "the grackle input data dir was not specified"
+
     wrapper_factory = pytest.mark.skipif(
-        cached_opts().grackle_input_data_dir is None,
-        reason = "GRACKLE_INPUT_DATA_DIR is not defined"
+        (not _has_grackle) or (not has_grackle_inputs), reason = skip_reason
     )
     return wrapper_factory(cls)
 

--- a/test/answer_tests/conftest.py
+++ b/test/answer_tests/conftest.py
@@ -1,5 +1,6 @@
 import os
 import os.path
+import sys
 
 import pytest
 
@@ -61,6 +62,8 @@ def _to_abs_path(path):
 
 # this hook gets executed after pytest finishes parsing all of the config opts
 def pytest_configure(config):
+    if "--help" in sys.argv[1:]:
+        return
 
     # first, collect values from the command line
     vals = {}
@@ -72,7 +75,7 @@ def pytest_configure(config):
                 raise RuntimeError(f"{arg_flag} or {env_var} must be set")
             else:
                 val = fallback
-        else:
+        elif val is None:
             val = os.environ.get(env_var)
         vals[arg_name] = val
 
@@ -91,6 +94,7 @@ def pytest_configure(config):
 
     set_cached_opts(
         enzoe_driver = enzoe_driver,
+        uses_double_prec = enzoe_driver.query_uses_double_precision(),
         generate_results = vals['answer_store'],
         test_results_dir = _to_abs_path(vals['local_dir']),
         grackle_input_data_dir = _to_abs_path(vals['grackle_input_data_dir'])

--- a/test/answer_tests/conftest.py
+++ b/test/answer_tests/conftest.py
@@ -1,41 +1,55 @@
 from collections import namedtuple
+from dataclasses import asdict
 import os
 import os.path
 import sys
 
 import pytest
 
-from answer_testing import set_cached_opts
+from answer_testing import set_cached_opts, cached_opts
 from test_utils.enzoe_driver import EnzoEDriver
+from test_utils.parse_cmake_cache import parse_cmake_cache
 
-_root_dir = os.path.abspath(os.path.join(os.path.dirname(__file__), "../.."))
-
-# each entry in the following list specifies a command-line options that
-# fall-back to an environment variable.
-_ConfigParam = namedtuple(
-    "_ConfigParam", ["flag", "env_var", "default", "help",
-                     "other_argparse_kwargs"])
-_CONFIG_OPTIONS = [
-    _ConfigParam(
-        flag = "--charm", env_var = "CHARM_PATH",
+# all cmd flags that fall-back to an environment variable are listed below
+_ConfigParam = namedtuple("_ConfigParam", ["env_var", "default", "help",
+                                           "other_argparse_kwargs",
+                                           "coerce_env_val"])
+_CONFIG_OPTIONS = {
+    '--charm' : _ConfigParam(
+        env_var = "CHARM_PATH",
         default = None,
         help = ("path to charmrun binary that is used to execute enzo-e or "
-                  "to the directory holding that binary."),
-        other_argparse_kwargs = dict(action = "store")
+                "to the directory holding that binary."),
+        other_argparse_kwargs = dict(action = "store"),
+        coerce_env_val = lambda s: s
     ),
-    _ConfigParam(
-        flag = "--local-dir", env_var = "TEST_RESULTS_DIR",
+    "--local-dir" : _ConfigParam(
+        env_var = "TEST_RESULTS_DIR",
         default = "~/enzoe_test_results",
         help = "Path to directory where answers are/will be stored.",
-        other_argparse_kwargs = dict(action = "store")
+        other_argparse_kwargs = dict(action = "store"),
+        coerce_env_val = lambda s: s
     ),
-    _ConfigParam(
-        flag = "--grackle-input-data-dir", env_var = "GRACKLE_INPUT_DATA_DIR",
-        default = "~/enzoe_test_results",
+    "--grackle-input-data-dir" : _ConfigParam(
+        env_var = "GRACKLE_INPUT_DATA_DIR",
+        default = None,
         help = "Path to directory of grackle input data files.",
-        other_argparse_kwargs = dict(action = "store")
+        other_argparse_kwargs = dict(action = "store"),
+        coerce_env_val = lambda s: s
+    ),
+    # it's important that the following is store_const instead of store_true
+    # (so that we can force argparse value default to None)
+    "--answer-store" : _ConfigParam(
+        env_var = "GENERATE_TEST_RESULTS",
+        default = False,
+        help = "Indicates whether to generate test results.",
+        other_argparse_kwargs = dict(action = "store_const", const = True),
+        coerce_env_val = lambda s: s.lower() == "true"
     )
-]
+}
+
+
+_root_dir = os.path.abspath(os.path.join(os.path.dirname(__file__), "../.."))
 
 
 # this hook is used to add more command line flags to the pytest launcher
@@ -43,80 +57,102 @@ def pytest_addoption(parser):
 
     # add ordinary flags (NOT backed by an environment variable)
 
-    # in the past, this could be set by the ENZO_PATH environment variable,
-    # but this wasn't used by CI
-    parser.addoption("--enzoe", action = 'store',
-                     default = os.path.join(_root_dir, "build/bin/enzo-e"),
-                     help = ("path to the enzo-e binary that will be tested. "
-                             "Default is <ROOT_DIR>/build/bin/enzo-e"))
+    # in the future, it would probably be more ergonomic to assume that the
+    # current working directory is the enzo-e build directory when this flag is
+    # not specified (and we may want to try parsing CMakeCache.txt)
+    parser.addoption(
+        "--build-dir", action = 'store', default = None,
+        help = ("points to the build-directory where the target enzo-e binary "
+                "was built (that binary has the path: BUILD_DIR/bin/enzo-e). "
+                "The path to the charmrun launcher will be inferred from the "
+                "BUILD_DIR/CMakeCache.txt file, but can be overwritten by the "
+                "--charm flag or the CHARM_PATH environment variable. Be "
+                "aware that problems can theoretically arise if you do "
+                "something to alter the build system's state after a build "
+                "without rebuilding enzo-e (CMakeCache.txt may no longer be "
+                "valid for the binary). When this flag isn't specified, the "
+                "test-driver assumes that the enzo-e binary is located at "
+                f"{_root_dir}/build/bin/enzo-e, but does not try to infer "
+                "charmrun's location from CMakeCache.txt.")
+    )
 
 
     # introduce flags that fall back to values specified in an env variable
-    # -> the main reason these flags exist is for backwards compatability
-    def _argparse_kwargs(other_kw, help, env_var):
-        _ERR_PREFIX = ()
-        if other_kw.get('action', 'store') in ['store_true', 'store_false']:
+    # (these flags primarily exist for backwards compatability)
+    for flag, par in _CONFIG_OPTIONS.items():
+        kwargs = par.other_argparse_kwargs.copy() # don't mutate the original
+        kwargs["help"] = (f"{par.help} If not specified, the program tries to "
+                          f"use the value set by {par.env_var}")
+        kwargs["default"] = None
+        if kwargs.get('action', 'store') in ['store_true', 'store_false']:
             raise RuntimeError(
                 "for a flag backed by an environment variable, the argparse "
-                "kwargs can't set 'action' to 'store_true' or 'store_false'. "
-                "These flags must default to None")
-
-        kwargs = other_kw.copy() # don't mutate the original
-        kwargs["help"] = (f"{help} If not specified, the program tries to "
-                          f"use the value set by {env_var}")
-        kwargs["default"] = None
-        return kwargs
-
-    for param in _CONFIG_OPTIONS:
-        parser.addoption(param.flag,
-                         **_argparse_kwargs(param.other_argparse_kwargs,
-                                            param.help, param.env_var))
-
-    parser.addoption(
-        "--answer-store",
-        **_argparse_kwargs({'action' : "store_const", 'const' : True},
-                           help="Indicates whether to generate test results.",
-                           env_var = "GENERATE_TEST_RESULTS"))
+                "kwargs can't set 'action' to 'store_true' or 'store_false'.")
+        parser.addoption(flag, **kwargs)
 
 
 def _to_abs_path(path):
+    if path is None:
+        return None
     return os.path.abspath(os.path.expanduser(path))
 
 
 # this hook gets executed after pytest finishes parsing all of the config opts
 def pytest_configure(config):
+    # inspect/parse parameters and initialize the globally cached options
+
+    # step 1: early exit if --help was passed
     if "--help" in sys.argv[1:]:
         return
 
-    # first, collect values from the command line
-    vals = {'enzoe' : config.getoption('--enzoe')}
+    # step 2: fetch the parameters that are backed by environment variables
+    vals = {}
+    for flag, par in _CONFIG_OPTIONS.items(): 
+        arg_name = flag.lstrip('-').replace('-', '_')
+        if config.getoption(arg_name) is not None:
+            vals[arg_name] = config.getoption(arg_name)
+        elif os.environ.get(par.env_var, None) is not None:
+            vals[arg_name] = par.coerce_env_val(os.environ.get(par.env_var))
+        else:
+            vals[arg_name] = par.default
+    
+    # step 3: initialize the enzo-e driver
+    build_dir = _to_abs_path(config.getoption("build_dir"))
 
-    for par in _CONFIG_OPTIONS: 
-        arg_name = par.flag.lstrip('-').replace('-', '_')
-        val = config.getoption(arg_name)
-        if (val is None) and (os.environ.get(par.env_var, None) is None):
-            if par.default is None:
-                raise RuntimeError(
-                    f"{par.arg_flag} or {par.env_var} must be set")
-            else:
-                val = par.default
-        elif val is None:
-            val = os.environ.get(par.env_var)
-        vals[arg_name] = val
-
-    if config.getoption('answer_store') is None:
-        vals['answer_store'] = os.environ.get(
-            "GENERATE_TEST_RESULTS", "false").lower() == "true"
+    # step 3a: determine the path to the enzo-e binary
+    if build_dir is not None:
+        enzoe_path = os.path.join(build_dir, 'bin/enzo-e')
+        if not os.path.isfile(enzoe_path):
+            raise RuntimeError(f"enzo-e isn't at {enzoe_path}.")
     else:
-        vals['answer_store'] = config.getoption('answer_store')
+        enzoe_path = os.path.join(_root_dir, 'build/bin/enzo-e')
+        if not os.path.isfile(enzoe_path):
+            raise RuntimeError(f"enzo-e isn't at {enzoe_path}. If the it is "
+                               "located elsewherer use --build-dir.")
 
-    # now, lets initialize the enzo-e driver
-    charmrun_path = _to_abs_path(vals['charm'])
-    if os.path.basename(charmrun_path) != "charmrun":
-        charmrun_path = os.path.join(charmrun_path, 'charmrun')
-    enzoe_driver = EnzoEDriver(enzoe_path = _to_abs_path(vals['enzoe']),
+    # step 3b: determine the path to charmrun
+    if (vals['charm'] is None) and (build_dir is None):
+        raise RuntimeError("Please specify --charm or set CHARM_PATH when "
+                           "--build-dir isn't specified")
+    elif vals['charm'] is None:
+        # this approach may be brittle (which is why we give --charm priority)
+        # - if it is brittle, we could have cmake directly spit out a JSON file 
+        #   with the desired info as part of the build 
+        _cache = parse_cmake_cache(os.path.join(build_dir, "CMakeCache.txt"))
+        if ("CHARM_RUN" not in _cache) or (_cache["CHARM_RUN"] == ''):
+            raise RuntimeError("did the buildsystem change? CHARM_RUN was not "
+                               "cached or it was assigned an empty string")
+        charmrun_path = _cache["CHARM_RUN"]
+    else:
+        charmrun_path = _to_abs_path(vals['charm'])
+        if os.path.basename(charmrun_path) != "charmrun":
+            charmrun_path = os.path.join(charmrun_path, 'charmrun')
+
+    # Step 3c: initialize EnzoEDriver
+    enzoe_driver = EnzoEDriver(enzoe_path = enzoe_path,
                                charmrun_path = charmrun_path)
 
+    # Step 4: initialize the cached options
     set_cached_opts(
         enzoe_driver = enzoe_driver,
         uses_double_prec = enzoe_driver.query_uses_double_precision(),
@@ -124,3 +160,25 @@ def pytest_configure(config):
         test_results_dir = _to_abs_path(vals['local_dir']),
         grackle_input_data_dir = _to_abs_path(vals['grackle_input_data_dir'])
     )
+
+
+# hook for printing information at the top of the test report
+def pytest_report_header(config):
+    opts = cached_opts()
+
+    def format_kv_pairs(prefix, pairs):
+        blank_prefix = ' ' * len(prefix)
+        for i, (k,v) in enumerate(pairs):
+            if i == 0:
+                yield f'{prefix}{k} = {v}'
+            else:
+                yield f'{blank_prefix}{k} = {v}'
+
+    part1 = list(format_kv_pairs("enzoe_driver:     ",
+                                 asdict(opts.enzoe_driver).items()))
+    part2 = list(format_kv_pairs(
+        "other properties: ",
+        filter(lambda pair: pair[0] != "enzoe_driver", asdict(opts).items())
+    ))
+
+    return part1 + part2

--- a/test/answer_tests/conftest.py
+++ b/test/answer_tests/conftest.py
@@ -1,0 +1,97 @@
+import os
+import os.path
+
+import pytest
+
+from answer_testing import set_cached_opts
+from test_utils.enzoe_driver import EnzoEDriver
+
+# each entry in this list is a tuple with the following format:
+# (name or flags -- to be passed to argparse.add_arguments,
+#  kwargs to pass to argparse.add_arguments,
+#  fallback-env-variable,
+#  fallback_value -- when neither the flag nor env-var is provided)
+_CONFIG_OPTIONS = [
+    ('--enzoe',
+     dict(action = "store", default = None,
+          help = "path to the enzo-e binary that will be tested."),
+     "ENZO_PATH", "build/bin/enzo-e"),
+
+    ("--charm",
+     dict(action="store", default = None,
+          help = ("path to charmrun binary that is used to execute enzo-e or "
+                  "to the directory holding that binary.")),
+     "CHARM_PATH", None),
+
+    ("--local-dir",
+     dict(action="store", default = None,
+          help = "Path to directory where answers are/will be stored."),
+     "TEST_RESULTS_DIR", "~/enzoe_test_results"),
+
+    ("--grackle-input-data-dir",
+     dict(action="store", default = None,
+          help = "Path to directory of grackle input data files."),
+     "GRACKLE_INPUT_DATA_DIR", None),
+]
+
+
+# this hook is used to add more tests to the pytest launcher
+def pytest_addoption(parser):
+
+    def _fallback_help_clause(env_var):
+        return ("If not specified, the program tries to use the value set by "
+                f"the {env_var} environment variable (if specified)")
+
+    for arg_flag, kwargs, env_var, _ in _CONFIG_OPTIONS:
+        tmp = kwargs.copy()
+        tmp["help"] += " " + _fallback_help_clause(env_var)
+        parser.addoption(arg_flag, **tmp)
+
+    parser.addoption(
+        "--answer-store", action="store_const",
+        default = None, const = True,
+        help = ("Indicates whether to generate test results. " +
+                _fallback_help_clause("GENERATE_TEST_RESULTS"))
+    )
+
+
+def _to_abs_path(path):
+    return os.path.abspath(os.path.expanduser(path))
+
+
+# this hook gets executed after pytest finishes parsing all of the config opts
+def pytest_configure(config):
+
+    # first, collect values from the command line
+    vals = {}
+    for arg_flag, _, env_var, fallback in _CONFIG_OPTIONS:
+        arg_name = arg_flag.lstrip('-').replace('-', '_')
+        val = config.getoption(arg_name)
+        if (val is None) and (os.environ.get(env_var, None) is None):
+            if fallback is None:
+                raise RuntimeError(f"{arg_flag} or {env_var} must be set")
+            else:
+                val = fallback
+        else:
+            val = os.environ.get(env_var)
+        vals[arg_name] = val
+
+    if config.getoption('answer_store') is None:
+        vals['answer_store'] = os.environ.get(
+            "GENERATE_TEST_RESULTS", "false").lower() == "true"
+    else:
+        vals['answer_store'] = config.getoption('answer_store')
+
+    # now, lets initialize the enzo-e driver
+    charmrun_path = _to_abs_path(vals['charm'])
+    if os.path.basename(charmrun_path) != "charmrun":
+        charmrun_path = os.path.join(charmrun_path, 'charmrun')
+    enzoe_driver = EnzoEDriver(enzoe_path = _to_abs_path(vals['enzoe']),
+                               charmrun_path = charmrun_path)
+
+    set_cached_opts(
+        enzoe_driver = enzoe_driver,
+        generate_results = vals['answer_store'],
+        test_results_dir = _to_abs_path(vals['local_dir']),
+        grackle_input_data_dir = _to_abs_path(vals['grackle_input_data_dir'])
+    )

--- a/test/answer_tests/test_cosmo.py
+++ b/test/answer_tests/test_cosmo.py
@@ -5,14 +5,11 @@ from answer_testing import \
     EnzoETest, \
     ytdataset_test, \
     assert_array_rel_equal, \
-    uses_grackle
-
-_base_file = os.path.basename(__file__)
+    uses_grackle, \
+    cached_opts
 
 # Set test tolerance based on compile precision
-use_double = os.environ.get("USE_DOUBLE", "false").lower() == "true"
-yt.mylog.info(f"{_base_file}: use_double = {use_double}")
-if use_double:
+if cached_opts().uses_double_prec:
     decimals = 12
 else:
     decimals = 6

--- a/test/answer_tests/test_grackle.py
+++ b/test/answer_tests/test_grackle.py
@@ -6,13 +6,11 @@ from answer_testing import \
     EnzoETest, \
     ytdataset_test, \
     assert_array_rel_equal, \
-    uses_grackle
-
-_base_file = os.path.basename(__file__)
+    uses_grackle, \
+    cached_opts
 
 # Set test tolerance based on compile precision
-use_double = os.environ.get("USE_DOUBLE", "false").lower() == "true"
-yt.mylog.info(f"{_base_file}: use_double = {use_double}")
+use_double = cached_opts().uses_double_prec
 if use_double:
     decimals = 12
 else:

--- a/test/answer_tests/test_utils/README.md
+++ b/test/answer_tests/test_utils/README.md
@@ -1,0 +1,10 @@
+This directory exists as a centralized location for defining functionallity, implemented in python that may be useful for implementing tests of Enzo-E and implementing tools provided in the root-directory.
+
+To make use of code in this directory from the ``answer_tests`` subdirectory, you can simply import things as you would with any python module.
+
+From other parts of the codebase, you will need to add code like the following before you try importing anything:
+
+    ```python
+    import sys
+    sys.path.append('path/to/test_utils')
+    ```

--- a/test/answer_tests/test_utils/enzoe_driver.py
+++ b/test/answer_tests/test_utils/enzoe_driver.py
@@ -190,7 +190,7 @@ class EnzoEDriver:
                     f"{proc.returncode}.")
         return elapsed
 
-    def query_precision(self):
+    def query_uses_double_precision(self):
         # we need to pass ++quiet to prevent charm++'s diagnostic messages from
         # clogging things up
         if self.charmrun_path is None:
@@ -198,8 +198,15 @@ class EnzoEDriver:
         else:
             command = (f"{self.charmrun_path} ++local +p1 ++quiet " +
                        f"{self.enzoe_path} -precision")
-        return subprocess.run(command, shell = True,
-                              capture_output=True).stdout
+
+        rslt = subprocess.run(command, shell = True,
+                              capture_output=True).stdout.rstrip()
+        if rslt == b'double':
+            return True
+        elif rslt == b'single':
+            return False
+        else:
+            raise RuntimeError(f"Something went horribly wrong: {rslt}")
 
     def query_has_grackle(self):
         if self.charmrun_path is None:

--- a/test/answer_tests/test_utils/enzoe_driver.py
+++ b/test/answer_tests/test_utils/enzoe_driver.py
@@ -199,3 +199,8 @@ def create_symlinks(dst_dir, src_l):
         dst = os.path.join(abs_dst_dir, os.path.basename(src))
         assert not os.path.exists(dst)
         os.symlink(src, dst)
+
+def create_enzoe_driver_from_args():
+    pass
+
+

--- a/test/answer_tests/test_utils/enzoe_driver.py
+++ b/test/answer_tests/test_utils/enzoe_driver.py
@@ -1,0 +1,201 @@
+import contextlib
+from dataclasses import dataclass
+import os
+import os.path
+import signal
+import subprocess
+import time
+from typing import Optional
+
+def _effective_parameter_fname(run_dir, parameter_fname, extra_options = []):
+    """
+    This assists with tweaking the parameters used by an existing file.
+
+    This is inspired by athena++. In the future we should allow enzo-e to
+    directly mutate the parameter values by letting us pass extra_options as
+    command line arguments. Instead, for the moment we just create a new 
+    parameter file with the updated values.
+
+    Parameters
+    ----------
+    run_dir: str
+        Path to the directory where enzo-e will be executed
+    parameter_fname: str
+        Path to the nominal parameter file
+    extra_options: list[str]
+        Each element is a key-value pair
+
+    Returns
+    -------
+    out: str
+        Returns the name of the newly created parameter file should be used to
+        run the simulation. If a new file is created, it's called 
+        f'{run_dir}/parameters.in'
+    """
+    if len(extra_options) == 0:
+        return os.path.abspath(parameter_fname)
+
+    new_parameter_fname = os.path.join(os.path.abspath(run_dir),
+                                       'parameters.in')
+    with open(new_parameter_fname,'w') as f:
+        f.write('# This file was automatically generated\n\n')
+        f.write(f'include "{os.path.abspath(parameter_fname)}"\n')
+        for elem in extra_options:
+            if '=' not in elem:
+                raise RuntimeError(f"'{elem}' can't be used as an option. It "
+                                   "doesn't have a '=' character")
+            param_name, value = elem.split('=', maxsplit=1)
+
+            separator = '='
+            if param_name[-1] == '+':
+                separator = '+='
+                param_name = param_name[:-1]
+
+            name_parts = param_name.split(':')
+            assert all(len(part) > 0 for part in name_parts)
+
+            f.write(
+                '{ '.join(name_parts) +
+                f' {separator} {value};' +
+                (' }' * (len(name_parts) - 1))
+                + '\n'
+            )
+    return new_parameter_fname
+
+@dataclass(frozen = True)
+class EnzoEDriver:
+    """
+    Wraps the Enzo-E binary. This can be used to execute Enzo-E from an 
+    arbitrary directory.
+
+    Parameters
+    ----------
+    enzoe_path: string
+        Path to the enzo-e binary.
+    charmrun_path: string, optional
+        Path to the charmrun binary. If this is not specified, the simulation 
+        can't be run in parallel.
+    """
+
+    enzoe_path: str
+    # charmrun_path should probably be a little more generic. Historically, on
+    # clusters when charm++ is built atop MPI, we need to use mpi launcher
+    charmrun_path: Optional[str] = None
+
+    def __post_init__(self):
+
+        # check invariants!
+        def _check_path(var_name, val):
+            if not os.path.isabs(val):
+                raise ValueError(f"{var_name} was assigned {val}, which isn't "
+                                 "an absolute path")
+            elif not os.path.isfile(val):
+                raise ValueError(f"the path assigned to {var_name}, {val}, "
+                                 "doesn't point to a file")
+
+        _check_path('enzoe_path', self.enzoe_path)
+        if self.charmrun_path is not None:
+            _check_path('charmrun_path', self.charmrun_path)
+
+    def run(self, parameter_fname, max_runtime = float('inf'), ncpus = 1,
+            sim_name = None, cwd = None, extra_options = [],
+            buffer_outputs_on_disk = False):
+        """
+        Run the Enzo-E simulation
+
+        Parameters
+        ----------
+        parameter_fname: str
+        max_runtime: float, Default: float('inf')
+        ncpus: int, Default: 1
+        sim_name: str, Default: None
+        cwd: str, Default: None
+            Forwarded to the `subprocess.Popen` constructor. This overrides the
+            current working directory
+        extra_options: list of strs, Default: []
+            List of extra options to use in the simulations (these can
+            overwrite values in the parameter file
+        buffer_outputs_on_disk: bool, Default: False
+            When True, the simulation's stdout and stderr are piped to 
+            {prefix}/log.out and {prefix}/log.err, respectively, where prefix
+            is replaced with cwd (or '.' if cwd is None). If the simulation
+            fails, these are forwarded to stdout and stderr, respectively.
+        Returns
+        -------
+        elapsed: float 
+            The elapsed times in seconds
+        """
+
+        if len(extra_options) > 0:
+            parameter_fname = _effective_parameter_fname(
+                run_dir = cwd if cwd is not None else './',
+                parameter_fname = parameter_fname,
+                extra_options = extra_options)
+
+        # build the enzo-e part of the command
+        # TODO: add support for extra options
+        enzoe_command = f"{self.enzoe_path} {parameter_fname}"
+
+        if self.charmrun_path is None:
+            if ncpus > 1:
+                raise ValueError(
+                    "Can't use more than 1 CPU when charmrun is not provided"
+                )
+            command = enzoe_command
+        else:
+            if os.path.basename(self.charmrun_path) == 'charmrun':
+                command = (
+                    f"{self.charmrun_path} ++local +p{ncpus} {enzoe_command}")
+            else:
+                raise ValueError("Not currently equipped to handle a launcher "
+                                 "other than charmrun")
+
+        if sim_name is None:
+            sim_name = 'Simulation'
+
+        with contextlib.ExitStack() as stack:
+            if buffer_outputs_on_disk:
+                _log_prefix = '%s/log.' % ('.' if cwd is None else cwd)
+                f_err, f_out = [
+                    stack.enter_context(open(_log_prefix + suffix, 'w'))
+                    for suffix in ('err', 'out')]
+            else:
+                f_err, f_out = None, None
+
+            proc = subprocess.Popen(
+                command, shell = True, close_fds = True,
+                preexec_fn = os.setsid,
+                cwd = cwd, stderr = f_err, stdout = f_out)
+
+            stime = time.time()
+            while proc.poll() is None:
+                if ((time.time() - stime) > max_runtime):
+                    os.killpg(proc.pid, signal.SIGUSR1)
+                    raise RuntimeError(
+                        f"{sim_name} exceeded max runtime of {max_runtime} "
+                        "seconds.")
+                time.sleep(1)
+            elapsed = time.time() - stime
+
+            if proc.returncode != 0:
+                print("Dumping logs:")
+
+                
+                raise RuntimeError(
+                    f"{sim_name} exited with nonzero return code "
+                    f"{proc.returncode}.")
+        return elapsed
+
+def create_symlinks(dst_dir, src_l):
+    """
+    Create a symlink for each item in src_l
+
+    Notes
+    -----
+    This is commonly used when setting up an Enzo-E simulation
+    """
+    abs_dst_dir = os.path.abspath(dst_dir)
+    for src in map(lambda e: os.path.abspath(src), src_l):
+        dst = os.path.join(abs_dst_dir, os.path.basename(src))
+        assert not os.path.exists(dst)
+        os.symlink(src, dst)

--- a/test/answer_tests/test_utils/parse_cmake_cache.py
+++ b/test/answer_tests/test_utils/parse_cmake_cache.py
@@ -1,0 +1,47 @@
+import re
+_MATCHER = re.compile(r"^(?P<key>.*):(?P<type>.*)=(?P<value>.*)")
+
+def parse_cmake_cache(path):
+    out = {}
+    with open(path, 'r') as f:
+        for line in f:
+            if (line.isspace() or (line[:1] == '#') or (line[:2] == '//')):
+                # blank line    or  comment          or  docstring
+                continue
+
+            match = _MATCHER.match(line.rstrip())
+            if match is None:
+                raise RuntimeError(
+                    "Something went wrong while parsing the following line "
+                    f"of '{path}': {line!r}. Lines that aren't blank and "
+                    "don't begin with '#' or '//' are expected to follow the "
+                    "structure: 'KEY:TYPE=VALUE'")
+
+            # a line consists of 3 parts: KEY:TYPE=VALUE
+
+            # 1. the key value:
+            # - it's allowed to be an empty string
+            # - when a key contains a colon, it must be enclosed in quotes
+            # - it seems the quotes are part of the key name in all other cases
+            key = match.group("key")
+            if ':' in key:
+                assert key[0] == key[-1] == '"'
+                key = key[1:-1]
+
+            # 2. get the type:
+            # this is used by cmake-gui to help with formatting.
+            # Allowed values include:
+            #    - BOOL (NOTE: THIS IS HARD TO COERCE!)
+            #    - STRING
+            #    - FILEPATH
+            #    - PATH
+            #    - UNINITIALIZED (a variable defined on the command line)
+            #    - STATIC (this seems to be a non-configurable value generated)
+            #    - INTERNAL
+            # we will ignore this for now
+
+            # 3. get the value (it's allowed to be empty)
+            value = match.group("value")
+
+            out[key] = value
+    return out

--- a/test/answer_tests/test_vlct.py
+++ b/test/answer_tests/test_vlct.py
@@ -4,14 +4,11 @@ import yt
 from answer_testing import \
     EnzoETest, \
     ytdataset_test, \
-    assert_array_rel_equal
-
-_base_file = os.path.basename(__file__)
+    assert_array_rel_equal, \
+    cached_opts
 
 # Set test tolerance based on compile precision
-use_double = os.environ.get("USE_DOUBLE", "false").lower() == "true"
-yt.mylog.info(f"{_base_file}: use_double = {use_double}")
-if use_double:
+if cached_opts().uses_double_prec:
     decimals = 12
 else:
     decimals = 6


### PR DESCRIPTION
This PR introduces a number of small changes that should make the pytest machinery easier to use, particularly when you are switching between multiple branches.

These changes include:
1. Introducing the ability to configure machinery by passing command-line arguments in addition to setting environment variables. Below I list new command-line arguments with their env variable counterparts (when both counterparts are set, the command-line flags have priority):
    - `--charm` and `CHARM_PATH`
    - `--grackle-input-data-dir` and `GRACKLE_INPUT_DATA_DIR`
    - `--local-dir` and `TEST_RESULTS_DIR` (the command line flag borrows the name that `yt` uses)
    - `--answer-store` and `GENERATE_TEST_RESULTS` (the command line flag borrows the name that `yt` uses)
2. I introduced the new flag called `--build-dir` which you can use to specify the directory where the target Enzo-E binary was built. If `--charm` and `CHARM_PATH` are not specified, then the test program will infer the appropriate location of the `charmrun` executable based on the contents of `CMakeCache.txt`.
3. I added the ability for the testing infrastructure to directly query what the compiled-precision is (obviating the need for the `USE_DOUBLE` environment variable), and querying whether the executable was built with Grackle (tests no longer fail problem if `GRACKLE_INPUT_DATA_DIR` is set and enzo-e was compiled without Grackle - those tests are now skipped).

As an aside, I completely removed the `ENZO_PATH` variable as it's no longer necessary (and I'm pretty sure that I'm the only person to use it). Everything else should be fully backwards-compatible.

-----

With these changes, it's much easier to invoke the pytest machinery while moving between different branches that are built in different build directories (and may depend on different versions of charm++).

For example, if I have the build-directories
- `build-intel-impi`
- `build-gcc-openmpi`

I can invoke `pytest` from the root directory with:
- ``pytest test/answer_test --build-dir ./build-intel-impi --local-dir ~/enzoe-gs-intel``
- ``pytest test/answer_test --build-dir ./build-gcc-openmpi --local-dir ~/enzoe-gs-gcc``

While this is verbose, I would have previously needed to be sure to update the `ENZO_PATH`, `CHARM_PATH`, and `TEST_RESULTS_DIR` environment variables. I might also need to adjust `GRACKLE_INPUT_DATA_DIR` or `USE_DOUBLE` if one of these builds was compiled with/without grackle or with a different precision. 

Additional improvements could potentially be made. For example, it may be sensible for `pytest` to assume that it is invoked from a build-directory when it is invoked without `--build-dir` (unless it is invoked from the root directory). But, that's a topic for another day.

----

In the course of this PR, I refactored the functionality for executing an `enzo-e` simulation into a class called `EnzoEDriver` and moved it into a new `test_utils` sub-directory.

- Currently there are a bunch of wrappers for executing `enzo-e` floating around the repository. The idea was to provide a single centralized implementation that other python code can call into. While most of these other wrappers occur in test code that should eventually be integrated into the pytest, I expect it may still be useful to have this centralized wrapper.

- In any case, it was important to factor out the enzo-e wrapper from the rest of the answer-testing machinery. This will be important for new checkpoint-restart tests that I'm adding to the pytest machinery, which are nearly ready for review.

- Along the way, I also added the ability to allow the enzo-e wrapper to easily modify the parameters used in the simulation. This was inspired by what athena++ does and greatly simplifies the code for forthcoming checkpoint-restart tests and convergence tests. (Note: modifying the parameters currently happens outside of the enzo-e binary, by creating a new parameter file)


**EDIT:** Reviewing this PR is important because it is a dependency of PR #324, which should be a high priority