### PR TITLE
Migrate Parameter Parsing: moved configuration of `EnzoInitiailFeedbackTest` into constructor

### DIFF
--- a/src/Enzo/enzo-core/EnzoConfig.cpp
+++ b/src/Enzo/enzo-core/EnzoConfig.cpp
@@ -78,19 +78,6 @@ EnzoConfig::EnzoConfig() throw ()
   initial_collapse_particle_ratio(0.0),
   initial_collapse_mass(0.0),
   initial_collapse_temperature(0.0),
-  // EnzoInitialFeedbackTest
-  initial_feedback_test_density(),
-  initial_feedback_test_HI_density(),
-  initial_feedback_test_HII_density(),
-  initial_feedback_test_HeI_density(),
-  initial_feedback_test_HeII_density(),
-  initial_feedback_test_HeIII_density(),
-  initial_feedback_test_e_density(),
-  initial_feedback_test_star_mass(),
-  initial_feedback_test_temperature(),
-  initial_feedback_test_from_file(),
-  initial_feedback_test_metal_fraction(0.01),
-  initial_feedback_test_luminosity(),
   // EnzoInitialGrackleTest
   initial_grackle_test_maximum_H_number_density(1000.0),
   initial_grackle_test_maximum_metallicity(1.0),
@@ -343,7 +330,6 @@ EnzoConfig::EnzoConfig() throw ()
     method_background_acceleration_center[i] = 0.5;
     method_background_acceleration_angular_momentum[i] = 0;
 
-    initial_feedback_test_position[i] = 0.5;
   }
 
   method_background_acceleration_angular_momentum[2] = 1;
@@ -495,20 +481,6 @@ void EnzoConfig::pup (PUP::er &p)
   p | initial_burkertbodenheimer_radius_relative;
   p | initial_burkertbodenheimer_rotating;
   p | initial_burkertbodenheimer_temperature;
-
-  PUParray(p, initial_feedback_test_position,3);
-  p | initial_feedback_test_luminosity;
-  p | initial_feedback_test_density;
-  p | initial_feedback_test_e_density;
-  p | initial_feedback_test_from_file;
-  p | initial_feedback_test_HeI_density;
-  p | initial_feedback_test_HeII_density;
-  p | initial_feedback_test_HeIII_density;
-  p | initial_feedback_test_HI_density;
-  p | initial_feedback_test_HII_density;
-  p | initial_feedback_test_metal_fraction;
-  p | initial_feedback_test_star_mass;
-  p | initial_feedback_test_temperature;
 
   PUParray(p, initial_IG_center_position,3);
   PUParray(p, initial_IG_bfield,3);
@@ -736,7 +708,6 @@ void EnzoConfig::read(Parameters * p) throw()
   read_initial_cloud_(p);
   read_initial_collapse_(p);
   read_initial_cosmology_(p);
-  read_initial_feedback_test_(p);
   read_initial_grackle_(p);
   read_initial_hdf5_(p);
   read_initial_isolated_galaxy_(p);
@@ -1243,49 +1214,6 @@ void EnzoConfig::read_initial_isolated_galaxy_(Parameters * p)
 }
 
 //----------------------------------------------------------------------
