### PR TITLE
Fix Answer Tests: Update CircleCi to use gold-standard version 5

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -280,7 +280,7 @@ jobs:
             - run: echo "starting steps for pytest answer generation"
             - compile-enzoe:
                 usedouble: << parameters.usedouble >>
-                tag: gold-standard-004
+                tag: gold-standard-005
                 skipfile: notafile
                 usegrackle: << parameters.usegrackle >>
             - run-answer-tests:


### PR DESCRIPTION
### Pull request summary

This PR modifies the CircleCI configuration file to bump the gold-standard version to version 5. 

This will help us fix the broken answer-tests. (The answer-tests will continue to fail in this PR since a `gold-standard-005` tag doesn't exist yet -- our standard procedure is to make the tag after this PR is merged)

### Detailed Description

Currently answer-tests are broken. This fixes the issue.

The Answer Tests are currently broken for the following reasons:
- ~3 days ago this PR, grackle-project/grackle#184, was merged into Grackle, which removed some deprecated functions from the Grackle codebase.
- Recall that continuous integration always builds the latest commit of Grackle for our tests[^1]
- However, the commit tagged as `gold-standard-004` (from 9 months back) **did** employ these functions. Thus, when our CI script tries to build that older version of Enzo-E to generate test-answer, the build fails.

The current tip of the main branch builds perfectly fine without these deprecated functions. Consequently, this PR seeks to take the first step towards bump the gold-standard version to the tip of the main branch (since the answer-tests all passed when the previous PR got merged).

**This bears repeating: (The answer-tests will continue to fail in this PR since a `gold-standard-005` tag doesn't exist yet -- our conventional procedure is to first merge this PR and then I will push the updated gold-standard tag onto the main branch)**

[^1]: It may be worth revisiting this choice. I think what we are doing makes sense since we are currently tell people to install the latest Grackle Version in our tutorial. Either way, I think this a topic for a separate discussion.