### PR TITLE
Introduce Precompiled Headers to Speed up Compilation 

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -23,6 +23,10 @@ commands:
   install-dependencies:
     description: "Install dependencies."
     steps:
+      - restore_cache:
+          name: "Restore dependencies cache."
+          key: dependencies-v3
+
       - run:
           name: "Install dependencies."
           command: |
@@ -56,6 +60,12 @@ commands:
             cd $HOME/yt
             export MAX_BUILD_CORES=2
             pip install -e .
+
+      - save_cache:
+          name: "Save dependencies cache"
+          key: dependencies-v3
+          paths:
+            - ~/local
 
   install-grackle:
     description: "Install grackle."
@@ -254,18 +264,7 @@ jobs:
     steps:
       - checkout
       - set-env
-
-      - restore_cache:
-          name: "Restore dependencies cache."
-          key: dependencies-v3
-
-      - install-dependencies
-
-      - save_cache:
-          name: "Save dependencies cache"
-          key: dependencies-v3
-          paths:
-            - ~/local
+      - install-dependencies # (handles caching of dependencies too)
 
       - when:
           condition: << parameters.usegrackle >>
@@ -329,18 +328,7 @@ jobs:
     steps:
       - checkout
       - set-env
-
-      - restore_cache:
-          name: "Restore dependencies cache."
-          key: dependencies-v3
-
-      - install-dependencies
-
-      - save_cache:
-          name: "Save dependencies cache"
-          key: dependencies-v3
-          paths:
-            - ~/local
+      - install-dependencies # (handles caching of dependencies too)
 
       - run: echo "About to test compilation without grackle!"
 

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -112,6 +112,9 @@ commands:
       usegrackle:
         type: boolean
         default: true
+      useprecompiledheaders:
+        type: boolean
+        default: true
     steps:
       - run:
           name: "Checkout target tag from enzo-e repository."
@@ -139,6 +142,7 @@ commands:
                     -GNinja \
                     -DUSE_DOUBLE_PREC=<< parameters.usedouble >> \
                     -DUSE_GRACKLE=<< parameters.usegrackle >> \
+                    -DUSE_PRECOMPILED_HEADERS=<< parameters.useprecompiledheaders >> \
                     -Bbuild \
                     -DPARALLEL_LAUNCHER_NPROC_ARG="++local;+p" \
                     -DPython3_FIND_VIRTUALENV=ONLY
@@ -307,6 +311,58 @@ jobs:
             - run-ctests:
                 skipfile: notafile
 
+# the following case considers a few IMPORTANT compilation configurations
+# 1. no-grackle
+# 2. no-precompiled-headers
+  extra-compile-tests:
+    parameters:
+      usedouble:
+        type: boolean
+
+    docker:
+      - image: cimg/python:3.10
+
+    resource_class: large
+
+    working_directory: ~/enzo-e
+
+    steps:
+      - checkout
+      - set-env
+
+      - restore_cache:
+          name: "Restore dependencies cache."
+          key: dependencies-v3
+
+      - install-dependencies
+
+      - save_cache:
+          name: "Save dependencies cache"
+          key: dependencies-v3
+          paths:
+            - ~/local
+
+      - run: echo "About to test compilation without grackle!"
+
+      - compile-enzoe:
+          usedouble: << parameters.usedouble >>
+          tag: tip
+          skipfile: notafile
+          usegrackle: false
+          useprecompiledheaders: true
+
+      - run: echo "About to test compilation without precompiled headers"
+
+      - install-grackle:
+          usedouble: true
+
+      - compile-enzoe:
+          usedouble: << parameters.usedouble >>
+          tag: tip
+          skipfile: notafile
+          usegrackle: false
+          useprecompiledheaders: false
+
   docs-build:
     docker:
       - image: cimg/python:3.10
@@ -342,9 +398,6 @@ workflows:
            usegrackle: true
            testframework: "pytest"
        - docs-build
-       - test-suite:
-           name: build-no-grackle
+       - extra-compile-tests:
            usedouble: true
-           usegrackle: false
-           testframework: "neither"
 

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -339,7 +339,7 @@ jobs:
           tag: tip
           skipfile: notafile
           useprecompiledheaders: true
