### PR TITLE
we dropped a handful of `ifdef` statements involving `CONFIG_USE_GRACKLE`

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -64,15 +64,10 @@ option(GRACKLE_USE_STATIC_LIBS  "sets Grackle's lib-type if USE_GRACKLE=ON" ON)
 if (USE_GRACKLE)
   find_package(Grackle)
   if (Grackle_FOUND)
-    # Setting global compile def as performance and simulation Cello libs need the var
-    # We should discuss the use of a central config.hpp (similar to the existing
-    # auto_config.def but also centrally included beyond informational output).
+    # This really only needs to be defined for a relatively small subset of
+    # files in the Enzo-layer
     add_compile_definitions(CONFIG_USE_GRACKLE)
 
-    # Also specifically setting the defines used in the *.ci files of Cello and Enzo.
-    # Alternatively, figure out a way to extract those from the `COMPILE_DEFINITIONS`
-    # property and directly process in `cmake/charm.cmake`.
-    set(CHARM_PREPROC_DEFS ${CHARM_PREPROC_DEFS} "-DCONFIG_USE_GRACKLE ")
   else()
     message(FATAL_ERROR
       "Configured to use Grackle but Grackle library not found.\n"

--- a/src/Cello/performance_Performance.hpp
+++ b/src/Cello/performance_Performance.hpp
@@ -58,9 +58,7 @@ enum perf_region {
   perf_stopping,
   perf_block,
   perf_exit,
-#ifdef CONFIG_USE_GRACKLE
   perf_grackle,
-#endif
   num_perf_region
 };
 

--- a/src/Cello/simulation_Simulation.cpp
+++ b/src/Cello/simulation_Simulation.cpp
@@ -426,9 +426,7 @@ void Simulation::initialize_performance_() throw()
   p->new_region(perf_stopping,           "stopping");
   p->new_region(perf_block,              "block");
   p->new_region(perf_exit,               "exit");
-#ifdef CONFIG_USE_GRACKLE
   p->new_region(perf_grackle,            "grackle");
-#endif
 
   timer_.start();
 

--- a/src/Enzo/enzo.ci
+++ b/src/Enzo/enzo.ci
@@ -23,9 +23,7 @@ module enzo {
   PUPable GrackleFacade;
 
   // EnzoInitial
-#ifdef CONFIG_USE_GRACKLE
   PUPable EnzoInitialGrackleTest;
-#endif
   PUPable EnzoInitialAccretionTest;
   PUPable EnzoInitialBBTest;
   PUPable EnzoInitialBCenter;

--- a/src/Enzo/hydro-mhd/EnzoMethodMHDVlct.cpp
+++ b/src/Enzo/hydro-mhd/EnzoMethodMHDVlct.cpp
@@ -43,16 +43,6 @@ EnzoMethodMHDVlct::EnzoMethodMHDVlct (std::string rsolver,
 				      bool store_fluxes_for_corrections)
   : Method()
 {
-#ifdef CONFIG_USE_GRACKLE
-  if (enzo::config()->method_grackle_use_grackle){
-    // we can remove the following once EnzoMethodGrackle no longer requires
-    // the internal_energy to be a permanent field
-    ASSERT("EnzoMethodMHDVlct::determine_quantities_",
-           ("Grackle cannot currently be used alongside this integrator "
-            "unless the dual-energy formalism is in use"),
-           enzo::fluid_props()->dual_energy_config().any_enabled());
-  }
-#endif /* CONFIG_USE_GRACKLE */
 
   time_scheme_ = time_scheme;
 
@@ -473,6 +463,18 @@ void EnzoMethodMHDVlct::compute ( Block * block) throw()
 
 void EnzoMethodMHDVlct::post_init_checks_() const noexcept
 {
+  if (enzo::grackle_chemistry() != nullptr){
+    // we can remove this check if:
+    // - EnzoMethodGrackle is modified to no longer require internal_energy to
+    //   be a permanent field
+    // - OR if EnzoMethodMHDVlct is modified to always track internal_energy
+    //   (even if not using dual-energy formalism)
+    ASSERT("EnzoMethodMHDVlct::determine_quantities_",
+           ("Grackle cannot currently be used alongside this integrator "
+            "unless the dual-energy formalism is in use"),
+           enzo::fluid_props()->dual_energy_config().any_enabled());
+  }
+
   ASSERT("EnzoMethodMHDVlct::post_init_checks_",
          "This solver isn't currently compatible with cosmological sims",
          enzo::cosmology() == nullptr);


### PR DESCRIPTION
### Pull request summary
This drops a handful of `ifdef` statements involving `CONFIG_USE_GRACKLE`

### Detailed Description

The benefits are pretty self-explanatory -- namely, it simplifies the codebase. In this particular case, it also simplifies some of the build files. It's also a step towards my goal of removing all of the `CONFIG_USE_GRACKLE` from all headers and just have it in a handful of source files in Enzo's `chemistry` subcomponent (so that rebuilding Enzo-E with/without grackle support can be done as incremental recompilation)