-
-void EnzoConfig::read_initial_feedback_test_(Parameters * p)
-{
-  for (int axis=0; axis<3; axis++){
-    initial_feedback_test_position[axis] = p->list_value_float
-      (axis, "Initial:feedback_test:position", 0.5);
-  }
-  initial_feedback_test_luminosity = p->value_float
-    ("Initial:feedback_test:luminosity", 0.0);
-
-  initial_feedback_test_density = p->value_float
-    ("Initial:feedback_test:density", 1.0E-24);
-
-  initial_feedback_test_HI_density = p->value_float
-    ("Initial:feedback_test:HI_density", 1.0E-24);
-
-  initial_feedback_test_HII_density = p->value_float
-    ("Initial:feedback_test:HII_density", 1.0E-100);
-
-  initial_feedback_test_HeI_density = p->value_float
-    ("Initial:feedback_test:HeI_density", 1.0E-100);
-
-  initial_feedback_test_HeII_density = p->value_float
-    ("Initial:feedback_test:HeII_density", 1.0E-100);
-
-  initial_feedback_test_HeIII_density = p->value_float
-    ("Initial:feedback_test:HeIII_density", 1.0E-100);
-
-  initial_feedback_test_e_density = p->value_float
-    ("Initial:feedback_test:e_density", 1.0E-100);
-
-  initial_feedback_test_star_mass = p->value_float
-    ("Initial:feedback_test:star_mass", 1000.0);
-
-  initial_feedback_test_temperature = p->value_float
-    ("Initial:feedback_test:temperature", 1.0E4);
-
-  initial_feedback_test_from_file = p->value_logical
-    ("Initial:feedback_test:from_file", false);
-
-  initial_feedback_test_metal_fraction = p->value_float
-    ("Initial:feedback_test:metal_fraction", 0.01);
-}
 
 void EnzoConfig::read_initial_merge_sinks_test_(Parameters * p)
 {

--- a/src/Enzo/enzo-core/EnzoConfig.hpp
+++ b/src/Enzo/enzo-core/EnzoConfig.hpp
@@ -120,19 +120,6 @@ public: // interface
       initial_collapse_temperature(0.0),
       // EnzoInitialCosmology
       initial_cosmology_temperature(0.0),
-      // EnzoInitialFeedbackTest
-      initial_feedback_test_density(),
-      initial_feedback_test_e_density(),
-      initial_feedback_test_from_file(),
-      initial_feedback_test_HeI_density(),
-      initial_feedback_test_HeII_density(),
-      initial_feedback_test_HeIII_density(),
-      initial_feedback_test_HI_density(),
-      initial_feedback_test_HII_density(),
-      initial_feedback_test_metal_fraction(),
-      initial_feedback_test_star_mass(),
-      initial_feedback_test_temperature(),
-      initial_feedback_test_luminosity(),
       // EnzoGrackleTest
       initial_grackle_test_maximum_H_number_density(1000.0),
       initial_grackle_test_maximum_metallicity(1.0),
@@ -385,8 +372,6 @@ public: // interface
       initial_accretion_test_sink_velocity[axis] = 0.0;
       method_background_acceleration_center[axis] = 0.5;
       method_background_acceleration_angular_momentum[axis] = 0;
-
-      initial_feedback_test_position[axis] = 0.5;
     }
     method_background_acceleration_angular_momentum[2] = 1;
   }
@@ -413,7 +398,6 @@ protected: // methods
   void read_initial_cloud_(Parameters *);
   void read_initial_collapse_(Parameters *);
   void read_initial_cosmology_(Parameters *);
-  void read_initial_feedback_test_(Parameters *);
   void read_initial_grackle_(Parameters *);
   void read_initial_hdf5_(Parameters *);
   void read_initial_isolated_galaxy_(Parameters *);
@@ -620,22 +604,6 @@ public: // attributes
   double                     initial_turbulence_density;
   double                     initial_turbulence_pressure;
   double                     initial_turbulence_temperature;
-
-  /// EnzoInitialFeedbackTest
-
-  double                     initial_feedback_test_position[3];
-  double                     initial_feedback_test_luminosity;
-  double                     initial_feedback_test_density;
-  double                     initial_feedback_test_HI_density;
-  double                     initial_feedback_test_HII_density;
-  double                     initial_feedback_test_HeI_density;
-  double                     initial_feedback_test_HeII_density;
-  double                     initial_feedback_test_HeIII_density;
-  double                     initial_feedback_test_e_density;
-  double                     initial_feedback_test_star_mass;
-  double                     initial_feedback_test_temperature;
-  bool                       initial_feedback_test_from_file;
-  double                     initial_feedback_test_metal_fraction;
 
   /// EnzoInitialIsolatedGalaxy
   bool                       initial_IG_analytic_velocity;

