### PR TITLE
Fix GH Issue #357

### DIFF
--- a/input/PPML/ppml.incl
+++ b/input/PPML/ppml.incl
@@ -14,6 +14,15 @@
       root_size = [32,32,32];
    }
 
+   Physics {
+      list = ["fluid_props"];
+      fluid_props {
+        eos {
+          type = "isothermal";
+        }
+      }
+   }
+
    # Field parameters include those concerning fields as a group, as
    # well as individual fields
 
@@ -35,8 +44,6 @@
          "velox_rz",    "veloy_rz",    "veloz_rz",
          "bfieldx_rz",  "bfieldy_rz",  "bfieldz_rz"
       ] ;
-
-      gamma = 1.0;
 
       padding   = 0;
       alignment = 8;

--- a/src/Cello/parameters_Parameters.hpp
+++ b/src/Cello/parameters_Parameters.hpp
@@ -57,6 +57,8 @@ public: // interface
   bool value (std::string s, bool deflt) throw()
   { return value_logical(s,deflt); }
 
+  std::string value (std::string s, const char * deflt) throw()
+  { return value_string(s,deflt); }
   std::string value (std::string s, std::string deflt) throw()
   { return value_string(s,deflt); }
 

--- a/src/Enzo/enzo-core/EnzoConfig.cpp
+++ b/src/Enzo/enzo-core/EnzoConfig.cpp
@@ -2325,20 +2325,29 @@ namespace{
 
       } else {
         ERROR1("parse_eos_choice_",
-               "there is currently no support for building of type \"%s\".",
+               "there's no support for building an eos of type \"%s\".",
                type.c_str());
       }
     }
 
 
     if (legacy_gamma_specified) {
+      double gamma = p->value_float("Field:gamma", -1.0);
+      if (gamma <= 1.0) {
+        std::string isothermal_name = EnzoEOSIsothermal::name();
+        ERROR2("parse_eos_choice_",
+               "\"Field:gamma\" is a legacy parameter that will be removed. "
+               "It has an invalid value of 1 or smaller. If you want to "
+               "initialize an \"%s\" EOS, you should delete this parameter & "
+               "assign Physics:fluid_props:eos:type a value of \"%s\"",
+               isothermal_name.c_str(), isothermal_name.c_str());
+      }
       WARNING1("parse_eos_choice_",
                "\"Field:gamma\" is a legacy parameter that will be removed. "
                "It is being used to configure an \"%s\" EOS. Going forward, "
                "set parameters in the \"Physics:fluid_props:eos\" parameter "
                "group instead.",
                ideal_name.c_str());
-      double gamma = p->value_float("Field:gamma", -1.0);
       return EnzoEOSVariant(EnzoEOSIdeal::construct(gamma));
 
     } else if (hydro_type == "ppml") {


### PR DESCRIPTION
The problem in that issue was relatively straight-forward. A while back we introduced a new way to initialize the global EOS object. At that time, I deprecated the `Field:gamma` parameter, but for the sake of backwards compatability I used `Field:gamma` to initialize an ideal EOS.

The error reported in Issue #357 occurred because `Field:gamma` was assigned a value of `1.0` to reflect the fact the PPML solver uses an isothermal function. When the code tried to use this to initialize `EnzoEOSIdeal`, the constructor complained because an adiabatic index of 1 is invalid for the current implementation.

To resolve this situation, I added a more informative error message explaining how the user should fix the problem. I also fixed the PPML test problem's input file to reflect the "correct" way to handle this case.

Along the way, I uncovered a minor bug in the way the `Parameters` class handles parsing a string with a fallback value (where the fallback value is specified as a string-literal). Essentially, we were missing an overload telling the function how to properly handle this case. Previously when the compiler saw a string literal passed, it coerced the pointer to a boolean (it asked if the pointer was NULL or not). I have now fixed that case.