### PR TITLE
C++ version bump from C++11 to C++17

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -19,8 +19,8 @@ endif()
 #Define project and languages
 project(Enzo-E VERSION 1.0.0 LANGUAGES C CXX Fortran)
 
-# We need C++11
-set(CMAKE_CXX_STANDARD 11)
+# We need C++17
+set(CMAKE_CXX_STANDARD 17)
 set(CMAKE_CXX_STANDARD_REQUIRED ON)
 
 set(CMAKE_EXPORT_COMPILE_COMMANDS ON)
@@ -81,6 +81,16 @@ if (USE_GRACKLE)
   endif()
 endif()
 
+# TODO: remove the dependency on boost::filesystem (since C++17 now offers
+# nearly identical functionality within the standard library). Initially, I
+# thought, it could make sense to keep using boost::filesystem in the
+# short-term since the clang compiler shipped on macOS didn't support this
+# library until version 11.0 of Xcode (requires macOS Mojave from 2018).
+# - Apple's clang compiler supports all new language features & the majority of
+#   new library features by version 10 (requires macOS High Sierra from 2017)
+# - For more info: https://en.cppreference.com/w/cpp/compiler_support/17
+# - After giving this some thought, this difference in support is probably not
+#   worth caring about
 find_package(Boost REQUIRED COMPONENTS filesystem)
 # Fix linking error to
 # /opt/apps/gcc/8.3.0/bin/ld: main.cpp:(.text+0x679e): undefined reference to `boost::system::generic_category()'

--- a/src/Cello/view_ViewCollec.hpp
+++ b/src/Cello/view_ViewCollec.hpp
@@ -10,7 +10,8 @@
 #include <array>
 #include <limits>
 #include <memory> // std::shared_ptr, std::default_delete
-#include <utility> // std::swap
+#include <utility> // std::in_place_type_t
+#include <variant>
 #include <vector>
 
 #ifndef VIEW_C_ARR_COLLEC_HPP
