### PR TITLE
Hilbert order method for load balancing 

### DIFF
--- a/input/LoadBalance/test_hilbert-balance-on-bcg.in
+++ b/input/LoadBalance/test_hilbert-balance-on-bcg.in
@@ -1,0 +1,46 @@
+include "input/LoadBalance/test_balance.incl"
+
+Adapt {
+     min_level = -2;
+ }
+
+ Method {
+     list = [ "order_hilbert", "balance", "ppm", "pm_deposit", "gravity", "pm_update", "comoving_expansion"];
+     order_hilbert { schedule { step = 20; var = "cycle"; }  }
+     balance      { schedule { step = 20; var = "cycle"; }  }
+     gravity { solver = "bcg"; }
+ }
+
+ Output {
+     list = [ "de", "dark", "mesh" ];
+
+     check { dir = [ "Dir_BALANCE_ON_%04d-checkpoint", "count" ]; }
+     ax    { dir = [ "Dir_BALANCE_ON_%04d", "cycle" ]; }
+     ay    { dir = [ "Dir_BALANCE_ON_%04d", "cycle" ]; }
+     az    { dir = [ "Dir_BALANCE_ON_%04d", "cycle" ]; }
+     dark  { dir = [ "Dir_BALANCE_ON_%04d", "cycle" ]; }
+     de    { dir = [ "Dir_BALANCE_ON_%04d", "cycle" ]; }
+     dep   { dir = [ "Dir_BALANCE_ON_%04d", "cycle" ]; }
+     depa  { dir = [ "Dir_BALANCE_ON_%04d", "cycle" ]; }
+     hdf5  { dir = [ "Dir_BALANCE_ON_%04d", "cycle" ]; }
+     po    { dir = [ "Dir_BALANCE_ON_%04d", "cycle" ]; }
+     mesh  { dir = [ "Dir_BALANCE_ON_%04d", "cycle" ];
+             image_reduce_type = "max";
+             image_mesh_color = "process";
+            }
+ }
+
+ Solver {
+     bcg {
+         iter_max = 1000;
+         monitor_iter = 10;
+         res_tol = 0.01;
+         type = "bicgstab";
+     }
+     list = [ "bcg" ];
+ }
+
+ Stopping {
+     cycle = 120;
+     redshift = 3.0;
+ }

--- a/src/Cello/_problem.hpp
+++ b/src/Cello/_problem.hpp
@@ -69,6 +69,7 @@ extern void method_close_files_mutex_init();
 #include "problem_MethodFluxCorrect.hpp"
 #include "problem_MethodNull.hpp"
 #include "problem_MethodOrderMorton.hpp"
+#include "problem_MethodOrderHilbert.hpp"
 #include "problem_MethodOutput.hpp"
 #include "problem_MethodRefresh.hpp"
 #include "problem_MethodTrace.hpp"

