### PR TITLE
Migrate Parameter Parsing: moved configuration of `EnzoInitiailCloud` into constructor

### DIFF
--- a/src/Enzo/enzo-core/EnzoConfig.cpp
+++ b/src/Enzo/enzo-core/EnzoConfig.cpp
@@ -52,24 +52,6 @@ EnzoConfig::EnzoConfig() throw ()
   initial_burkertbodenheimer_densityprofile(1),
   initial_burkertbodenheimer_rotating(true),
   initial_burkertbodenheimer_outer_velocity(-1),
-  // EnzoInitialCloud
-  initial_cloud_center_x(0.0),
-  initial_cloud_center_y(0.0),
-  initial_cloud_center_z(0.0),
-  initial_cloud_density_cloud(0.0),
-  initial_cloud_density_wind(0.0),
-  initial_cloud_eint_wind(0.0),
-  initial_cloud_etot_wind(0.0),
-  initial_cloud_initialize_uniform_bfield(false),
-  initial_cloud_metal_mass_frac(0.0),
-  initial_cloud_perturb_Nwaves(0),
-  initial_cloud_perturb_amplitude(0.),
-  initial_cloud_perturb_min_wavelength(std::numeric_limits<double>::min()),
-  initial_cloud_perturb_max_wavelength(std::numeric_limits<double>::min()),
-  initial_cloud_perturb_seed(0),
-  initial_cloud_radius(0.),
-  initial_cloud_subsample_n(0),
-  initial_cloud_velocity_wind(0.0),
   // EnzoInitialCosmology
   initial_cosmology_temperature(0.0),
   // EnzoInitialCollapse
