### PR TITLE
Speed up CI: Modify CMake files to skip unit-test binaries when `BUILD_TESTING` option is `OFF`

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -112,6 +112,10 @@ commands:
       usegrackle:
         type: boolean
         default: true
+      setupCTests:
+        type: boolean
+        default: true
+        description: whether to build CTest machinery (has no effect on pytest framework)
     steps:
       - run:
           name: "Checkout target tag from enzo-e repository."
@@ -128,9 +132,6 @@ commands:
             source $BASH_ENV
             source $HOME/venv/bin/activate
 
-            # convert boolean parameter to an env var storing 0 or 1
-            USE_DOUBLE=$(( 0 <<# parameters.usedouble >> + 1 <</ parameters.usedouble >> ))
-            USE_GRACKLE=$(( 0 <<# parameters.usegrackle >> + 1 <</ parameters.usegrackle >> ))
             # remove build directory in case we've already compiled before
             rm -rf build
 
@@ -139,11 +140,11 @@ commands:
                     -GNinja \
                     -DUSE_DOUBLE_PREC=<< parameters.usedouble >> \
                     -DUSE_GRACKLE=<< parameters.usegrackle >> \
+                    -DBUILD_TESTING=<< parameters.setupCTests >> \
                     -Bbuild \
                     -DPARALLEL_LAUNCHER_NPROC_ARG="++local;+p" \
                     -DPython3_FIND_VIRTUALENV=ONLY
               cmake --build build -j 4
-              source $HOME/venv/bin/activate
             fi
 
   run-ctests:
@@ -277,6 +278,7 @@ jobs:
           tag: tip
           skipfile: notafile
           usegrackle: << parameters.usegrackle >>
+          setupCTests: true
 
       - run-ctests:
           skipfile: notafile
@@ -321,6 +323,7 @@ jobs:
           tag: gold-standard-004
           skipfile: notafile
           usegrackle: << parameters.usegrackle >>
+          setupCTests: false
 
       - run-answer-tests:
           usedouble: << parameters.usedouble >>
@@ -332,6 +335,7 @@ jobs:
           tag: tip
           skipfile: notafile
           usegrackle: << parameters.usegrackle >>
+          setupCTests: false
 
       - run-answer-tests:
           usedouble: << parameters.usedouble >>

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -309,6 +309,13 @@ if (__processedUserDefaults)
   include(${Enzo-E_CONFIG_PATH})
 endif()
 
+# we need to pull CTest sooner or later anyways. We do it before adding the
+# source directories because it introduces the BUILD_TESTING option which is
+# set to ON if it was not previously initialized (e.g. from the command line)
+# -> this option is used within source directories to determine whether the
+#    binaries for unit-tests should be declared
+include(CTest)
+
 # In principle a more fine grained control (i.e., target specific include directories
 # rather than this global one would be preferred, but, e.g., `pngwriter.h` is curently
 # included in many targets/libraries (without being linked) so we'll use the global for
@@ -321,10 +328,7 @@ add_subdirectory(src/Enzo)
 add_subdirectory(src/External)
 
 
-include(CTest)
 
-# include(CTest) implicitly initializes BUILD_TESTING to ON if it was not
-# previously initialized (e.g. from the command line)
 if (BUILD_TESTING)
   add_subdirectory(test)
 endif()

--- a/doc/source/tutorial/getting_started.rst
+++ b/doc/source/tutorial/getting_started.rst
@@ -284,7 +284,7 @@ These options control compilation choices that can be used to facillitate profil
 Testing Options
 ^^^^^^^^^^^^^^^
 
-These options configure properties of parallel automated tests.
+These options configure properties of automated tests. These options currently just affect tests in the :ref:`ctest framework <ctest>` and don't affect tests in the :ref:`pytest framework <pytest>`.
 
 .. list-table:: Testing-Related Configuration
    :widths: 10 30 5
@@ -302,6 +302,10 @@ These options configure properties of parallel automated tests.
    * - ``PARALLEL_LAUNCHER_NPROC``
      - Number of processors to run parallel unit tests
      - 4
+   * - ``BUILD_TESTING``
+     - Whether to setup the CTest infrastructure and build unit test binaries (which are primarily built to be executed by the CTest infrastructure). This has no effect on the pytest infrastructure.
+     - "ON"
+
 
 Debugging Options
 ^^^^^^^^^^^^^^^^^

--- a/src/Cello/CMakeLists.txt
+++ b/src/Cello/CMakeLists.txt
@@ -338,9 +338,13 @@ function(addUnitTestBinary BINNAME SRCS LIB TESTER)
   #   TESTER:    Tester target library (usually, this is tester_default,
   #              tester_mesh, OR tester_simulation)
 
-  add_executable(${BINNAME} ${SRCS})
-  target_link_libraries(${BINNAME} PUBLIC ${LIB} ${TESTER})
-  target_link_options(${BINNAME} PRIVATE ${Cello_TARGET_LINK_OPTIONS})
+  if (BUILD_TESTING)
+    # only declare the binary for a unit-test when BUILD_TESTING is ON (the
+    # default case)
+    add_executable(${BINNAME} ${SRCS})
+    target_link_libraries(${BINNAME} PUBLIC ${LIB} ${TESTER})
+    target_link_options(${BINNAME} PRIVATE ${Cello_TARGET_LINK_OPTIONS})
+  endif()
 endfunction(addUnitTestBinary)
 
 # tests of the cello-component

--- a/src/Enzo/CMakeLists.txt
+++ b/src/Enzo/CMakeLists.txt
@@ -89,8 +89,13 @@ add_subdirectory(io)
 add_subdirectory(mesh)
 add_subdirectory(obsolete)
 add_subdirectory(particle)
-add_subdirectory(tests)
 add_subdirectory(utils)
+
+# note that the tests subdirectory introduces problem initializers that can
+# be used to setup test-problems. The BUILD_TESTING option has no impact on
+# what is built from this directory (it only affects whether binaries,
+# expressly used for unit-testing are built)
+add_subdirectory(tests)
 
 # Step 4: specify additional information about the Enzo library
 # (dependencies are only PUBLIC because of the way that all headers are
@@ -116,12 +121,14 @@ add_executable(enzo-e enzo-e.cpp)
 target_link_libraries(enzo-e PRIVATE enzo main_enzo ${External_LIBS})
 target_link_options(enzo-e PRIVATE ${Cello_TARGET_LINK_OPTIONS})
 
-# define a unit test:
-#
-# consider removing the enzo-specific stuff from this test so that we can
-# define it entirely in the Cello layer
-add_executable(
-  test_class_size "${CMAKE_CURRENT_SOURCE_DIR}/../Cello/test_class_size.cpp"
-)
-target_link_libraries(test_class_size PRIVATE enzo mesh tester_mesh)
-target_link_options(test_class_size PRIVATE ${Cello_TARGET_LINK_OPTIONS})
+if (BUILD_TESTING)
+  # define a unit test:
+  #
+  # consider removing the enzo-specific stuff from this test so that we can
+  # define it entirely in the Cello layer
+  add_executable(
+    test_class_size "${CMAKE_CURRENT_SOURCE_DIR}/../Cello/test_class_size.cpp"
+    )
+  target_link_libraries(test_class_size PRIVATE enzo mesh tester_mesh)
+  target_link_options(test_class_size PRIVATE ${Cello_TARGET_LINK_OPTIONS})
+endif()

--- a/src/Enzo/enzo-core/CMakeLists.txt
+++ b/src/Enzo/enzo-core/CMakeLists.txt
@@ -26,7 +26,9 @@ list(FILTER LOCAL_SRC_FILES EXCLUDE REGEX "test_EnzoUnits")
 
 target_sources(enzo PRIVATE ${LOCAL_SRC_FILES})
 
-# Add a unit test
-add_executable(test_enzo_units "test_EnzoUnits.cpp")
-target_link_libraries(test_enzo_units PRIVATE enzo main_enzo)
-target_link_options(test_enzo_units PRIVATE ${Cello_TARGET_LINK_OPTIONS})
+if (BUILD_TESTING)
+  # Add a unit test
+  add_executable(test_enzo_units "test_EnzoUnits.cpp")
+  target_link_libraries(test_enzo_units PRIVATE enzo main_enzo)
+  target_link_options(test_enzo_units PRIVATE ${Cello_TARGET_LINK_OPTIONS})
+endif()


### PR DESCRIPTION
`BUILD_TESTING` is a commonly occuring option across many different CMake projects. In fact, it is automatically defined by CTest, and was already used to determine whether parts of CTest machinery should be defined. The option is automatica a default value on `ON` (users need to explicitly opt out of building it).

This PR made 3 very small changes:
1. When `BUILD_TESTING` is disabled, we no longer build the unit-test binaries.
2. Documentation about this option has been added.
3. The CircleCI file has been updated to set `BUILD_TESTING=OFF` when building Enzo-E for the purposes of running answer testing

On my personal machine, using the clang compiler and 4 cores, the build step takes 3 minutes 45 seconds when `BUILD_TESTING=ON` and 3 minutes 7 seconds when  `BUILD_TESTING=OFF`.

- This time savings arises because we are skipping the building and linking of ~40 c++ files.
- Since the answer-testing CircleCI job needs to build Enzo-E twice per run (once to generate test answers and a second time to run the tests) and `BUILD_TESTING` has no impact on answer testing, this should save a bunch of time. (Note: we won't see any time-savings in the first build until the Gold standard gets updated again)

I think these are all very sensible changes, since the user builds these tests by default.