--- a/src/Cello/mesh.ci
+++ b/src/Cello/mesh.ci
@@ -56,6 +56,7 @@ module mesh {
   PUPable MethodFluxCorrect;
   PUPable MethodNull;
   PUPable MethodOrderMorton;
+  PUPable MethodOrderHilbert;
   PUPable MethodOutput;
   PUPable MethodRefresh;
   PUPable MethodTrace;
@@ -137,6 +138,11 @@ module mesh {
     entry void r_method_order_morton_complete(CkReductionMsg * msg);
     entry void p_method_order_morton_weight(int ic3[3], int weight, Index index);
     entry void p_method_order_morton_index(int index, int count);
+
+    entry void r_method_order_hilbert_continue(CkReductionMsg * msg);
+    entry void r_method_order_hilbert_complete(CkReductionMsg * msg);
+    entry void p_method_order_hilbert_weight(int ic3[3], int weight, Index index);
+    entry void p_method_order_hilbert_index(int index, int count);
 
     entry void p_method_output_next(MsgOutput *);
     entry void p_method_output_write(MsgOutput *);

--- a/src/Cello/mesh_Block.hpp
+++ b/src/Cello/mesh_Block.hpp
@@ -596,6 +596,11 @@ public:
   void p_method_order_morton_weight(int ic3[3], int weight, Index index);
   void p_method_order_morton_index(int index, int count);
 
+  void r_method_order_hilbert_continue(CkReductionMsg * msg);
+  void r_method_order_hilbert_complete(CkReductionMsg * msg);
+  void p_method_order_hilbert_weight(int ic3[3], int weight, Index index);
+  void p_method_order_hilbert_index(int index, int count);
+
   void p_method_output_next (MsgOutput * msg);
   void p_method_output_write (MsgOutput * msg);
   void r_method_output_continue(CkReductionMsg * msg);

--- a/src/Cello/problem_MethodOrderHilbert.cpp
+++ b/src/Cello/problem_MethodOrderHilbert.cpp
@@ -40,8 +40,8 @@ MethodOrderHilbert::MethodOrderHilbert(int min_level) throw ()
   is_next_         = cello::scalar_descr_index()->new_value(name() + ":next");
   is_weight_       = cello::scalar_descr_long_long()->new_value(name() + ":weight");
   is_weight_child_ = cello::scalar_descr_long_long()->new_value(name() + ":weight_child",n);
-  is_sync_index_  = cello::scalar_descr_sync()->new_value(name() + ":sync_index");
-  is_sync_weight_ = cello::scalar_descr_sync()->new_value(name() + ":sync_weight");
+  is_sync_index_   = cello::scalar_descr_sync()->new_value(name() + ":sync_index");
+  is_sync_weight_  = cello::scalar_descr_sync()->new_value(name() + ":sync_weight");
 }
 
 //======================================================================
@@ -113,8 +113,6 @@ void MethodOrderHilbert::send_weight(Block * block, int weight_child, bool self)
     int na3[3];
     cello::simulation()->hierarchy()->root_blocks(na3,na3+1,na3+2);
 
-    // TODO: use a "Hilbert_next" function here.
-    // Index index_next = block->index().next(rank,na3,block->is_leaf(),min_level_);
     Index index_next = hilbert_next(block->index(), rank, block->is_leaf(), min_level_);
 
     *pindex_(block) = 0;
@@ -166,7 +164,6 @@ void MethodOrderHilbert::send_index
   if (!block->is_leaf()) {
     int index = *pindex_(block) + 1;
 
-    // TODO: Insert here code to loop over child blocks in hilbert order (I think this is done??)
     int children[cello::num_children()];
     hilbert_children(block, children);
 
@@ -201,8 +198,6 @@ void MethodOrderHilbert::recv_index
     int na3[3];
     cello::simulation()->hierarchy()->root_blocks(na3,na3+1,na3+2);
 
-    // TODO: use a "Hilbert_next" function here.
-    // Index index_next = block->index().next(rank,na3,block->is_leaf(),min_level_);
     Index index_next = hilbert_next(block->index(), rank, block->is_leaf(), min_level_);
     *pindex_(block) = index;
     *pcount_(block) = count;
@@ -308,70 +303,33 @@ Sync * MethodOrderHilbert::psync_weight_(Block * block)
 
 void MethodOrderHilbert::hilbert_children(Block * block, int* children){
     Index index = block->index();
-    int T = next_hilbert_state(index);
+    int ARRAY_BITS = 10;
+    int m = ARRAY_BITS + index.level();;
+    int states[m+2];
+    hilbert_states(index, m, states);
+    int T = states[m+1];
 
     for (int ic=0; ic<cello::num_children(); ic++) {
-        int hilbert_ind = PHM[T][ic];
+        int hilbert_ind = coord_to_hilbert_ind(T, ic);
         children[hilbert_ind] = ic;
     }
 }
 
-int MethodOrderHilbert::next_hilbert_state(Index index){
-    int level = index.level();
-
-    // Get binary inds for block. Here the ind for a particular
-    // direction consists of the array bits (which is 10 bits) and 
-    // the first l tree bits where l is the level of the block.
-    // ie, if block is on level 5 then x = AAAAAAAAAATTTTT.
-
-    // I think inds are already in the form I need. The bits are
-    // AAAAAAAAAATTTTTTTTTTTTTTTTTTTTLL where the array bits are
-    // right-justified and the tree bits are left justified. I just
-    // need to ignore the last two sign bits.
-
-    // Array bits for blocks with a negative level are already 
-    // appropriately padded with zeros on the left when they're
-    // created.
-
-    // All of this should mean we can take the index bits 'as-is'
-    // and work with them to get the hilbert indices etc.
-    int x = index[0];
-    int z = index[0];
-    int y = index[0];
-
-    int m = 10 + level;
-    int T = 0;
-    int TOTAL_BITS = 32;
-    int xi, yi, zi, xyzi;
-
-    for (int i = 0; i <= m; i++){
-        xi = (x >> (TOTAL_BITS-i)) & 1;
-        yi = (y >> (TOTAL_BITS-i)) & 1;
-        zi = (z >> (TOTAL_BITS-i)) & 1;
-
-        xyzi = (xi << 2) | (yi << 1) | zi;
-        T = PNM[T][xyzi];
-    }
-
-    return T;
-}
-
 Index MethodOrderHilbert::hilbert_next (Index index, int rank, bool is_leaf, int min_level)
 {
-    // make a copy
     Index index_next = index;
     int level = index.level();
     int ARRAY_BITS = 10;
     int m = ARRAY_BITS + level;
-    int states[m+1];
+    int states[m+2];
     hilbert_states(index, m, states);
     int T = states[m];
 
     // If the block has children then the first child (according to the hilbert order)
     // is the next index.
     if (! is_leaf) {
-        int ic = HPM[T][0];
-        index_next.push_child((ic >> 2) & 1, (ic >> 1) & 1, ic & 1, min_level);
+        int ic = hilbert_ind_to_coord(T, 0);
+        index_next.push_child(ic & 1, (ic >> 1) & 1, (ic >> 2) & 1, min_level);
 
     // Otherwise the next index is the next child of the first ancestor block whose children
     // haven't been completely processed yet
@@ -379,14 +337,14 @@ Index MethodOrderHilbert::hilbert_next (Index index, int rank, bool is_leaf, int
         // find the first ancestor (including self) that has child[k]=0 for some k.
         int ic3[3] = {0,0,0};
         int level = index_next.level();
-        int xyz = 0;
+        int zyx = 0;
         if (level > min_level) {
             // NOTE: sets ic3 to child index of this index in parent.
             index_next.child(level, ic3, ic3+1, ic3+2, min_level);
-            xyz = (ic3[0] << 2) + (ic3[1] << 1) + (ic3[2]);
+            zyx = (ic3[2] << 2) + (ic3[1] << 1) + (ic3[0]);
         }
 
-        bool last = (level == min_level) || (PHM[T][xyz] == 7);
+        bool last = (level == min_level) || (coord_to_hilbert_ind(T, zyx) == 7);
 
         // NOTE: this loop walks up the tree until it finds an index where last isn't true.
         while (level > min_level && last) {
@@ -396,105 +354,187 @@ Index MethodOrderHilbert::hilbert_next (Index index, int rank, bool is_leaf, int
             ic3[0] = ic3[1] = ic3[2] =0;
             if (level>min_level) {
                 index_next.child(level, ic3, ic3+1, ic3+2, min_level);
-                xyz = (ic3[0] << 2) + (ic3[1] << 1) + (ic3[2]);
+                zyx = (ic3[2] << 2) + (ic3[1] << 1) + (ic3[0]);
             }
 
             T = states[ARRAY_BITS + level];
-            bool last = (level == min_level) || (PHM[T][xyz] == 7);
+            bool last = (level == min_level) || (coord_to_hilbert_ind(T, zyx) == 7);
         }
 
         if (level == min_level) {
-            xyz = (ic3[0] << 2) + (ic3[1] << 1) + (ic3[2]);
-            int A_k = PHM[T][xyz];
+            zyx = (ic3[2] << 2) + (ic3[1] << 1) + (ic3[0]);
+            int A_k = coord_to_hilbert_ind(T, zyx);
             A_k = (A_k + 1) % 8;
-            xyz = HPM[T][A_k];
+            zyx = hilbert_ind_to_coord(T, A_k);
         } else {
-            xyz = 0;
+            zyx = 0;
         }
     
-        ic3[0] = (xyz >> 2) & 1;
-        ic3[1] = (xyz >> 1) & 1;
-        ic3[2] = xyz & 1;
+        ic3[2] = (zyx >> 2) & 1;
+        ic3[1] = (zyx >> 1) & 1;
+        ic3[0] = zyx & 1;
         index_next.set_child(level, ic3[0], ic3[1], ic3[2], min_level);
     }
     return index_next;
 }
 
 void MethodOrderHilbert::hilbert_states(Index index, int m, int* states) {
+    // Note: the length of the int array 'states' is expected to be m+2.
     int TOTAL_BITS = 32;
     int x = index[0];
     int y = index[1];
     int z = index[2];
-    int xi, yi, zi, xyzi, T = 0;
+    int xi, yi, zi, zyxi, T = 0;
 
-    for (int i = 0; i < m; i++) {
+    for (int i = 0; i <= m; i++) {
         xi = (x >> (TOTAL_BITS-i)) & 1;
         yi = (y >> (TOTAL_BITS-i)) & 1;
         zi = (z >> (TOTAL_BITS-i)) & 1;
-        xyzi = (xi << 2) || (yi << 1) || zi;
+        zyxi = (zi << 2) || (yi << 1) || xi;
 
         states[i] = T;
-        T = PNM[T][xyzi];
+        T = coord_to_next_state(T, zyxi);
     }
-    states[m] = T;
+    states[m+1] = T;
 }
+
+//========== Hilbert lookup functions ==========
+
+int MethodOrderHilbert::coord_to_hilbert_ind(int state, int coord) {
+    int rank = cello::rank();
+    int hilbert_ind;
+
+    if (rank == 3) {
+        hilbert_ind = PHM[state & 7][coord & 7];
+    } else if (rank == 2) {
+        hilbert_ind = CHM[state & 3][coord & 3];
+    } else if (rank == 1) {
+        hilbert_ind = coord & 1;
+    }
+
+    return hilbert_ind;
+}
+
+int MethodOrderHilbert::coord_to_next_state(int state, int coord) {
+    int rank = cello::rank();
+    int next_state;
+
+    if (rank == 3) {
+        next_state = PNM[state & 7][coord & 7];
+    } else if (rank == 2) {
+        next_state = CSM[state & 3][coord & 3];
+    } else if (rank == 1) {
+        next_state = 0;
+    }
+
+    return next_state;
+}
+
+int MethodOrderHilbert::hilbert_ind_to_coord(int state, int hilbert_ind) {
+    int rank = cello::rank();
+    int coord;
+
+    if (rank == 3) {
+        coord = HPM[state & 7][hilbert_ind & 7];
+    } else if (rank == 2) {
+        coord = HCM[state & 3][hilbert_ind & 3];
+    } else if (rank == 1) {
+        coord = hilbert_ind & 1;
+    }
+
+    return coord;
+}
+
+
+//========== 3D Hilbert lookup tables ==========
 
 // Hilbert ind to Point Map
 int MethodOrderHilbert::HPM[12][8] = {
-  {0, 1, 3, 2, 6, 7, 5, 4},
-  {6, 7, 5, 4, 0, 1, 3, 2},
-  {5, 7, 6, 4, 0, 2, 3, 1},
-  {3, 1, 0, 2, 6, 4, 5, 7},
-  {0, 1, 5, 4, 6, 7, 3, 2},
-  {6, 2, 3, 7, 5, 1, 0, 4},
-  {5, 1, 0, 4, 6, 2, 3, 7},
-  {3, 2, 6, 7, 5, 4, 0, 1},
-  {0, 4, 6, 2, 3, 7, 5, 1},
-  {6, 4, 0, 2, 3, 1, 5, 7},
-  {5, 7, 3, 1, 0, 2, 6, 4},
-  {3, 7, 5, 1, 0, 4, 6, 2}};
+    {0, 1, 3, 2, 6, 7, 5, 4},
+    {6, 7, 5, 4, 0, 1, 3, 2},
+    {5, 7, 6, 4, 0, 2, 3, 1},
+    {3, 1, 0, 2, 6, 4, 5, 7},
+    {0, 1, 5, 4, 6, 7, 3, 2},
+    {6, 2, 3, 7, 5, 1, 0, 4},
+    {5, 1, 0, 4, 6, 2, 3, 7},
+    {3, 2, 6, 7, 5, 4, 0, 1},
+    {0, 4, 6, 2, 3, 7, 5, 1},
+    {6, 4, 0, 2, 3, 1, 5, 7},
+    {5, 7, 3, 1, 0, 2, 6, 4},
+    {3, 7, 5, 1, 0, 4, 6, 2}};
 
 // Hilbert ind to Next state Map
 int MethodOrderHilbert::HNM[12][8] = {
-  { 8,  4,  4,  3,  3,  5,  5, 10},
-  { 9,  5,  5,  2,  2,  4,  4, 11},
-  { 6, 10, 10,  1,  1,  8,  8,  7},
-  { 7, 11, 11,  0,  0,  9,  9,  6},
-  { 8,  0,  0,  6,  6,  1,  1, 11},
-  { 1,  9,  9,  7,  7, 10, 10,  0},
-  { 2, 10, 10,  4,  4,  9,  9,  3},
-  {11,  3,  3,  5,  5,  2,  2,  8},
-  { 0,  4,  4,  9,  9,  7,  7,  2},
-  { 5,  1,  1,  8,  8,  3,  3,  6},
-  { 6,  2,  2, 11, 11,  0,  0,  5},
-  { 3,  7,  7, 10, 10,  4,  4,  1}};
+    { 8,  4,  4,  3,  3,  5,  5, 10},
+    { 9,  5,  5,  2,  2,  4,  4, 11},
+    { 6, 10, 10,  1,  1,  8,  8,  7},
+    { 7, 11, 11,  0,  0,  9,  9,  6},
+    { 8,  0,  0,  6,  6,  1,  1, 11},
+    { 1,  9,  9,  7,  7, 10, 10,  0},
+    { 2, 10, 10,  4,  4,  9,  9,  3},
+    {11,  3,  3,  5,  5,  2,  2,  8},
+    { 0,  4,  4,  9,  9,  7,  7,  2},
+    { 5,  1,  1,  8,  8,  3,  3,  6},
+    { 6,  2,  2, 11, 11,  0,  0,  5},
+    { 3,  7,  7, 10, 10,  4,  4,  1}};
 
 // Point to Hilbert ind Map
 int MethodOrderHilbert::PHM[12][8] = {
-  {0, 1, 3, 2, 7, 6, 4, 5},
-  {4, 5, 7, 6, 3, 2, 0, 1},
-  {4, 7, 5, 6, 3, 0, 2, 1},
-  {2, 1, 3, 0, 5, 6, 4, 7},
-  {0, 1, 7, 6, 3, 2, 4, 5},
-  {6, 5, 1, 2, 7, 4, 0, 3},
-  {2, 1, 5, 6, 3, 0, 4, 7},
-  {6, 7, 1, 0, 5, 4, 2, 3},
-  {0, 7, 3, 4, 1, 6, 2, 5},
-  {2, 5, 3, 4, 1, 6, 0, 7},
-  {4, 3, 5, 2, 7, 0, 6, 1},
-  {4, 3, 7, 0, 5, 2, 6, 1}};
+    {0, 1, 3, 2, 7, 6, 4, 5},
+    {4, 5, 7, 6, 3, 2, 0, 1},
+    {4, 7, 5, 6, 3, 0, 2, 1},
+    {2, 1, 3, 0, 5, 6, 4, 7},
+    {0, 1, 7, 6, 3, 2, 4, 5},
+    {6, 5, 1, 2, 7, 4, 0, 3},
+    {2, 1, 5, 6, 3, 0, 4, 7},
+    {6, 7, 1, 0, 5, 4, 2, 3},
+    {0, 7, 3, 4, 1, 6, 2, 5},
+    {2, 5, 3, 4, 1, 6, 0, 7},
+    {4, 3, 5, 2, 7, 0, 6, 1},
+    {4, 3, 7, 0, 5, 2, 6, 1}};
 
 // Point to Next state Map
 int MethodOrderHilbert::PNM[12][8] = {
-  { 8,  4,  3,  4, 10,  5,  3,  5},
-  { 2,  4, 11,  4,  2,  5,  9,  5},
-  { 1,  7,  8,  8,  1,  6, 10, 10},
-  {11, 11,  0,  7,  9,  9,  0,  6},
-  { 8,  0, 11,  1,  6,  0,  6,  1},
-  {10, 10,  9,  9,  0,  7,  1,  7},
-  {10, 10,  9,  9,  4,  2,  4,  3},
-  { 2,  8,  3, 11,  2,  5,  3,  5},
-  { 0,  2,  9,  9,  4,  7,  4,  7},
-  { 1,  3,  8,  8,  1,  3,  5,  6},
-  {11, 11,  0,  2,  5,  6,  0,  2},
-  {10, 10,  1,  3,  4,  7,  4,  7}};
+    { 8,  4,  3,  4, 10,  5,  3,  5},
+    { 2,  4, 11,  4,  2,  5,  9,  5},
+    { 1,  7,  8,  8,  1,  6, 10, 10},
+    {11, 11,  0,  7,  9,  9,  0,  6},
+    { 8,  0, 11,  1,  6,  0,  6,  1},
+    {10, 10,  9,  9,  0,  7,  1,  7},
+    {10, 10,  9,  9,  4,  2,  4,  3},
+    { 2,  8,  3, 11,  2,  5,  3,  5},
+    { 0,  2,  9,  9,  4,  7,  4,  7},
+    { 1,  3,  8,  8,  1,  3,  5,  6},
+    {11, 11,  0,  2,  5,  6,  0,  2},
+    {10, 10,  1,  3,  4,  7,  4,  7}};
+
+
+//========== 2D Hilbert lookup tables ==========
+
+// Point to Hilbert ind to Coord Map
+int MethodOrderHilbert::HCM[4][4] = {
+    {0, 1, 3, 2},
+    {0, 2, 3, 1},
+    {3, 2, 0, 1},
+    {3, 1, 0, 2}};
+
+// Point to Hilbert ind to State Map
+int MethodOrderHilbert::HSM[4][4] = {
+    {1, 0, 0, 3},
+    {0, 1, 1, 2},
+    {3, 2, 2, 1},
+    {2, 3, 3, 0}};
+
+// Point to Coord to Hilbert ind Map
+int MethodOrderHilbert::CHM[4][4] = {
+    {0, 1, 3, 2},
+    {0, 3, 1, 2},
+    {2, 3, 1, 0},
+    {2, 1, 3, 0}};
+
+// Point to Coord to State Map
+int MethodOrderHilbert::CSM[4][4] = {
+    {1, 0, 3, 0},
+    {0, 2, 1, 1},
+    {2, 1, 2, 3},
+    {3, 3, 0, 2}};

--- a/src/Cello/problem_MethodOrderHilbert.cpp
+++ b/src/Cello/problem_MethodOrderHilbert.cpp
@@ -1,0 +1,497 @@
+// See LICENSE_CELLO file for license and copyright information
+
+/// @file     problem_MethodOrderHilbert.cpp
+/// @author   John Brennan (john.brennnan@mu.ie)
+/// @date     2023-11-13
+/// @brief
+
+#include "problem.hpp"
+
+// #define TRACE_ORDER
+
+#ifdef TRACE_ORDER
+#  define TRACE_ORDER_BLOCK(MSG,BLOCK)          \
+  CkPrintf ("TRACE_ORDER %s %s\n",              \
+            std::string(MSG).c_str(),           \
+            BLOCK->name().c_str());             \
+  fflush(stdout);
+#else
+#  define TRACE_ORDER_BLOCK(MSG,BLOCK) /* ... */
+#endif
+
+
+//----------------------------------------------------------------------
+
+MethodOrderHilbert::MethodOrderHilbert(int min_level) throw ()
+  : Method(),
+    is_index_(-1),
+    is_weight_(-1),
+    is_weight_child_(-1),
+    min_level_(min_level)
+{
+  Refresh * refresh = cello::refresh(ir_post_);
+  cello::simulation()->refresh_set_name(ir_post_,name());
+  refresh->add_field("density");
+
+  /// Create Scalar data for ordering index
+  const int n = cello::num_children();
+  is_index_        = cello::scalar_descr_long_long()->new_value(name() + ":index");
+  is_count_        = cello::scalar_descr_long_long()->new_value(name() + ":count");
+  is_next_         = cello::scalar_descr_index()->new_value(name() + ":next");
+  is_weight_       = cello::scalar_descr_long_long()->new_value(name() + ":weight");
+  is_weight_child_ = cello::scalar_descr_long_long()->new_value(name() + ":weight_child",n);
+  is_sync_index_  = cello::scalar_descr_sync()->new_value(name() + ":sync_index");
+  is_sync_weight_ = cello::scalar_descr_sync()->new_value(name() + ":sync_weight");
+}
+
+//======================================================================
+
+void MethodOrderHilbert::compute (Block * block) throw()
+{
+  // Initialize counters, then barrier to ensure counters initialized
+  // before first entry method can arrive
+  TRACE_ORDER_BLOCK("compute",block);
+  Sync * sync_index = psync_index_(block);
+  Sync * sync_weight = psync_weight_(block);
+
+  *pindex_(block) = 0;
+  *pcount_(block) = 0;
+  *pweight_(block) = 1;
+  for (int i=0; i<cello::num_children(); i++) {
+    *pweight_child_(block,i) = 0;
+  }
+  sync_index->reset();
+  sync_weight->reset();
+  sync_index->set_stop(1 + 1);
+  sync_weight->set_stop(1 + cello::num_children());
+
+  CkCallback callback (CkIndex_Block::r_method_order_hilbert_continue(nullptr),
+                       block->proxy_array());
+
+  block->contribute (callback);
+
+}
+
+//----------------------------------------------------------------------
+
+void Block::r_method_order_hilbert_continue(CkReductionMsg * msg)
+{
+  delete msg;
+  static_cast<MethodOrderHilbert*>
+    (this->method())->compute_continue(this);
+}
+
+//----------------------------------------------------------------------
+
+void MethodOrderHilbert::compute_continue(Block * block)
+{
+  TRACE_ORDER_BLOCK("continue",block);
+  send_weight(block, 0, true);
+}
+
+//======================================================================
+void MethodOrderHilbert::send_weight(Block * block, int weight_child, bool self)
+{
+  // update own weight
+  // if not at finest level, send weight to parent
+  int weight = *pweight_(block);
+  int ic3[3] = {0,0,0};
+  if (self) {
+    recv_weight(block,ic3,0,true);
+  }
+  const int level = block->level();
+  if ((!self || block->is_leaf()) && level > min_level_)  {
+    const Index index_parent = block->index().index_parent(min_level_);
+    block->index().child(level,ic3,ic3+1,ic3+2,min_level_);
+    TRACE_ORDER_BLOCK("send_weight",block);
+    cello::block_array()[index_parent].p_method_order_hilbert_weight
+      (ic3,weight,block->index());
+    send_index(block, 0, 0, self);
+  } else if (level == min_level_) {
+
+    const int rank = cello::rank();
+    int na3[3];
+    cello::simulation()->hierarchy()->root_blocks(na3,na3+1,na3+2);
+
+    // TODO: use a "Hilbert_next" function here.
+    // Index index_next = block->index().next(rank,na3,block->is_leaf(),min_level_);
+    Index index_next = hilbert_next(block->index(), rank, block->is_leaf(), min_level_);
+
+    *pindex_(block) = 0;
+    *pcount_(block) = 0;
+    *pnext_(block) = index_next;
+
+    send_index(block, 0, weight, self);
+    if (!self) {
+      CkCallback callback
+        (CkIndex_Block::r_method_order_hilbert_complete (nullptr),
+         block->proxy_array());
+      block->contribute (callback);
+    }
+  }
+}
+
+//----------------------------------------------------------------------
+
+void Block::p_method_order_hilbert_weight(int ic3[3], int weight, Index index_child)
+{
+  static_cast<MethodOrderHilbert*>
+    (this->method())->recv_weight(this, ic3,weight,false);
+}
+
+//----------------------------------------------------------------------
+
+void MethodOrderHilbert::recv_weight
+(Block * block, int ic3[3], int weight, bool self)
+{
+  TRACE_ORDER_BLOCK("recv_weight",block);
+  // Update children weight if needed
+  if (!self) {
+    *pweight_(block) += weight;
+    int i = ic3[0] + 2*(ic3[1]+2*ic3[2]);
+    *pweight_child_(block,i) = weight;
+  }
+  if ((!block->is_leaf()) && psync_weight_(block)->next()) {
+    // Forward weight to parent when computed
+    int ic3[3] = {0,0,0};
+    block->index().child(block->level(),ic3,ic3+1,ic3+2,min_level_);
+    send_weight(block,*pweight_(block),false);
+  }
+}
+
+void MethodOrderHilbert::send_index
+(Block * block, int index_parent, int count, bool self)
+{
+  *pcount_(block) = count;
+  if (!block->is_leaf()) {
+    int index = *pindex_(block) + 1;
+
+    // TODO: Insert here code to loop over child blocks in hilbert order (I think this is done??)
+    int children[8];
+    hilbert_children(block, children);
+
+    for (int i=0; i<cello::num_children(); i++) {
+      int ic3[3];
+      ic3[0] = (children[i] >> 0) & 1;
+      ic3[1] = (children[i] >> 1) & 1;
+      ic3[2] = (children[i] >> 2) & 1;
+      Index index_child = block->index().index_child(ic3,min_level_);
+      cello::block_array()[index_child].p_method_order_hilbert_index(index,count);
+      index += *pweight_child_(block, children[i]);
+    }
+  }
+}
+
+void Block::p_method_order_hilbert_index(int index, int count)
+{
+  static_cast<MethodOrderHilbert*>
+    (this->method())->recv_index(this, index, count, false);
+}
+
+void MethodOrderHilbert::recv_index
+(Block * block, int index, int count, bool self)
+{
+  {
+    char buffer[80];
+    sprintf (buffer,"recv_index %d %d\n",index,count);
+    TRACE_ORDER_BLOCK(buffer,block);
+  }
+  if (!self) {
+    const int rank = cello::rank();
+    int na3[3];
+    cello::simulation()->hierarchy()->root_blocks(na3,na3+1,na3+2);
+
+    // TODO: use a "Hilbert_next" function here.
+    // Index index_next = block->index().next(rank,na3,block->is_leaf(),min_level_);
+    Index index_next = hilbert_next(block->index(), rank, block->is_leaf(), min_level_);
+    *pindex_(block) = index;
+    *pcount_(block) = count;
+    *pnext_(block) = index_next;
+  }
+  if (psync_index_(block)->next()) {
+    {
+      char buffer[80];
+      sprintf (buffer,"complete %d %d\n",index,count);
+      TRACE_ORDER_BLOCK(buffer,block);
+    } 
+    send_index(block,index, count, false);
+    CkCallback callback (CkIndex_Block::r_method_order_hilbert_complete(nullptr),
+                       block->proxy_array());
+    block->contribute (callback);
+  }
+}
+
+//----------------------------------------------------------------------
+
+void Block::r_method_order_hilbert_complete(CkReductionMsg * msg)
+{
+  delete msg;
+  static_cast<MethodOrderHilbert*>
+    (this->method())->compute_complete(this);
+}
+
+//----------------------------------------------------------------------
+
+void MethodOrderHilbert::compute_complete(Block * block)
+{
+  // Update Block's index and count
+  block->set_order(*pindex_(block),*pcount_(block));
+  block->compute_done();
+}
+
+
+//======================================================================
+
+long long * MethodOrderHilbert::pindex_(Block * block)
+{
+  Scalar<long long> scalar(cello::scalar_descr_long_long(),
+                     block->data()->scalar_data_long_long());
+  return scalar.value(is_index_);
+}
+
+//----------------------------------------------------------------------
+
+long long * MethodOrderHilbert::pcount_(Block * block)
+{
+  Scalar<long long> scalar(cello::scalar_descr_long_long(),
+                     block->data()->scalar_data_long_long());
+  return scalar.value(is_count_);
+}
+
+//----------------------------------------------------------------------
+
+Index * MethodOrderHilbert::pnext_(Block * block)
+{
+  Scalar<Index> scalar(cello::scalar_descr_index(),
+                     block->data()->scalar_data_index());
+  return scalar.value(is_next_);
+}
+
+//----------------------------------------------------------------------
+
+Sync * MethodOrderHilbert::psync_index_(Block * block)
+{
+  Scalar<Sync> scalar(cello::scalar_descr_sync(),
+                      block->data()->scalar_data_sync());
+  return scalar.value(is_sync_index_);
+}
+
+//----------------------------------------------------------------------
+
+long long * MethodOrderHilbert::pweight_(Block * block)
+{
+  Scalar<long long> scalar(cello::scalar_descr_long_long(),
+                     block->data()->scalar_data_long_long());
+  return scalar.value(is_weight_);
+}
+
+//----------------------------------------------------------------------
+
+long long * MethodOrderHilbert::pweight_child_(Block * block, int i)
+{
+  Scalar<long long> scalar(cello::scalar_descr_long_long(),
+                     block->data()->scalar_data_long_long());
+  return scalar.value(is_weight_child_)+i;
+}
+
+//----------------------------------------------------------------------
+
+Sync * MethodOrderHilbert::psync_weight_(Block * block)
+{
+  Scalar<Sync> scalar(cello::scalar_descr_sync(),
+                      block->data()->scalar_data_sync());
+  return scalar.value(is_sync_weight_);
+}
+
+
+//=========================================================
+
+void MethodOrderHilbert::hilbert_children(Block * block, int* children){
+    Index index = block->index();
+    int T = next_hilbert_state(index);
+
+    for (int ic=0; ic<cello::num_children(); ic++) {
+        int hilbert_ind = PHM[T][ic];
+        children[hilbert_ind] = ic;
+    }
+}
+
+int MethodOrderHilbert::next_hilbert_state(Index index){
+    int level = index.level();
+
+    // Get binary inds for block. Here the ind for a particular
+    // direction consists of the array bits (which is 10 bits) and 
+    // the first l tree bits where l is the level of the block.
+    // ie, if block is on level 5 then x = AAAAAAAAAATTTTT.
+
+    // I think inds are already in the form I need. The bits are
+    // AAAAAAAAAATTTTTTTTTTTTTTTTTTTTLL where the array bits are
+    // right-justified and the tree bits are left justified. I just
+    // need to ignore the last two sign bits.
+
+    // Array bits for blocks with a negative level are already 
+    // appropriately padded with zeros on the left when they're
+    // created.
+
+    // All of this should mean we can take the index bits 'as-is'
+    // and work with them to get the hilbert indices etc.
+    int x = index[0];
+    int z = index[0];
+    int y = index[0];
+
+    int m = 10 + level;
+    int T = 0;
+    int TOTAL_BITS = 32;
+    int xi, yi, zi, xyzi;
+
+    for (int i = 0; i <= m; i++){
+        xi = (x >> (TOTAL_BITS-i)) & 1;
+        yi = (y >> (TOTAL_BITS-i)) & 1;
+        zi = (z >> (TOTAL_BITS-i)) & 1;
+
+        xyzi = (xi << 2) | (yi << 1) | zi;
+        T = PNM[T][xyzi];
+    }
+
+    return T;
+}
+
+int MethodOrderHilbert::HPM[12][8] = {{0, 1, 3, 2, 6, 7, 5, 4},
+                                      {6, 7, 5, 4, 0, 1, 3, 2},
+                                      {5, 7, 6, 4, 0, 2, 3, 1},
+                                      {3, 1, 0, 2, 6, 4, 5, 7},
+                                      {0, 1, 5, 4, 6, 7, 3, 2},
+                                      {6, 2, 3, 7, 5, 1, 0, 4},
+                                      {5, 1, 0, 4, 6, 2, 3, 7},
+                                      {3, 2, 6, 7, 5, 4, 0, 1},
+                                      {0, 4, 6, 2, 3, 7, 5, 1},
+                                      {6, 4, 0, 2, 3, 1, 5, 7},
+                                      {5, 7, 3, 1, 0, 2, 6, 4},
+                                      {3, 7, 5, 1, 0, 4, 6, 2}};
+
+int MethodOrderHilbert::HNM[12][8] = {{ 8,  4,  4,  3,  3,  5,  5, 10},
+                                      { 9,  5,  5,  2,  2,  4,  4, 11},
+                                      { 6, 10, 10,  1,  1,  8,  8,  7},
+                                      { 7, 11, 11,  0,  0,  9,  9,  6},
+                                      { 8,  0,  0,  6,  6,  1,  1, 11},
+                                      { 1,  9,  9,  7,  7, 10, 10,  0},
+                                      { 2, 10, 10,  4,  4,  9,  9,  3},
+                                      {11,  3,  3,  5,  5,  2,  2,  8},
+                                      { 0,  4,  4,  9,  9,  7,  7,  2},
+                                      { 5,  1,  1,  8,  8,  3,  3,  6},
+                                      { 6,  2,  2, 11, 11,  0,  0,  5},
+                                      { 3,  7,  7, 10, 10,  4,  4,  1}};
+
+int MethodOrderHilbert::PHM[12][8] = {{0, 1, 3, 2, 7, 6, 4, 5},
+                                      {4, 5, 7, 6, 3, 2, 0, 1},
+                                      {4, 7, 5, 6, 3, 0, 2, 1},
+                                      {2, 1, 3, 0, 5, 6, 4, 7},
+                                      {0, 1, 7, 6, 3, 2, 4, 5},
+                                      {6, 5, 1, 2, 7, 4, 0, 3},
+                                      {2, 1, 5, 6, 3, 0, 4, 7},
+                                      {6, 7, 1, 0, 5, 4, 2, 3},
+                                      {0, 7, 3, 4, 1, 6, 2, 5},
+                                      {2, 5, 3, 4, 1, 6, 0, 7},
+                                      {4, 3, 5, 2, 7, 0, 6, 1},
+                                      {4, 3, 7, 0, 5, 2, 6, 1}};
+
+int MethodOrderHilbert::PNM[12][8] = {{ 8,  4,  3,  4, 10,  5,  3,  5},
+                                      { 2,  4, 11,  4,  2,  5,  9,  5},
+                                      { 1,  7,  8,  8,  1,  6, 10, 10},
+                                      {11, 11,  0,  7,  9,  9,  0,  6},
+                                      { 8,  0, 11,  1,  6,  0,  6,  1},
+                                      {10, 10,  9,  9,  0,  7,  1,  7},
+                                      {10, 10,  9,  9,  4,  2,  4,  3},
+                                      { 2,  8,  3, 11,  2,  5,  3,  5},
+                                      { 0,  2,  9,  9,  4,  7,  4,  7},
+                                      { 1,  3,  8,  8,  1,  3,  5,  6},
+                                      {11, 11,  0,  2,  5,  6,  0,  2},
+                                      {10, 10,  1,  3,  4,  7,  4,  7}};
+
+
+
+//##########################################################
+Index MethodOrderHilbert::hilbert_next (Index index, int rank, bool is_leaf, int min_level)
+{
+    // make a copy
+    Index index_next = index;
+
+    int level = index.level();
+    int ARRAY_BITS = 10;
+    int m = ARRAY_BITS + level;
+    int states[m+1];
+    hilbert_states(index, m, states);
+    int T = states[m];
+
+    if (! is_leaf) {
+        int ic = HPM[T][0];
+        index_next.push_child((ic >> 2) & 1, (ic >> 1) & 1, ic & 1, min_level);
+
+    } else {
+        // find the first ancestor (including self) that has child[k]=0 for some k.
+        int ic3[3] = {0,0,0};
+        int level = index_next.level();
+        int xyz = 0;
+        if (level > min_level) {
+            index_next.child(level, ic3, ic3+1, ic3+2, min_level); // NOTE: sets ic3 to child index of this index in parent.
+            xyz = (ic3[0] << 2) + (ic3[1] << 1) + (ic3[0]);
+        }
+
+        bool last = (level == min_level) || (PHM[T][xyz] == 7);
+
+        // NOTE: this loop walks up the tree until it finds an index where last isn't true.
+        while (level > min_level && last) {
+            // NOTE: this repeats the same logic as above but for the parent index.
+            index_next = index_next.index_parent(min_level);
+            level = index_next.level();
+            ic3[0] = ic3[1] = ic3[2] =0;
+            if (level>min_level) {
+                index_next.child(level, ic3, ic3+1, ic3+2, min_level);
+                xyz = (ic3[0] << 2) + (ic3[1] << 1) + (ic3[0]);
+            }
+
+            T = states[ARRAY_BITS + level];
+            bool last = (level == min_level) || (PHM[T][xyz] == 7);
+        }
+
+        if (level == min_level) {
+            xyz = (ic3[0] << 2) + (ic3[1] << 1) + (ic3[0]);
+            int A_k = PHM[T][xyz];
+            A_k = (A_k + 1) % 8;
+            xyz = HPM[T][A_k];
+        } else {
+            xyz = 0;
+        }
+    
+        ic3[0] = (xyz >> 2) & 1;
+        ic3[1] = (xyz >> 1) & 1;
+        ic3[2] = xyz & 1;
+        index_next.set_child(level, ic3[0], ic3[1], ic3[2], min_level);
+    }
+    return index_next;
+}
+
+void MethodOrderHilbert::hilbert_states(Index index, int m, int* states) {
+    int TOTAL_BITS = 32;
+
+    // int level = index.level();
+    // int ARRAY_BITS = 10;
+    // int m = ARRAY_BITS + level;
+    // int states[m+1];
+
+    int x = index[0];
+    int y = index[1];
+    int z = index[2];
+    int xi, yi, zi, xyzi, T = 0;
+
+    for (int i = 0; i < m; i++) {
+        xi = (x >> (TOTAL_BITS-i)) & 1;
+        yi = (y >> (TOTAL_BITS-i)) & 1;
+        zi = (z >> (TOTAL_BITS-i)) & 1;
+        xyzi = (xi << 2) || (yi << 1) || zi;
+
+        states[i] = T;
+        T = PNM[T][xyzi];
+    }
+    states[m] = T;
+}

--- a/src/Cello/problem_MethodOrderHilbert.hpp
+++ b/src/Cello/problem_MethodOrderHilbert.hpp
@@ -99,13 +99,16 @@ private: // methods
   /// Write, to the given states array, the recursive states of the given index up to level m. 
   void hilbert_states(Index index, int m, int* states);
 
-  /// Convert a zyx coordinate to the corresponding hilbert index for a given state
+  /// Check if the given coordinate is the last in the hilbert order with state T. 
+  bool is_last_child(int T, int coord);
+
+  /// Convert a zyx coordinate to the corresponding hilbert index for a given state.
   int coord_to_hilbert_ind(int state, int coord);
 
-  /// Convert a zyx coordinate to the next state for a given state
+  /// Convert a zyx coordinate to the next state for a given state.
   int coord_to_next_state(int state, int coord);
 
-  /// Convert a hilbert index to the corresponding zyx coordinate for a given state
+  /// Convert a hilbert index to the corresponding zyx coordinate for a given state.
   int hilbert_ind_to_coord(int state, int hilbert_ind);
 
 private: // functions

--- a/src/Cello/problem_MethodOrderHilbert.hpp
+++ b/src/Cello/problem_MethodOrderHilbert.hpp
@@ -1,0 +1,122 @@
+// See LICENSE_CELLO file for license and copyright information
+
+/// @file     problem_MethodOrderHilbert.hpp
+/// @author   John Brennan (john.brennnan@mu.ie)
+/// @date     2023-11-13
+/// @brief    [\ref Problem] Declaration of the MethodOrderHilbert class for
+///           generating the Hilbert ordering of blocks in the hierarchy
+
+#ifndef PROBLEM_METHOD_ORDER_HILBERT_HPP
+#define PROBLEM_METHOD_ORDER_HILBERT_HPP
+
+class MethodOrderHilbert : public Method {
+
+  /// @class    MethodOrderHilbert
+  /// @ingroup  Problem
+  /// @brief    [\ref Problem] 
+
+public: // interface
+
+  /// Constructor
+  MethodOrderHilbert(int min_level) throw();
+
+  /// Charm++ PUP::able declarations
+  PUPable_decl(MethodOrderHilbert);
+  
+  /// Charm++ PUP::able migration constructor
+  MethodOrderHilbert (CkMigrateMessage *m)
+    : Method (m)
+  { }
+
+  /// CHARM++ Pack / Unpack function
+  void pup (PUP::er &p)
+  {
+    Method::pup(p);
+    p | is_index_;
+    p | is_count_;
+    p | is_next_;
+    p | is_weight_;
+    p | is_weight_child_;
+    p | is_sync_index_;
+    p | is_sync_weight_;
+    p | min_level_;
+  }
+
+  void compute_continue( Block * block);
+  void compute_complete( Block * block);
+  void send_weight(Block * block, int weight, bool self);
+  void recv_weight(Block * block, int ic3[3], int weight, bool self);
+  void send_index(Block * block, int index, int count, bool self);
+  void recv_index(Block * block, int index, int count, bool self);
+
+public: // virtual methods
+  
+  /// Apply the method to determine the Hilbert ordering of blocks
+  virtual void compute( Block * block) throw();
+
+  virtual std::string name () throw () 
+  { return "order_hilbert"; }
+
+private: // methods
+
+  /// Return the pointer to the Block's Hilbert ordering index 
+  long long * pindex_(Block * block);
+
+  /// Return the pointer to the number of Block indices
+  long long * pcount_(Block * block);
+
+  /// Return the pointer to the Index of the "next" block
+  Index * pnext_(Block * block);
+
+  /// Return the pointer to the Block's weight (including self)
+  long long * pweight_(Block * block);
+
+  /// Return the pointer to the given Block's child weight
+  long long * pweight_child_(Block * block, int index);
+
+  /// Return the pointer to the Block's Hilbert ordering index 
+  Sync * psync_index_(Block * block);
+
+  /// Return the pointer to the Block's weight (including self)
+  Sync * psync_weight_(Block * block);
+
+private: // functions
+
+
+private: // attributes
+
+  // NOTE: change pup() function whenever attributes change
+
+  /// Block Scalar<int> index
+  int is_index_;
+  /// Block Scalar<int> count
+  int is_count_;
+  /// Block Scalar<Index> next
+  int is_next_;
+  /// Block Scalar<int> weight (#decendent blocks + self)
+  int is_weight_;
+  /// Block Scalar<int> child weight (array of size cello::num_children())
+  int is_weight_child_;
+  /// Block Scalar<Sync> sync counter for index (coarse->fine)
+  int is_sync_index_;
+  /// Block Scalar<sync> sync counter for weight (fine->coarse)
+  int is_sync_weight_;
+
+  /// Minimum refinement level for ordering; may be < 0
+  int min_level_;
+
+  /// Look up tables for encoding/decoding Hilbert indices
+  // TODO: update pup function
+  static int HPM[12][8];
+  static int HNM[12][8];
+  static int PHM[12][8];
+  static int PNM[12][8];
+
+  void hilbert_children(Block * block, int* children);
+  int next_hilbert_state(Index index);
+  Index hilbert_next (Index index, int rank, bool is_leaf, int min_level);
+  void hilbert_states(Index index, int m, int* states);
+};
+
+#endif /* PROBLEM_METHOD_ORDER_HILBERT_HPP */
+

--- a/src/Cello/problem_MethodOrderHilbert.hpp
+++ b/src/Cello/problem_MethodOrderHilbert.hpp
@@ -4,7 +4,17 @@
 /// @author   John Brennan (john.brennnan@mu.ie)
 /// @date     2023-11-13
 /// @brief    [\ref Problem] Declaration of the MethodOrderHilbert class for
-///           generating the Hilbert ordering of blocks in the hierarchy
+///           generating the Hilbert ordering of blocks in the hierarchy. This
+///           method uses the same communication pattern as MethodOrderMorton
+///           and an iterative algorithm based on lookup tables to compute 
+///           order indices for blocks. The iterative algorithm is based on
+///           those presented in "Mengjuan Li et al 2023 (Efficient entry 
+///           point encoding and decoding algorithms on 2D Hilbert space 
+///           filling curve)" and "Lianyin Jia et al 2022 (Efficient 3D 
+///           Hilbert curve encoding and decoding algorithms)".
+///           Note: There are some typos in the lookup tables presented in
+///           papers cited above. The tables used by this method should be
+///           the corrected versions.
 
 #ifndef PROBLEM_METHOD_ORDER_HILBERT_HPP
 #define PROBLEM_METHOD_ORDER_HILBERT_HPP
@@ -83,14 +93,20 @@ private: // methods
   /// Write child blocks of the given block to the children array in the hilbert order.
   void hilbert_children(Block * block, int* children);
 
-  /// Return the hilbert state for the next recursive layer (ie for the child blocks of the given index)
-  int next_hilbert_state(Index index);
-
   /// Return the index appearing after the given index in the hilber order.
   Index hilbert_next (Index index, int rank, bool is_leaf, int min_level);
 
   /// Write, to the given states array, the recursive states of the given index up to level m. 
   void hilbert_states(Index index, int m, int* states);
+
+  /// Convert a zyx coordinate to the corresponding hilbert index for a given state
+  int coord_to_hilbert_ind(int state, int coord);
+
+  /// Convert a zyx coordinate to the next state for a given state
+  int coord_to_next_state(int state, int coord);
+
+  /// Convert a hilbert index to the corresponding zyx coordinate for a given state
+  int hilbert_ind_to_coord(int state, int hilbert_ind);
 
 private: // functions
 
@@ -118,11 +134,15 @@ private: // attributes
   int min_level_;
 
   /// Look up tables for encoding/decoding Hilbert indices
-  // TODO: update pup function
   static int HPM[12][8];
   static int HNM[12][8];
   static int PHM[12][8];
   static int PNM[12][8];
+
+  static int HCM[4][4];
+  static int HSM[4][4];
+  static int CHM[4][4];
+  static int CSM[4][4];
 };
 
 #endif /* PROBLEM_METHOD_ORDER_HILBERT_HPP */

