### PR TITLE
macOS bugfix: support sizeof(long double) == 8

### DIFF
--- a/src/Cello/cello.cpp
+++ b/src/Cello/cello.cpp
@@ -11,11 +11,12 @@
 namespace cello {
 
   // @@@ KEEP IN SYNCH WITH precision_enum in cello.hpp
-  const char * precision_name[7] = {
+  const char * precision_name[8] = {
     "unknown",
     "default",
     "single",
     "double",
+    "extended64",
     "extended80",
     "extended96",
     "quadruple"
@@ -27,6 +28,7 @@ namespace cello {
     "default",    // "default" floating-point precision, e.g. enzo_float
     "single",
     "double",
+    "extended64",
     "extended80",
     "extended96",
     "quadruple",
@@ -42,6 +44,7 @@ namespace cello {
     0, // default
     4, // single
     8, // double
+    8, // extended64
     10, // extended80
     12, // extended96
     16, // quadruple
@@ -62,6 +65,7 @@ namespace cello {
     return (type == type_single || 
 	    type == type_double || 
 	    type == type_quadruple ||
+	    type == type_extended64 ||
 	    type == type_extended80 ||
 	    type == type_extended96);
   }
@@ -85,6 +89,9 @@ namespace cello {
       size = 4;
       break;
     case precision_double:
+      size = 8;
+      break;
+    case precision_extended64:
       size = 8;
       break;
     case precision_extended80:
@@ -119,6 +126,9 @@ namespace cello {
       break;
     case precision_double:
       is_supported = (sizeof(double)==8);
+      break;
+    case precision_extended64:
+      is_supported = (sizeof(long double)==8);
       break;
     case precision_extended80:
       is_supported = (sizeof(long double)==10);

--- a/src/Cello/cello.hpp
+++ b/src/Cello/cello.hpp
@@ -155,6 +155,7 @@ enum precision_enum {
   precision_default,     //  default precision
   precision_single,      //  32-bit field data
   precision_double,      //  64-bit field data
+  precision_extended64,  //  64-bit field data (long double)
   precision_extended80,  //  80-bit field data
   precision_extended96,  //  96-bit field data
   precision_quadruple,   // 128-bit field data
@@ -179,6 +180,7 @@ enum type_enum {
   type_single,
   type_float = type_single,
   type_double,
+  type_extended64,
   type_extended80,
   type_extended96,
   type_quadruple,
@@ -689,7 +691,7 @@ namespace cello {
 
   int sizeof_precision       (precision_type);
   int is_precision_supported (precision_type);
-  extern const char * precision_name[7];
+  extern const char * precision_name[8];
 
   /// converts a precision_enum to type_enum
   ///
@@ -862,6 +864,8 @@ namespace cello {
       return type_single;
     } else if constexpr (std::is_same_v<T_, double>) {
       return type_double;
+    } else if constexpr (std::is_same_v<T_, long double> && (sizeof(T_)==8)) {
+      return type_extended64;
     } else if constexpr (std::is_same_v<T_, long double> && (sizeof(T_)==10)) {
       return type_extended80;
     } else if constexpr (std::is_same_v<T_, long double> && (sizeof(T_)==12)) {

--- a/src/Cello/disk_FileHdf5.cpp
+++ b/src/Cello/disk_FileHdf5.cpp
@@ -908,6 +908,7 @@ hdf5_id FileHdf5::scalar_to_hdf5_ (int type) const throw()
 
   switch (type) {
   case type_unknown:
+  case type_extended64:
   case type_extended80:
   case type_extended96:
     ERROR1("FileHdf5::scalar_to_hdf5_",

--- a/src/Cello/problem_BoundaryValue.cpp
+++ b/src/Cello/problem_BoundaryValue.cpp
@@ -245,6 +245,7 @@ void BoundaryValue::enforce
 	  }
 	}
        	break;
+      case precision_extended64:
       case precision_extended80:
       case precision_extended96:
       case precision_quadruple:

--- a/src/Cello/test_Type.cpp
+++ b/src/Cello/test_Type.cpp
@@ -18,7 +18,8 @@ void check_get_type_enum(){
   unit_assert (cello::get_type_enum<double>() == type_double);
   {
     int long_double_val = cello::get_type_enum<long double>();
-    unit_assert((long_double_val == type_extended80) ||
+    unit_assert((long_double_val == type_extended64) ||
+                (long_double_val == type_extended80) ||
                 (long_double_val == type_extended96) ||
                 (long_double_val == type_quadruple));
   }
@@ -59,6 +60,8 @@ void check_enum_conversion(){
                 cello::convert_enum_precision_to_type(precision_single) );
   unit_assert ( type_double ==
                 cello::convert_enum_precision_to_type(precision_double) );
+  unit_assert ( type_extended64 ==
+                cello::convert_enum_precision_to_type(precision_extended64) );
   unit_assert ( type_extended80 ==
                 cello::convert_enum_precision_to_type(precision_extended80) );
   unit_assert ( type_extended96 ==


### PR DESCRIPTION
This is pretty self-explanatory. It turns out that apple-clang on arm-based Macs assign `long double` a size of 8 bytes. Even though it is the same size as a regular `double`, I think it makes more sense to treat it as a discrete type.