@@ -65,12 +66,6 @@ namespace detail {
     T& operator[](std::size_t i) noexcept { return arr_.get()[i]; }
     std::size_t size() const noexcept {return length_;}
 
-    void swap(SharedBuffer_<T>& other) noexcept
-    {
-      this->arr_.swap(other.arr_);
-      std::swap(this->length_, other.length_);
-    }
-
   private:
     std::shared_ptr<T> arr_;
     std::size_t length_;
@@ -106,9 +101,6 @@ namespace detail {
       ERROR("ArrOfPtrsViewCollec_::get_backing_array",
             "This is an invalid method call");
     }
-
-    friend void swap(ArrOfPtrsViewCollec_<T>& a, ArrOfPtrsViewCollec_<T>& b)
-      noexcept { a.arrays_.swap(b.arrays_); }
 
     // There might be some benefit to not directly constructing subarrays and
     // lazily evaluating them later
@@ -154,10 +146,6 @@ namespace detail {
     const CelloView<T, 4> get_backing_array() const noexcept
     { return backing_array_; }
 
-    friend void swap(SingleAddressViewCollec_<T>& a,
-                     SingleAddressViewCollec_<T>& b) noexcept
-    { swap(a.backing_array_, b.backing_array_); }
-
     SingleAddressViewCollec_<T> subarray_collec(const CSlice &slc_z,
                                                 const CSlice &slc_y,
                                                 const CSlice &slc_x) const
@@ -189,131 +177,44 @@ class ViewCollec{
   /// collections of CelloViews. Under the hood, the arrays are either stored
   /// in a single 4D Contiguous Array (see SingleAddressViewCollec_) or an
   /// array of 3D CelloViews (see ArrOfPtrsViewCollec_)
-  ///
-  /// The implementation of this hybrid data-structure is fairly crude. If we
-  /// decide that we want to support this hybrid data-type in the long-term,
-  /// we probably want to consider using boost::variant/a backport of
-  /// std::variant or take advantage of the fact that we can represent the
-  /// contents of a SingleAddressViewCollec_ with a ArrOfPtrsViewCollec_
 
-private:
-  // tags how the arrays are stored (whether they're stored in a single
-  // contiguous CelloView or stored like an array of pointers)
-  enum class Tag {CONTIG, ARR_OF_PTR};
-  Tag tag_;
+private: // attributes
 
-  union{
-    detail::SingleAddressViewCollec_<T> single_arr_;
-    detail::ArrOfPtrsViewCollec_<T> arr_of_ptr_;
-  };
-
-private: // helper methods:
-
-  /// default construct the active member
-  void activate_member_(Tag tag, bool currently_initialized = true){
-    if (currently_initialized) { dealloc_active_member_(); }
-    tag_ = tag;
-
-    switch (tag_){
-      case Tag::CONTIG: {
-        new(&single_arr_) detail::SingleAddressViewCollec_<T>;
-        break;
-      }
-      case Tag::ARR_OF_PTR: {
-        new(&arr_of_ptr_) detail::ArrOfPtrsViewCollec_<T>;
-        break;
-      }
-    }
-  }
-
-  // used in destructor and to help switch the active member of the enum
-  // need to explicitly call destructor because we use placement new
-  void dealloc_active_member_() noexcept{
-    // note, we need to use the full qualified names of destructors to avoid
-    // errors with the nvidia compiler
-    switch (tag_){
-      case Tag::CONTIG: {
-        single_arr_.detail::SingleAddressViewCollec_<T>::~SingleAddressViewCollec_();
-        break;
-      }
-      case Tag::ARR_OF_PTR: {
-        arr_of_ptr_.detail::ArrOfPtrsViewCollec_<T>::~ArrOfPtrsViewCollec_();
-        break;
-      }
-    }
-  }
+  std::variant<detail::SingleAddressViewCollec_<T>,
+               detail::ArrOfPtrsViewCollec_<T>> collec_;
 
 public: /// public interface
   /// default constructor
-  ViewCollec() noexcept { activate_member_(Tag::CONTIG, false); }
+  ViewCollec() = default;
 
   /// construct a container of arrays without wrapping existing arrays
-  ViewCollec(std::size_t n_arrays, const std::array<int,3>& shape) noexcept {
-    activate_member_(Tag::CONTIG, false);
-    single_arr_ = detail::SingleAddressViewCollec_<T>(n_arrays, shape);
-  }
+  ViewCollec(std::size_t n_arrays, const std::array<int,3>& shape) noexcept
+    : collec_(std::in_place_type_t<detail::SingleAddressViewCollec_<T>>(),
+              n_arrays, shape)
+  { }
 
   /// construct from vector of arrays
-  ViewCollec(const std::vector<CelloView<T, 3>>& v) noexcept{
-    activate_member_(Tag::ARR_OF_PTR, false);
-    arr_of_ptr_ = detail::ArrOfPtrsViewCollec_<T>(v);
-  }
-
-  /// copy constructor
-  ViewCollec(const ViewCollec& other) noexcept{
-    activate_member_(other.tag_, false);
-    switch (other.tag_){
-      case Tag::CONTIG:     { single_arr_ = other.single_arr_; break; }
-      case Tag::ARR_OF_PTR: { arr_of_ptr_ = other.arr_of_ptr_; break; }
-    }
-  }
-
-  /// copy assignment
-  ViewCollec& operator=(const ViewCollec &other) noexcept {
-    ViewCollec tmp(other);
-    swap(*this,tmp);
-    return *this;
-  }
-
-  /// move constructor
-  ViewCollec (ViewCollec&& other) noexcept : ViewCollec(){ swap(*this,other); }
-
-  /// move assignment
-  ViewCollec& operator=(ViewCollec&& other) noexcept {
-    swap(*this, other);
-    return *this;
-  }
+  ViewCollec(const std::vector<CelloView<T, 3>>& v) noexcept
+    : collec_(std::in_place_type_t<detail::ArrOfPtrsViewCollec_<T>>(), v)
+  { }
 
   /// Destructor
-  ~ViewCollec(){dealloc_active_member_();}
+  ~ViewCollec() = default;
+
+  /// copy/move constructors & assignment operations
+  ViewCollec(const ViewCollec& other)  = default;
+  ViewCollec& operator=(const ViewCollec &other) = default;
+  ViewCollec (ViewCollec&& other) = default;
+  ViewCollec& operator=(ViewCollec&& other) = default;
 
   /// swaps the contents of `a` with `b`
   friend void swap(ViewCollec<T>& a, ViewCollec<T>& b) noexcept{
-    if (&a == &b) { return; }
-    if (a.tag_ == b.tag_){
-      switch (a.tag_){
-        case Tag::CONTIG:     { swap(a.single_arr_, b.single_arr_); break; }
-        case Tag::ARR_OF_PTR: { swap(a.arr_of_ptr_, b.arr_of_ptr_); break; }
-      }
-    } else if (a.tag_ == Tag::CONTIG){
-      detail::SingleAddressViewCollec_<T> temp_single_arr;
-      swap(temp_single_arr, a.single_arr_);
-      a.activate_member_(Tag::ARR_OF_PTR, true);
-      swap(a.arr_of_ptr_, b.arr_of_ptr_);
-      b.activate_member_(Tag::CONTIG, true);
-      swap(temp_single_arr, b.single_arr_);
-    } else {
-      swap(b,a);
-    }
+    a.collec_.swap(b.collec_);
   }
 
   /// Returns the number of arrays held in the collection
   std::size_t size() const noexcept {
-    switch (tag_){
-      case Tag::CONTIG:     { return single_arr_.size(); }
-      case Tag::ARR_OF_PTR: { return arr_of_ptr_.size(); }
-    }
-    ERROR("ViewCollec::size", "problem with exhaustive switch-statement");
+    return std::visit([](auto&& arg) { return arg.size(); }, collec_);
   }
 
   /// Returns a shallow copy of the specified array
@@ -322,22 +223,14 @@ public: /// public interface
     ASSERT2("ViewCollec::operator[]",
             "Can't retrieve value at %zu when size() is %zu",
             i, n_elements, i < n_elements);
-    switch (tag_){
-      case Tag::CONTIG:     { return single_arr_[i]; }
-      case Tag::ARR_OF_PTR: { return arr_of_ptr_[i]; }
-    }
-    ERROR("ViewCollec::operator[]", "problem with exhaustive switch-statement");
+    return std::visit([=](auto&& arg) { return arg[i]; }, collec_);
   }
 
   /// Indicates if the contained arrays are stored in a single 4D array
   /// (Alternatively they can be stored as an array of pointers)
   bool contiguous_items() const noexcept {
-    switch (tag_){
-      case Tag::CONTIG:     { return single_arr_.contiguous_items(); }
-      case Tag::ARR_OF_PTR: { return arr_of_ptr_.contiguous_items(); }
-    }
-    ERROR("ViewCollec::contiguous_items",
-          "problem with exhaustive switch-statement");
+    return std::visit([](auto&& arg) { return arg.contiguous_items(); },
+                      collec_);
   }
 
   /// Returns a shallow copy of the 4D array holding each contained array.
@@ -349,12 +242,8 @@ public: /// public interface
   /// The program will abort if this method is called on an object for which
   /// the `contiguous_items()` method returns `false`.
   const CelloView<T,4> get_backing_array() const noexcept {
-    switch (tag_){
-      case Tag::CONTIG:     { return single_arr_.get_backing_array(); }
-      case Tag::ARR_OF_PTR: { return arr_of_ptr_.get_backing_array(); }
-    }
-    ERROR("ViewCollec::get_backing_array",
-          "problem with exhaustive switch-statement");
+    return std::visit([](auto&& arg) { return arg.get_backing_array(); },
+                      collec_);
   }
 
   /// Returns the length along a given dimension of each contained array
@@ -372,10 +261,10 @@ public: /// public interface
     } else if (dim > 3) {
       ERROR("ViewCollec::array_shape", "invalid dimension");
     }
-    return (*this)[0].shape(dim); // could be optimized based on tag
+    return (*this)[0].shape(dim);
   }
 