@@ -332,7 +314,6 @@ EnzoConfig::EnzoConfig() throw ()
 
 {
   for (int i=0; i<3; i++) {
-    initial_cloud_uniform_bfield[i] = 0;
     initial_sedov_array[i] = 0;
     initial_soup_array[i]  = 0;
     initial_soup_d_pos[i]  = 0.0;
@@ -394,25 +375,6 @@ void EnzoConfig::pup (PUP::er &p)
   p | physics_gravity_grav_constant_codeU;
 
   p | initial_bcenter_update_etot;
-
-  p | initial_cloud_subsample_n;
-  p | initial_cloud_radius;
-  p | initial_cloud_center_x;
-  p | initial_cloud_center_y;
-  p | initial_cloud_center_z;
-  p | initial_cloud_density_cloud;
-  p | initial_cloud_density_wind;
-  p | initial_cloud_velocity_wind;
-  p | initial_cloud_etot_wind;
-  p | initial_cloud_eint_wind;
-  p | initial_cloud_metal_mass_frac;
-  p | initial_cloud_initialize_uniform_bfield;
-  PUParray(p,initial_cloud_uniform_bfield,3);
-  p | initial_cloud_perturb_Nwaves;
-  p | initial_cloud_perturb_amplitude;
-  p | initial_cloud_perturb_min_wavelength;
-  p | initial_cloud_perturb_max_wavelength;
-  p | initial_cloud_perturb_seed;
 
   p | initial_cosmology_temperature;
 
@@ -733,7 +695,6 @@ void EnzoConfig::read(Parameters * p) throw()
   read_initial_bb_test_(p);
   read_initial_bcenter_(p);
   read_initial_burkertbodenheimer_(p);
-  read_initial_cloud_(p);
   read_initial_collapse_(p);
   read_initial_cosmology_(p);
   read_initial_feedback_test_(p);
@@ -1060,73 +1021,6 @@ void EnzoConfig::read_initial_bcenter_(Parameters * p)
   // VL+CT b-field initialization
   initial_bcenter_update_etot = p->value_logical
     ("Initial:vlct_bfield:update_etot",false);
-}
-
-//----------------------------------------------------------------------
-
-void EnzoConfig::read_initial_cloud_(Parameters * p)
-{
-  // Cloud Crush Initialization
-  initial_cloud_subsample_n            = p->value_integer
-    ("Initial:cloud:subsample_n",0);
-  initial_cloud_radius                 = p->value_float
-    ("Initial:cloud:cloud_radius",0.0);
-  initial_cloud_center_x               = p->value_float
-    ("Initial:cloud:cloud_center_x",0.0);
-  initial_cloud_center_y               = p->value_float
-    ("Initial:cloud:cloud_center_y",0.0);
-  initial_cloud_center_z               = p->value_float
-    ("Initial:cloud:cloud_center_z",0.0);
-  initial_cloud_density_cloud          = p->value_float
-    ("Initial:cloud:cloud_density",0.0);
-  initial_cloud_density_wind           = p->value_float
-    ("Initial:cloud:wind_density",0.0);
-  initial_cloud_velocity_wind          = p->value_float
-    ("Initial:cloud:wind_velocity",0.0);
-  initial_cloud_etot_wind              = p->value_float
-    ("Initial:cloud:wind_total_energy",0.0);
-  initial_cloud_eint_wind              = p->value_float
-    ("Initial:cloud:wind_internal_energy",0.0);
-  initial_cloud_metal_mass_frac        = p->value_float
-    ("Initial:cloud:metal_mass_fraction",0.0);
-  initial_cloud_perturb_Nwaves         = p->value_integer
-    ("Initial:cloud:perturb_Nwaves", 0);
-  initial_cloud_perturb_amplitude      = p->value_float
-    ("Initial:cloud:perturb_amplitude", 0.);
-  initial_cloud_perturb_min_wavelength = p->value_float
-    ("Initial:cloud:perturb_min_lambda", std::numeric_limits<double>::min());
-  initial_cloud_perturb_max_wavelength = p->value_float
-    ("Initial:cloud:perturb_max_lambda", std::numeric_limits<double>::min());
-  if (initial_cloud_perturb_Nwaves > 0){
-    if (initial_cloud_perturb_max_wavelength
-        == std::numeric_limits<double>::min() ){
-      initial_cloud_perturb_max_wavelength = initial_cloud_radius;
-    }
-  }
-
-
-  int init_cloud_perturb_seed_         = p->value_integer
-    ("Initial:cloud:perturb_seed",0);
-  ASSERT("EnzoConfig::read()",
-         "Initial:cloud:perturb_seed must be a 32-bit unsigned integer",
-	 (init_cloud_perturb_seed_ >= 0) &&
-         (init_cloud_perturb_seed_ <= 4294967295L));
-  initial_cloud_perturb_seed = (unsigned int) init_cloud_perturb_seed_;
-
-  int initial_cloud_uniform_bfield_length = p->list_length
-    ("Initial:cloud:uniform_bfield");
-  if (initial_cloud_uniform_bfield_length == 0){
-    initial_cloud_initialize_uniform_bfield = false;
-  } else if (initial_cloud_uniform_bfield_length == 3){
-    initial_cloud_initialize_uniform_bfield = true;
-    for (int i = 0; i <3; i++){
-      initial_cloud_uniform_bfield[i] = p->list_value_float
-	(i,"Initial:cloud:uniform_bfield");
-    }
-  } else {
-    ERROR("EnzoConfig::read",
-	  "Initial:cloud:uniform_bfield must contain 0 or 3 entries.");
-  }
 }
 
 //----------------------------------------------------------------------

--- a/src/Enzo/enzo-core/EnzoConfig.hpp
+++ b/src/Enzo/enzo-core/EnzoConfig.hpp
@@ -94,24 +94,6 @@ public: // interface
       initial_burkertbodenheimer_rank(0),
       initial_burkertbodenheimer_rotating(true),
       initial_burkertbodenheimer_temperature(0.0),
-      // EnzoInitialCloud
-      initial_cloud_center_x(0.0),
-      initial_cloud_center_y(0.0),
-      initial_cloud_center_z(0.0),
-      initial_cloud_density_cloud(0.0),
-      initial_cloud_density_wind(0.0),
-      initial_cloud_eint_wind(0.0),
-      initial_cloud_etot_wind(0.0),
-      initial_cloud_initialize_uniform_bfield(false),
-      initial_cloud_metal_mass_frac(0.0),
-      initial_cloud_perturb_Nwaves(0),
-      initial_cloud_perturb_amplitude(0.0),
-      initial_cloud_perturb_min_wavelength(std::numeric_limits<double>::min()),
-      initial_cloud_perturb_max_wavelength(std::numeric_limits<double>::min()),
-      initial_cloud_perturb_seed(0),
-      initial_cloud_radius(0.),
-      initial_cloud_subsample_n(0),
-      initial_cloud_velocity_wind(0.0),
       // EnzoInitialCollapse
       initial_collapse_mass(0.0),
       initial_collapse_particle_ratio(0.0),
@@ -372,7 +354,6 @@ public: // interface
 
   {
     for (int axis=0; axis<3; axis++) {
-      initial_cloud_uniform_bfield[axis] = 0;
       initial_sedov_array[axis] = 0;
       initial_sedov_random_array[axis] = 0;
       initial_soup_array[axis] = 0;
@@ -410,7 +391,6 @@ protected: // methods
   void read_initial_bb_test_(Parameters *);
   void read_initial_bcenter_(Parameters *);
   void read_initial_burkertbodenheimer_(Parameters *);
-  void read_initial_cloud_(Parameters *);
   void read_initial_collapse_(Parameters *);
   void read_initial_cosmology_(Parameters *);
   void read_initial_feedback_test_(Parameters *);
@@ -506,26 +486,6 @@ public: // attributes
   int                        initial_burkertbodenheimer_densityprofile;
   bool                       initial_burkertbodenheimer_rotating;
   double                     initial_burkertbodenheimer_outer_velocity;
-
-  /// EnzoInitialCloud;
-  double                     initial_cloud_center_x;
-  double                     initial_cloud_center_y;
-  double                     initial_cloud_center_z;
-  double                     initial_cloud_density_cloud;
-  double                     initial_cloud_density_wind;
-  double                     initial_cloud_eint_wind;
-  double                     initial_cloud_etot_wind;
-  bool                       initial_cloud_initialize_uniform_bfield;
-  double                     initial_cloud_uniform_bfield[3];
-  double                     initial_cloud_metal_mass_frac;
-  int                        initial_cloud_perturb_Nwaves;
-  double                     initial_cloud_perturb_amplitude;
-  double                     initial_cloud_perturb_min_wavelength;
-  double                     initial_cloud_perturb_max_wavelength;
-  unsigned int               initial_cloud_perturb_seed;
-  double                     initial_cloud_radius;
-  int                        initial_cloud_subsample_n;
-  double                     initial_cloud_velocity_wind;
 
   /// EnzoInitialCosmology;
   double                     initial_cosmology_temperature;

--- a/src/Enzo/enzo-core/EnzoProblem.cpp
+++ b/src/Enzo/enzo-core/EnzoProblem.cpp
@@ -171,26 +171,7 @@ Initial * EnzoProblem::create_initial_
     initial = new EnzoInitialBCenter(parameters, cycle, time,
 				     enzo_config->initial_bcenter_update_etot);
   } else if (type == "cloud") {
-    initial = new EnzoInitialCloud
-      (cycle,time,
-       enzo_config->initial_cloud_subsample_n,
-       enzo_config->initial_cloud_radius,
-       enzo_config->initial_cloud_center_x,
-       enzo_config->initial_cloud_center_y,
-       enzo_config->initial_cloud_center_z,
-       enzo_config->initial_cloud_density_cloud,
-       enzo_config->initial_cloud_density_wind,
-       enzo_config->initial_cloud_etot_wind,
-       enzo_config->initial_cloud_eint_wind,
-       enzo_config->initial_cloud_velocity_wind,
-       enzo_config->initial_cloud_metal_mass_frac,
-       enzo_config->initial_cloud_initialize_uniform_bfield,
-       enzo_config->initial_cloud_uniform_bfield,
-       enzo_config->initial_cloud_perturb_Nwaves,
-       enzo_config->initial_cloud_perturb_amplitude,
-       enzo_config->initial_cloud_perturb_min_wavelength,
-       enzo_config->initial_cloud_perturb_max_wavelength,
-       enzo_config->initial_cloud_perturb_seed);
+    initial = new EnzoInitialCloud(cycle,time, p_group);
   } else if (type == "collapse") {
     initial = new EnzoInitialCollapse
       (cycle,time,

--- a/src/Enzo/initial/EnzoInitialCloud.hpp
+++ b/src/Enzo/initial/EnzoInitialCloud.hpp
@@ -36,7 +36,6 @@ public: // interface
       eint_wind_(p.value_float("wind_internal_energy",0.0)),
       velocity_wind_(p.value_float("wind_velocity",0.0)),
       metal_mass_frac_(p.value_float("metal_mass_fraction",0.0)),
-      initialize_uniform_bfield_(false),
       perturb_Nwaves_(p.value_integer("perturb_Nwaves", 0)),
       perturb_amplitude_(p.value_float("perturb_amplitude", 0.)),
       perturb_min_wavelength_(p.value_float

--- a/src/Enzo/initial/EnzoInitialCloud.hpp
+++ b/src/Enzo/initial/EnzoInitialCloud.hpp
@@ -23,64 +23,80 @@ class EnzoInitialCloud : public Initial {
 public: // interface
 
   /// Constructor
-  EnzoInitialCloud(int cycle, double time, int subsample_n,
-		   double cloud_radius, double cloud_center_x,
-		   double cloud_center_y, double cloud_center_z,
-		   double density_cloud, double density_wind,
-		   double etot_wind, double eint_wind,
-		   double velocity_wind, double metal_mass_frac,
-		   bool initialize_uniform_bfield,
-		   const double uniform_bfield[3],
-		   int perturb_Nwaves, double perturb_amplitude,
-                   double perturb_min_wavelength,
-                   double perturb_max_wavelength, unsigned int perturb_seed)
+  EnzoInitialCloud(int cycle, double time, ParameterGroup p) noexcept
     : Initial(cycle,time),
-      subsample_n_(subsample_n),
-      cloud_radius_(cloud_radius),
-      cloud_center_x_(cloud_center_x),
-      cloud_center_y_(cloud_center_y),
-      cloud_center_z_(cloud_center_z),
-      density_cloud_(density_cloud),
-      density_wind_(density_wind),
-      etot_wind_(etot_wind),
-      eint_wind_(eint_wind),
-      velocity_wind_(velocity_wind),
-      metal_mass_frac_(metal_mass_frac),
-      initialize_uniform_bfield_(initialize_uniform_bfield),
-      perturb_Nwaves_(perturb_Nwaves),
-      perturb_amplitude_(perturb_amplitude),
-      perturb_min_wavelength_(perturb_min_wavelength),
-      perturb_max_wavelength_(perturb_max_wavelength),
-      perturb_seed_(perturb_seed)
+      subsample_n_(p.value_integer("subsample_n",0)),
+      cloud_radius_(p.value_float("cloud_radius",0.0)),
+      cloud_center_x_(p.value_float("cloud_center_x",0.0)),
+      cloud_center_y_(p.value_float("cloud_center_y",0.0)),
+      cloud_center_z_(p.value_float("cloud_center_z",0.0)),
+      density_cloud_(p.value_float("cloud_density",0.0)),
+      density_wind_(p.value_float("wind_density",0.0)),
+      etot_wind_(p.value_float("wind_total_energy",0.0)),
+      eint_wind_(p.value_float("wind_internal_energy",0.0)),
+      velocity_wind_(p.value_float("wind_velocity",0.0)),
+      metal_mass_frac_(p.value_float("metal_mass_fraction",0.0)),
+      initialize_uniform_bfield_(false),
+      perturb_Nwaves_(p.value_integer("perturb_Nwaves", 0)),
+      perturb_amplitude_(p.value_float("perturb_amplitude", 0.)),
+      perturb_min_wavelength_(p.value_float
+                              ("perturb_min_lambda",
+                               std::numeric_limits<double>::min())),
+      perturb_max_wavelength_(p.value_float
+                              ("perturb_max_lambda",
+                               std::numeric_limits<double>::min())),
+      perturb_seed_(0)
   {
-    for (int i = 0; i < 3; i++){ uniform_bfield_[i] = uniform_bfield[i]; }
+    if ( (perturb_Nwaves_ > 0) &&
+         (perturb_max_wavelength_ == std::numeric_limits<double>::min()) ){
+      perturb_max_wavelength_ = cloud_radius_;
+    }
 
-    ASSERT("EnzoInitialCloud", "subsample_n must be >=0", subsample_n>=0);
+    int perturb_seed_tmp = p.value_integer("perturb_seed",0);
+    ASSERT("EnzoInitialCloud",
+           "Initial:cloud:perturb_seed must be a 32-bit unsigned integer",
+           (perturb_seed_tmp >= 0) && (perturb_seed_tmp <= 4294967295L));
+    perturb_seed_ = (unsigned int) perturb_seed_tmp;
+
+    int uniform_bfield_length = p.list_length("uniform_bfield");
+    if (uniform_bfield_length == 0) {
+      initialize_uniform_bfield_ = false;
+    } else if (uniform_bfield_length == 3) {
+      initialize_uniform_bfield_ = true;
+      for (int i = 0; i <3; i++) {
+        uniform_bfield_[i] = p.list_value_float(i,"uniform_bfield");
+      }
+    } else {
+      ERROR("EnzoInitialCloud",
+            "Initial:cloud:uniform_bfield must contain 0 or 3 entries.");
+    }
+
+    ASSERT("EnzoInitialCloud", "subsample_n must be >=0", subsample_n_>=0);
     ASSERT("EnzoInitialCloud", "cloud_radius must be positive",
-	   cloud_radius>0);
+	   cloud_radius_>0);
     ASSERT("EnzoInitialCloud", "density_wind must be positive",
            density_wind_>0);
     ASSERT("EnzoInitialCloud", "density_cloud must be positive",
            density_cloud_>0);
     double ke_w = 0.5*velocity_wind_*velocity_wind_;
     ASSERT("EnzoInitialCloud", "etot_wind must exceed wind kinetic energy",
-	   etot_wind>ke_w);
+	   etot_wind_>ke_w);
     if (initialize_uniform_bfield_) {
       double me_w = 0.5*(uniform_bfield_[0]*uniform_bfield_[0]+
 			 uniform_bfield_[1]*uniform_bfield_[1]+
 			 uniform_bfield_[2]*uniform_bfield_[2])/density_wind_;
       ASSERT("EnzoInitialCloud",
 	     "etot_wind must exceed wind specific kinetic and magnetic energy",
-	     etot_wind>(ke_w+me_w));
+	     etot_wind_>(ke_w+me_w));
     }
     ASSERT("EnzoInitialCloud", "eint_wind must be zero or positive.",
-	   eint_wind>=0.);
+	   eint_wind_>=0.);
     ASSERT("EnzoInitialCloud", "metal_mass_frac must be in [0,1]",
-	   metal_mass_frac >=0 && metal_mass_frac <=1);
+	   metal_mass_frac_ >=0 && metal_mass_frac_ <=1);
     if (perturb_Nwaves_ > 0){
       ASSERT("EnzoInitialCloud",
              "perturb_amplitude_ must be positive if perturb_Nwaves_>0",
-             perturb_amplitude > 0);
+             perturb_amplitude_ > 0);
       ASSERT("EnzoInitialCloud",
              "perturb_min_wavelength_ must be positive if perturb_Nwaves_>0",
              perturb_min_wavelength_ > 0);


### PR DESCRIPTION
### Pull request summary

Followup from #349: moved parameter parsing for `EnzoInitiailCloud` from `EnzoConfig` into constructor.

**Aside:** This sort of migration is the sort of thing that needs to be done for a lot more examples. This is a great first-time-contribution for new developers. I'm going to create an Issue summarizing the process and that links to this PR as an example (in reality, I will probably link to the particular commit that makes this change).