### PR TITLE
Cleanup `_enzo.hpp` header

### DIFF
--- a/src/Enzo/_enzo.hpp
+++ b/src/Enzo/_enzo.hpp
@@ -29,29 +29,6 @@
 
 //----------------------------------------------------------------------
 
-enum {
-  index_turbulence_vad,
-  index_turbulence_aad,
-  index_turbulence_vvdot,
-  index_turbulence_vvot,
-  index_turbulence_vvd,
-  index_turbulence_vv,
-  index_turbulence_dd,
-  index_turbulence_d,
-  index_turbulence_dax,
-  index_turbulence_day,
-  index_turbulence_daz,
-  index_turbulence_dvx,
-  index_turbulence_dvy,
-  index_turbulence_dvz,
-  index_turbulence_dlnd,
-  index_turbulence_zones,
-  index_turbulence_mind,
-  index_turbulence_maxd,
-  max_turbulence_array };
-
-//----------------------------------------------------------------------
-
 enum enzo_sync_id {
   enzo_sync_id_cg = sync_id_last,
   enzo_sync_id_comoving_expansion,

--- a/src/Enzo/_enzo.hpp
+++ b/src/Enzo/_enzo.hpp
@@ -29,14 +29,6 @@
 
 //----------------------------------------------------------------------
 
-enum mass_type {
-  mass_unknown,
-  mass_dark,
-  mass_baryon
-};
-
-//----------------------------------------------------------------------
-
 enum {
   index_turbulence_vad,
   index_turbulence_aad,
@@ -116,22 +108,6 @@ enum return_enum {
   return_diverged,
   return_error,
   return_bypass
-};
-
-//----------------------------------------------------------------------
-
-const int field_undefined = -1;
-
-//----------------------------------------------------------------------
-
-struct enzo_fluxes
-{
-  long_int LeftFluxStartGlobalIndex [MAX_DIMENSION][MAX_DIMENSION];
-  long_int LeftFluxEndGlobalIndex   [MAX_DIMENSION][MAX_DIMENSION];
-  long_int RightFluxStartGlobalIndex[MAX_DIMENSION][MAX_DIMENSION];
-  long_int RightFluxEndGlobalIndex  [MAX_DIMENSION][MAX_DIMENSION];
-  enzo_float *LeftFluxes [MAX_NUMBER_OF_BARYON_FIELDS][MAX_DIMENSION];
-  enzo_float *RightFluxes[MAX_NUMBER_OF_BARYON_FIELDS][MAX_DIMENSION];
 };
 
 //----------------------------------------------------------------------

--- a/src/Enzo/assorted/EnzoMethodTurbulence.hpp
+++ b/src/Enzo/assorted/EnzoMethodTurbulence.hpp
@@ -11,6 +11,29 @@
 
 //----------------------------------------------------------------------
 
+enum {
+  index_turbulence_vad,
+  index_turbulence_aad,
+  index_turbulence_vvdot,
+  index_turbulence_vvot,
+  index_turbulence_vvd,
+  index_turbulence_vv,
+  index_turbulence_dd,
+  index_turbulence_d,
+  index_turbulence_dax,
+  index_turbulence_day,
+  index_turbulence_daz,
+  index_turbulence_dvx,
+  index_turbulence_dvy,
+  index_turbulence_dvz,
+  index_turbulence_dlnd,
+  index_turbulence_zones,
+  index_turbulence_mind,
+  index_turbulence_maxd,
+  max_turbulence_array };
+
+//----------------------------------------------------------------------
+
 class EnzoMethodTurbulence : public Method {
 
   /// @class    EnzoMethodTurbulence


### PR DESCRIPTION
### Pull request summary

This cleans up the `_enzo.hpp` header

### Detailed Description

I removed the following items (they weren't used anywhere):

- the ``mass_type`` enum
- the ``enzo_fluxes`` struct
- the ``field_undefined`` global constant

I also shifted the `index_turbulence_*` enum family to the header of `EnzoMethodTurbulence.hpp`, which defines the only class that uses these enums). 


<!--
**Thank you!**

We understand that PRs can sometimes be overwhelming, especially as the reviews start coming in.  Please let us know if the reviews are unclear or the recommended next step seems overly demanding, or if you would like help in addressing a reviewer's comments.  Lastly, please ping us if you've been waiting too long to hear back on your PR.
-->