-  /// Return a new collection of subsections of each array in the collection
+  /// Return a new collection of subsections of each view in the collection
   ///
   /// @param slc_z, slc_y, slc_x Instance of CSlice that specify that are
   ///    passed to the `subarray` method of each contained array.
@@ -383,23 +272,11 @@ public: /// public interface
                                 const CSlice &slc_y,
                                 const CSlice &slc_x) const noexcept
   {
-
-    // initialize out and activate the union member matching this->tag_.
     ViewCollec<T> out;
-    out.activate_member_(tag_, true);
-
-    switch (tag_){
-      case Tag::CONTIG: {
-        out.single_arr_ = single_arr_.subarray_collec(slc_z,slc_y,slc_x);
-        return out;
-      }
-      case Tag::ARR_OF_PTR: {
-        out.arr_of_ptr_ = arr_of_ptr_.subarray_collec(slc_z,slc_y,slc_x);
-        return out;
-      }
-    }
-    ERROR("ViewCollec::subarray_collec_",
-          "problem with exhaustive switch-statement");
+    auto fn = [&out, &slc_z, &slc_y, &slc_x](auto&& arg)
+      { out.collec_ = arg.subarray_collec(slc_z,slc_y,slc_x); };
+    std::visit(fn, collec_);
+    return out;
   }
 
 };


### PR DESCRIPTION
A number of advantages are highlighted in Issue #317 (C++17 adds a number of useful new features).

The main reasons NOT to do this would be compiler-support. At this point most major compilers support C++17. But since there is ongoing work to introduce dependencies on libraries that require C++17 (like Kokkos or libtorch), this is something of a moot point. Furthermore, there are [discussions of bumping the minimum required compiler version for charm++ to C++17](https://github.com/UIUC-PPL/charm/discussions/3684).


This resolves #317.

This PR includes some minor refactoring of `ViewCollec` to make use of `std::variant`. While similar refactoring is now possible in other areas of the code, I wanted to limit the size of this PR. This fix is somewhat important for robustly addressing some compiler-portability issues that keep cropping up in this area of the code (see PR #309 and PR #319).