-          usegrackle: << parameters.usegrackle >>
+          usegrackle: false
           setupCTests: false
 
       - run: echo "About to test compilation without precompiled headers"

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -152,18 +152,12 @@ commands:
       skipfile:
         type: string
         default: notafile
-      skiptest:
-        type: boolean
-        default: false
     steps:
       - run:
           name: "Run the unit tests with ctest."
           command: |
             source $BASH_ENV
             source $HOME/venv/bin/activate
-
-            # convert boolean parameter to an env var storing 0 or 1
-            SKIP_TEST=$(( 0 <<# parameters.skiptest >> + 1 <</ parameters.skiptest >> ))
 
             if [ ! -f << parameters.skipfile >> ]; then
               source $HOME/venv/bin/activate
@@ -234,17 +228,20 @@ commands:
             python -m sphinx -M html "." "_build" -W
 
 jobs:
-  ctest-suite:
+  test-suite:
     parameters:
       usedouble:
         type: boolean
       usegrackle:
         type: boolean
-      skiptest:
-        type: boolean
+      testframework:
+        default: "neither"
+        type: enum
+        description: Specifies which sets of tests to run. Must be one of "neither", "ctest", "pytest".
+        enum: ["neither", "ctest", "pytest"]
 
     docker:
-      - image: cimg/python:3.9
+      - image: cimg/python:3.10
 
     resource_class: large
 
@@ -272,71 +269,43 @@ jobs:
             - install-grackle:
                 usedouble: << parameters.usedouble >>
 
+      - when:
+          condition:
+            equal: [ pytest, << parameters.testframework >> ]
+          steps:
+            - run: echo "starting steps for pytest answer generation"
+            - compile-enzoe:
+                usedouble: << parameters.usedouble >>
+                tag: gold-standard-004
+                skipfile: notafile
+                usegrackle: << parameters.usegrackle >>
+            - run-answer-tests:
+                usedouble: << parameters.usedouble >>
+                usegrackle: << parameters.usegrackle >>
+                generate: true
+            - run: echo "Completed steps for pytest answer generation"
+
       - compile-enzoe:
           usedouble: << parameters.usedouble >>
           tag: tip
           skipfile: notafile
           usegrackle: << parameters.usegrackle >>
-
-      - run-ctests:
-          skipfile: notafile
-          skiptest: << parameters.skiptest >>
-
-  answer-test-suite:
-    parameters:
-      usedouble:
-        type: boolean
-      usegrackle:
-        type: boolean
-
-    docker:
-      - image: cimg/python:3.10
-
-    working_directory: ~/enzo-e
-
-    steps:
-      - checkout
-      - set-env
-
-      - restore_cache:
-          name: "Restore dependencies cache."
-          key: dependencies-v3
-
-      - install-dependencies
-
-      - save_cache:
-          name: "Save dependencies cache"
-          key: dependencies-v3
-          paths:
-            - ~/local
 
       - when:
-          condition: << parameters.usegrackle >>
+          condition:
+            equal: [ pytest, << parameters.testframework >> ]
           steps:
-            - install-grackle:
+            - run-answer-tests:
                 usedouble: << parameters.usedouble >>
+                usegrackle: << parameters.usegrackle >>
+                generate: false
 
-      - compile-enzoe:
-          usedouble: << parameters.usedouble >>
-          tag: gold-standard-004
-          skipfile: notafile
-          usegrackle: << parameters.usegrackle >>
-
-      - run-answer-tests:
-          usedouble: << parameters.usedouble >>
-          usegrackle: << parameters.usegrackle >>
-          generate: true
-
-      - compile-enzoe:
-          usedouble: << parameters.usedouble >>
-          tag: tip
-          skipfile: notafile
-          usegrackle: << parameters.usegrackle >>
-
-      - run-answer-tests:
-          usedouble: << parameters.usedouble >>
-          usegrackle: << parameters.usegrackle >>
-          generate: false
+      - when:
+         condition:
+            equal: [ ctest, << parameters.testframework >> ]
+         steps:
+            - run-ctests:
+                skipfile: notafile
 
   docs-build:
     docker:
@@ -352,27 +321,30 @@ jobs:
 workflows:
    tests:
      jobs:
-       - ctest-suite:
+       - test-suite:
            name: ctest-suite_single-prec
            usedouble: false
            usegrackle: true
-           skiptest: false
-       - ctest-suite:
+           testframework: "ctest"
+       - test-suite:
            name: ctest-suite_double-prec
            usedouble: true
            usegrackle: true
-           skiptest: false
-       - docs-build
-       - ctest-suite:
-           name: build-no-grackle
-           usedouble: true
-           usegrackle: false
-           skiptest: true
-       - answer-test-suite:
+           testframework: "ctest"
+       - test-suite:
            name: answer-tests_single
            usedouble: false
            usegrackle: true
-       - answer-test-suite:
+           testframework: "pytest"
+       - test-suite:
            name: answer-tests_double
            usedouble: true
            usegrackle: true
+           testframework: "pytest"
+       - docs-build
+       - test-suite:
+           name: build-no-grackle
+           usedouble: true
+           usegrackle: false
+           testframework: "neither"
+

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -316,6 +316,9 @@ endif()
 include_directories(${CMAKE_CURRENT_SOURCE_DIR}/src/External)
 set(CMAKE_RUNTIME_OUTPUT_DIRECTORY ${CMAKE_BINARY_DIR}/bin)
 
+option(USE_PRECOMPILED_HEADERS
+  "Use precompiled headers to speed up compilation" ON)
+
 add_subdirectory(src/Cello)
 add_subdirectory(src/Enzo)
 add_subdirectory(src/External)

--- a/doc/source/tutorial/getting_started.rst
+++ b/doc/source/tutorial/getting_started.rst
@@ -341,6 +341,22 @@ The following options are useful for debugging.
      - Trace main phases
      - OFF
 
+Misc Options
+^^^^^^^^^^^^
+
+The following options don't really belong in any other category
+
+.. list-table:: Misc Options
+   :widths: 10 30 5
+   :header-rows: 1
+
+   * - Name
+     - Description
+     - Default
+   * - ``USE_PRECOMPILED_HEADERS``
+     - Precompile headers to try to reduce compile time
+     - ON
+
 .. _how_to_specify_the_configuration:
 
 Specifying Configuration Options

--- a/src/Cello/CMakeLists.txt
+++ b/src/Cello/CMakeLists.txt
@@ -111,6 +111,44 @@ target_link_libraries(parallel
 add_library(view INTERFACE)
 target_link_libraries(view INTERFACE error monitor)
 
+
+# A brief segue: define a common target, cello_component_PCH, that is used to
+# propagate a precompiled header
+# - if USE_PRECOMPILED_HEADERS is OFF, then linking against this target does
+#   nothing!
+# - A precompiled header stores the contents of preparsed headers in a binary
+#   format. They can significantly reduce compilation times when they are used
+#   to define large headers that are included in MANY files.
+# - NOTE: there's still a compile-time cost to including unnecessary headers
+#   (For example, even when the <charm++.h> header is precompiled, a bunch of
+#   time is still spent instantiate functions)
+#
+# Using a precompiled header will forcibly include all preparsed headers
+# inside a source file. If care isn't taken, this can unintentionally lead to
+# a source file knowing about symbols that it hasn't properly included.
+# Obviously, we REALLY want to avoid that scenario.
+#
+# For that reason, we are going to do something simple, we are just going to
+# precompile some of the expensive external headers included by cello.hpp.
+# - we will only use this for targets for which ALL source files include the
+#   cello.hpp file (as a rule of thumb, this should just be used when the
+#   cello_component target, defined below, is a public dependency). This saves
+#   time parsing the <vector> and <charm++.h> headers.
+# - In the worst case scenario, we are limiting the symbols can know about
+#   (that it shouldn't) to stuff in the std:: namespace and stuff from charm++
+#
+# Because it's good practice to make precompiled headers opt-in (since a given
+# file can only use 1 precompiled header), all targets that link to this to
+# target use a PRIVATE dependence (to avoid transitive dependence)
+add_library(cello_component_PCH INTERFACE)
+if(USE_PRECOMPILED_HEADERS)
+  target_precompile_headers(cello_component_PCH INTERFACE
+    <random> # this takes a shockingly long time to compile (and really
+             # shouldn't be in cello.hpp)
+    <string> <vector> <charm++.h> "\"pup_stl.h\""
+  )
+endif()
+
 #===============================================
 # Defining Cello-Component Targets step 2 (of 3)
 #===============================================
@@ -138,10 +176,12 @@ target_link_libraries(view INTERFACE error monitor)
 # (and rely upon on CMake's ability to handle such transitive dependencies for
 # us). This might help speed up incremental re-compilation
 
+
 # first, we define 2 targets that have "special names"
 # ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 # These names were chosen to minimize confusion (we have other targets that
 # share similar names)
+
 
 # note: in the near future, we may make a separate target called something like
 # CELLO_COMBINED to represent the complete library that is composed of the
@@ -153,7 +193,9 @@ target_link_libraries (cello_component
   PUBLIC CHARM::CHARM_HEADERS # charm++.h included in public header
   PRIVATE charm_component error simulation # these private dependencies arise
                                            # from source files
+  PRIVATE cello_component_PCH # cello component-precompiled header
 )
+
 
 
 file(GLOB CHARM_COMP_SRC_FILES charm*.cpp *charm*.hpp)
@@ -178,6 +220,7 @@ addCelloLib(compute "")
 target_link_libraries(compute
   PUBLIC cello_component charm_component error performance monitor memory
          parallel disk io parameters problem mesh view data simulation
+  PRIVATE cello_component_PCH # (b/c cello.hpp included in ALL source files)
 )
 
 
@@ -185,6 +228,7 @@ addCelloLib(control "")
 target_link_libraries(control
   PUBLIC cello_component charm_component
   PRIVATE simulation mesh # these arise from source files
+  PRIVATE cello_component_PCH # (b/c cello.hpp included in ALL source files)
 )
 
 
@@ -193,6 +237,7 @@ addCelloLib(data  "field_face_store.F")
 target_link_libraries(data
   PUBLIC cello_component charm_component error memory performance monitor
          parallel disk problem mesh parameters io compute simulation view
+  PRIVATE cello_component_PCH # (b/c cello.hpp included in ALL source files)
 )
 
 
@@ -214,6 +259,7 @@ target_link_libraries(io
                                      # these into private dependencies
   PUBLIC cello_component charm_component parallel monitor performance error
          parameters disk problem compute mesh view data simulation
+  PRIVATE cello_component_PCH # (b/c cello.hpp included in ALL source files)
 )
 
 
@@ -225,6 +271,7 @@ addCelloLib(mesh "")
 target_link_libraries(mesh
   PUBLIC cello_component charm_component performance monitor parallel disk
          parameters control io problem compute simulation view data
+  PRIVATE cello_component_PCH # (b/c cello.hpp included in ALL source files)
 )
 
 
@@ -258,6 +305,7 @@ addCelloLib(problem "")
 target_link_libraries(problem
   PUBLIC cello_component charm_component error performance monitor memory
          parallel disk io parameters compute control mesh view data simulation
+  PRIVATE cello_component_PCH # (b/c cello.hpp included in ALL source files)
 )
 
 addCelloLib(simulation "")
@@ -265,6 +313,7 @@ addCelloLib(simulation "")
 target_link_libraries(simulation
   PUBLIC cello_component charm_component error memory performance monitor
          parallel disk problem mesh view data parameters io compute
+  PRIVATE cello_component_PCH # (b/c cello.hpp included in ALL source files)
 )
 
 

--- a/src/Cello/cello.hpp
+++ b/src/Cello/cello.hpp
@@ -18,6 +18,9 @@
 // SYSTEM INCLUDES
 //----------------------------------------------------------------------
 
+// (check CMakeLists.txt to check to see if headers in the associated
+//  precompiled header needs to change whenever any of these include statements
+//  are removed - the precompiled header should only contain a subset of them)
 #include <execinfo.h>
 #include <math.h>
 #include <stdio.h>

--- a/src/Enzo/CMakeLists.txt
+++ b/src/Enzo/CMakeLists.txt
@@ -107,6 +107,28 @@ target_include_directories(enzo
 target_link_options(enzo PRIVATE ${Cello_TARGET_LINK_OPTIONS})
 
 
+# At the time of writing, cello.hpp is included in basically every source file
+# (it's either directly included, or included via enzo.hpp). Thus it's okay to
+# use these precompiled headers in all of the files.
+target_link_libraries(enzo PRIVATE cello_component_PCH)
+
+# At the time of wriing, enzo.hpp is included in just about every source file
+# compiled as part of the enzo-target. For that reason, using
+#     > if(USE_PRECOMPILED_HEADERS)
+#     >    target_precompile_headers(enzo PRIVATE enzo.hpp)
+#      > endif()
+# actually saves a lot of extra time.
+# - However, I'm VERY worried that future source files could get introduced
+#   that don't include enzo.hpp. In that case, the precompiled headers would
+#   allow the source file to access just about ANY in symbol in the entire
+#   codebase without an appropriate include-statement.
+# - While the same could still happen with the headers in cello_component_PCH,
+#   I'm much less concerned since those are standard library headers and
+#   charm++ headers
+# - Maybe we can revisit this if we can come up with a better automatic test
+#   for catching these cases (more helpful than the existing CI test). It could
+#   when/if we start subdividing the enzo-target into subtargets...
+
 #======================
 # Define Binary Targets
 #======================


### PR DESCRIPTION
This introduces the ability to use precompiled headers to speed up the compile times. I had done some light profiling of compile-times with clang's `-ftime-trace` command in order to see where time was being spent during compilation time. 

- As I suspected, we spend a lot of time reading in headers (since every source file reads more headers than necessary). But, the details really surprised me.
- I had been concerned that my `View` template class was increasing compile times by a lot, but it took a negligible amount of time.
- instead a bunch of time is spent reading headers like `<random>`, `<vector>`, `<charm++.h>`, and `<boost/filesystem.h>`. (That last case is addressed separately in PR #320).

To mitigate this to some extent, I started to make use of precompiled headers. This is a compiler-specific feature that cmake provides a nice abstraction for. 
- Essentially a compiler will preparse a set of header-files and store the binary representation known as a precompiled header. 
- There is still a compile-time penalty for unnecessarily including headers (e.g. the compiler still spends a bunch of time instantiating lots of charm++ template specializations in every source file), but this is definitely helpful.
- There is a potential drawback - if we aren't careful, source files that make use of a precompiled header know about all symbols declared in the preparsed header (even if that that header would not be included in the source file).

For that last reason, our usage of precompiled headers is fairly conservative. We just precompile `<random>`, `<string>`, `<vector>`, `<charm++.h>`, and `"pup_stl.h"`. These are all included in `cello.hpp`. And we try to only use the precompiled header in source files that include the `cello.hpp` file. 
- in the worst case scenario, where a source file doesn't include `cello.hpp`, it will just know about some functions/classes in the `std` namespace and from the charm++. This seemed better than also exposing symbols from within Enzo-E
- I also added a compile-test to circleci to confirm that Enzo-E will continue to compile when we disable these precompiled headers. Along the way I refactored some existing CircleCi tests, so that they were implemented in a slightly more concise manner (I confirmed that they still work).



**Some Numbers:** On my machine, with the clang compiler and 4 cores, this reduces compile-times from 3 min 45 seconds to 3 minutes 12 seconds (A ~15% speedup). 
- This doesn't include the speedup from PR #320 - that's maybe another 5-10 seconds faster on my machine in the same configuration.
- Keep in mind that unit-test binaries generally account for ~30 seconds of that time (see PR #321). Those don't get rebuilt very frequently during incremental rebuilds.

As an experiment, I tried using a precompiled header for enzo.hpp for all files in the Enzo-layer and that shaved off another 25 seconds from my build. But, due to the concerns cited earlier, I don't think it's a good idea to go that route (unless we come up with a more robust testing methodology).