--- a/src/Cello/problem_MethodOrderHilbert.hpp
+++ b/src/Cello/problem_MethodOrderHilbert.hpp
@@ -80,6 +80,18 @@ private: // methods
   /// Return the pointer to the Block's weight (including self)
   Sync * psync_weight_(Block * block);
 
+  /// Write child blocks of the given block to the children array in the hilbert order.
+  void hilbert_children(Block * block, int* children);
+
+  /// Return the hilbert state for the next recursive layer (ie for the child blocks of the given index)
+  int next_hilbert_state(Index index);
+
+  /// Return the index appearing after the given index in the hilber order.
+  Index hilbert_next (Index index, int rank, bool is_leaf, int min_level);
+
+  /// Write, to the given states array, the recursive states of the given index up to level m. 
+  void hilbert_states(Index index, int m, int* states);
+
 private: // functions
 
 
@@ -111,11 +123,6 @@ private: // attributes
   static int HNM[12][8];
   static int PHM[12][8];
   static int PNM[12][8];
-
-  void hilbert_children(Block * block, int* children);
-  int next_hilbert_state(Index index);
-  Index hilbert_next (Index index, int rank, bool is_leaf, int min_level);
-  void hilbert_states(Index index, int m, int* states);
 };
 
 #endif /* PROBLEM_METHOD_ORDER_HILBERT_HPP */