--- a/src/Enzo/enzo-core/EnzoProblem.cpp
+++ b/src/Enzo/enzo-core/EnzoProblem.cpp
@@ -166,7 +166,7 @@ Initial * EnzoProblem::create_initial_
     initial = new EnzoInitialGrackleTest(enzo_config);
 #endif /* CONFIG_USE_GRACKLE */
   } else if (type == "feedback_test") {
-    initial = new EnzoInitialFeedbackTest(enzo_config);
+    initial = new EnzoInitialFeedbackTest(cycle, time, p_group);
   } else if (type == "vlct_bfield") {
     initial = new EnzoInitialBCenter(parameters, cycle, time,
 				     enzo_config->initial_bcenter_update_etot);

--- a/src/Enzo/tests/EnzoInitialFeedbackTest.cpp
+++ b/src/Enzo/tests/EnzoInitialFeedbackTest.cpp
@@ -18,14 +18,32 @@
 int nlines(std::string fname);
 
 
-EnzoInitialFeedbackTest::EnzoInitialFeedbackTest
-(const EnzoConfig * config) throw ()
-  : Initial(config->initial_cycle, config->initial_time)
+EnzoInitialFeedbackTest::EnzoInitialFeedbackTest(int cycle, double time,
+                                                 ParameterGroup p) throw ()
+  : Initial(cycle, time),
+    density_CGS_(p.value_float("density", 1.0E-24)),
+    temperature_(p.value_float("temperature", 1.0E4)),
+    metal_fraction_(p.value_float("metal_fraction", 0.01)),
+    species_densities_CGS_(),
+    num_particles(0),
+    position{},
+    mass(),
+    luminosity()
 {
 
   cello::particle_descr()->check_particle_attribute("star","mass");
 
-  if (config->initial_feedback_test_from_file){
+  // I kept things consistent when I transfered the parsing of parameters out
+  // of EnzoConfig, but it seems like HI_density should default to the value
+  // this->density_CGS_
+  species_densities_CGS_["HI_density"] = p.value_float("HI_density", 1.0E-24);
+  const std::vector<std::string> other_species =
+    {"HII_density","HeI_density","HeII_density","HeIII_density","e_density"};
+  for (const std::string species : other_species) {
+    species_densities_CGS_[species] = p.value_float(species, 1.0E-100);
+  }
+
+  if (p.value_logical("from_file", false)){
     this->num_particles = nlines("initial_feedback_stars.in");
 
     for (int dim = 0; dim < 3; dim++){
@@ -37,7 +55,8 @@ EnzoInitialFeedbackTest::EnzoInitialFeedbackTest
     std::fstream inFile;
     inFile.open("initial_feedback_stars.in", std::ios::in);
 
-    ASSERT("EnzoInitialFeedbackTest", "initial_feedback_stars.in failed to open",
+    ASSERT("EnzoInitialFeedbackTest",
+           "initial_feedback_stars.in failed to open",
            inFile.is_open());
 
     int i = 0;
@@ -55,10 +74,10 @@ EnzoInitialFeedbackTest::EnzoInitialFeedbackTest
     for (int dim = 0; dim < 3; dim++){
       this->position[dim].resize(this->num_particles);
 
-      this->position[dim][0] = config->initial_feedback_test_position[dim];
+      this->position[dim][0] = p.list_value_float(dim, "position", 0.5);
     }
-    this->mass[0] = config->initial_feedback_test_star_mass;
-    this->luminosity[0] = config->initial_feedback_test_luminosity;
+    this->mass[0] = p.value_float("star_mass", 1000.0);
+    this->luminosity[0] = p.value_float("luminosity", 0.0);
   }
 
   return;
@@ -74,9 +93,14 @@ void EnzoInitialFeedbackTest::pup (PUP::er &p)
 
   Initial::pup(p);
 
+  p | density_CGS_;
+  p | temperature_;
+  p | metal_fraction_;
+  p | species_densities_CGS_;
   p | num_particles;
   for (int dim = 0; dim < 3; dim++) p | position[dim];
   p | mass;
+  p | luminosity;
 
   return;
 }
@@ -94,8 +118,6 @@ void EnzoInitialFeedbackTest::enforce_block
     return;
   }
 
-  EnzoBlock * enzo_block = enzo::block(block);
-  const EnzoConfig * enzo_config = enzo::config();
   EnzoUnits * enzo_units = enzo::units();
 
   Field field = block->data()->field();
@@ -112,7 +134,6 @@ void EnzoInitialFeedbackTest::enforce_block
   enzo_float * d_HeII = (enzo_float *) field.values("HeII_density");
   enzo_float * d_HeIII = (enzo_float *) field.values("HeIII_density");
   enzo_float * d_electron = (enzo_float *) field.values("e_density");
-  enzo_float * temperature = (enzo_float *) field.values("temperature");
 
   enzo_float * v3[3] = { (enzo_float *) field.values("velocity_x"),
                          (enzo_float *) field.values("velocity_y"),
@@ -143,7 +164,15 @@ void EnzoInitialFeedbackTest::enforce_block
   int ngz = nz + 2*gz;
 
   const enzo_float gamma = enzo::fluid_props()->gamma();
+  // shouldn't we be using a self-consistent mmw?
   const enzo_float mol_weight = enzo::fluid_props()->mol_weight();
+
+  double d_HI_CGS = species_densities_CGS_.at("HI_density");
+  double d_HII_CGS = species_densities_CGS_.at("HII_density");
+  double d_HeI_CGS = species_densities_CGS_.at("HeI_density");
+  double d_HeII_CGS = species_densities_CGS_.at("HeII_density");
+  double d_HeIII_CGS = species_densities_CGS_.at("HeIII_density");
+  double d_electron_CGS = species_densities_CGS_.at("e_density");
 
   for (int iz = 0; iz < ngz; iz++){
     for (int iy = 0; iy < ngy; iy++){
@@ -152,23 +181,23 @@ void EnzoInitialFeedbackTest::enforce_block
          int i = INDEX(ix,iy,iz,ngx,ngy);
 
          // values are specified in CGS in the parameter file
-         d[i]  = enzo_config->initial_feedback_test_density / enzo_units->density(); 
-         d_HI[i]  = enzo_config->initial_feedback_test_HI_density / enzo_units->density();
-         d_HII[i]  = enzo_config->initial_feedback_test_HII_density / enzo_units->density();
-         d_HeI[i]  = enzo_config->initial_feedback_test_HeI_density / enzo_units->density();
-         d_HeII[i]  = enzo_config->initial_feedback_test_HeII_density / enzo_units->density();
-         d_HeIII[i]  = enzo_config->initial_feedback_test_HeIII_density / enzo_units->density();
-         d_electron[i]  = enzo_config->initial_feedback_test_e_density / enzo_units->density();
+         d[i]          = density_CGS_ / enzo_units->density(); 
+         d_HI[i]       = d_HI_CGS / enzo_units->density();
+         d_HII[i]      = d_HII_CGS / enzo_units->density();
+         d_HeI[i]      = d_HeI_CGS / enzo_units->density();
+         d_HeII[i]     = d_HeII_CGS / enzo_units->density();
+         d_HeIII[i]    = d_HeIII_CGS / enzo_units->density();
+         d_electron[i] = d_electron_CGS / enzo_units->density();
 
          for (int dim = 0; dim < 3; dim++) v3[dim][i] = 0.0;
 
-         ge[i] = (enzo_config->initial_feedback_test_temperature / mol_weight /
+         ge[i] = (temperature_ / mol_weight /
                   enzo_units->kelvin_per_energy_units() / (gamma - 1.0));
 
          for (int dim = 0; dim < 3; dim ++)
              te[i] = ge[i] + 0.5 * v3[dim][i] * v3[dim][i];
 
-         metal[i] = enzo_config->initial_feedback_test_metal_fraction * d[i];
+         metal[i] = this->metal_fraction_ * d[i];
 
       }
     }

--- a/src/Enzo/tests/EnzoInitialFeedbackTest.hpp
+++ b/src/Enzo/tests/EnzoInitialFeedbackTest.hpp
@@ -17,14 +17,22 @@ class EnzoInitialFeedbackTest : public Initial {
 public:  // interface
 
   ///Charm++ constructor
-  EnzoInitialFeedbackTest(const EnzoConfig * enzo_config) throw();
+  EnzoInitialFeedbackTest(int cycle, double time, ParameterGroup p) throw();
 
   /// Charm++ PUP::able declaration
   PUPable_decl(EnzoInitialFeedbackTest);
 
   /// CHARM++ migration constructor
   EnzoInitialFeedbackTest(CkMigrateMessage *m)
-      : Initial (m)
+    : Initial (m),
+      density_CGS_(0.0),
+      temperature_(0.0),
+      metal_fraction_(0.0),
+      species_densities_CGS_(),
+      num_particles(0),
+      position{},
+      mass(),
+      luminosity()
   {  }
 
   /// CHARM++ Pack / Unpack function
@@ -39,7 +47,11 @@ public:  // interface
   virtual ~EnzoInitialFeedbackTest() throw() {};
 
 private:
-
+  
+  double density_CGS_;
+  double temperature_;
+  double metal_fraction_;
+  std::map<std::string, double> species_densities_CGS_;
   int num_particles;
   std::vector<double> position[3];
   std::vector<double> mass;


### PR DESCRIPTION
### Pull request summary

Followup from #349: moved parameter parsing for `EnzoInitiailFeedbackTest` from `EnzoConfig` into constructor.

**Aside:** This sort of migration is the sort of thing that needs to be done for a lot more examples. This is a great first-time-contribution for new developers. I'm going to create an Issue summarizing the process and that links to this PR as an example (in reality, I will probably link to the particular commit that makes this change).