### PR TITLE
Resolve #353: CircleCI "extra-compile-tests"

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -398,10 +398,8 @@ jobs:
           usegrackle: true
           setupCTests: false
 
-      - run-answer-tests:
-          usedouble: << parameters.usedouble >>
-          usegrackle: true
-          generate: false
+      # in the future, it may be worth considering running a test-suite here... But for now,
+      # this job is only intended to check whether things successfully compile
 
   docs-build:
     docker:


### PR DESCRIPTION
Part 2 of resolving issue #353

This fixes a bug in "extra-compile-tests" job. This job is used to test that Enzo-E can be successfuly be compiled in 2 IMPORTANT compilation configurations that are not tested by any other tests.

The Problem:
- The final step of the "extra-compile-tests" job was failing. This step called the "run-answer-tests" command, which executes the answer-test machinery.
- Specifically, the "run-answer-tests" command failed because the generate parameter was set to false. This means that the command tried to execute the pytest-framework while comparing results to previously generated test-answers. The issue was that there wasn't any previously generated test-answers to be found. (So the command failed - as it should have).

The Solution:
- The solution is simple. We simply deleted this last step from the "extra-compile-tests" job. This step was not originally part of the job. It was introduced accidentally while the reviewer merged the main branch into the changes introduced to PR #322