--- a/src/Cello/problem_Problem.cpp
+++ b/src/Cello/problem_Problem.cpp
@@ -931,6 +931,10 @@ Method * Problem::create_method_
     //     Hierarchy?
     method = new MethodOrderMorton(config->mesh_min_level);
 
+  } else if (name == "order_hilbert") {
+
+    method = new MethodOrderHilbert(config->mesh_min_level);
+
   } else if (name == "refresh") {
     method = new MethodRefresh(p_group);
   } else if (name == "debug") {

--- a/src/Enzo/enzo-core/EnzoMethodBalance.cpp
+++ b/src/Enzo/enzo-core/EnzoMethodBalance.cpp
@@ -50,8 +50,8 @@ void EnzoMethodBalance::compute ( Block * block) throw()
     monitor->print("Method", "Calling Cello load-balancer");
 
   ScalarDescr * sd = cello::scalar_descr_long_long();
-  const int is_count = sd->index("order_morton:count");  
-  const int is_index = sd->index("order_morton:index");  
+  const int is_count = sd->index("order_hilbert:count") == -1 ? sd->index("order_morton:count") : sd->index("order_hilbert:count");
+  const int is_index = sd->index("order_hilbert:index") == -1 ? sd->index("order_morton:index") : sd->index("order_hilbert:index");
   Scalar<long long> scalar(cello::scalar_descr_long_long(),
                      block->data()->scalar_data_long_long());
 

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -293,3 +293,6 @@ add_custom_target(process_test_results
                   pandoc -s -o TEST_RESULTS.html --metadata title="Enzo-E Test Results" TEST_RESULTS.md
                   WORKING_DIRECTORY ${PROJECT_BINARY_DIR})
 
+# Load Balance
+#setup_test_parallel(LoadBalance-1 LoadBalance/morton-1  input/LoadBalance/test_balance-on-bcg.in)
+setup_test_parallel(LoadBalance-2 LoadBalance/hilbert-1  input/LoadBalance/test_hilbert-balance-on-bcg.in)


### PR DESCRIPTION
A `MethodOrderHilbert` class was added which uses a Hilbert curve to order blocks in a simulation.

The class is largely based on the MethodOrderMorton class but with some key logic/functions replaced with Hilbert versions. Namely, the logic for iterating over child blocks in a Morton order was replaced with a Hilbert version (facilitated by a `hilbert_children` function) and the `Index.next` method was replaced with `MethodOrderHilbert::hilbert_next`.

The algorithms for determining the Hilbert order are based on those presented in "Mengjuan Li et al 2023 (Efficient entry point encoding and decoding algorithms on 2D Hilbert space filling curve)" and "Lianyin Jia et al 2022 (Efficient 3D Hilbert curve encoding and decoding algorithms)" which are iterative and use look-up tables rather than recursive. Note, there are typos in the tables presented in these papers, the tables used by the `MethodOrderHilbert` class should be the correct ones.