### PR TITLE
Replacing sprintf

### DIFF
--- a/src/Cello/_data.hpp
+++ b/src/Cello/_data.hpp
@@ -160,9 +160,9 @@ class FieldFace;
     CkPrintf ("DEBUG_FIELD %s %20.18g %20.18g %20.18g\n",  NAME,sum_abs,sum_mean,sum_var); \
     fflush(stdout);							\
     char filename[80];						\
-    sprintf (filename,"renzo-e-%s.png",NAME);				\
+    snprintf (filename,sizeof(filename),"renzo-e-%s.png",NAME); \
     png_array (filename,(float*)(FIELD),gx,gy,gz,mx,my,mz,__FILE__,__LINE__,2,16,16,SCALE); \
-    sprintf (filename,"enzo-e-%s.png",NAME);				\
+    snprintf (filename,sizeof(filename),"enzo-e-%s.png",NAME); \
     png_array (filename,(float*)(FIELD),0,0,0,mx,my,mz,__FILE__,__LINE__,2,16,16,SCALE); \
   }
 #   define TRACE_FIELD_(NAME,FIELD,SCALE) TRACE_FIELD_GM(NAME,FIELD,SCALE,gx_,gy_,gz_,mx_,my_,mz_,false)

--- a/src/Cello/cello.cpp
+++ b/src/Cello/cello.cpp
@@ -523,17 +523,21 @@ namespace cello {
       left  = left.substr(0,pos);
 
       strncpy (buffer, middle.c_str(),MAX_BUFFER);
-      if      (arg == "cycle") { sprintf (buffer_new,buffer, cycle); }
-      else if (arg == "time")  { sprintf (buffer_new,buffer, time); }
-      else if (arg == "count") { sprintf (buffer_new,buffer, counter); }
-      else if (arg == "proc")  { sprintf (buffer_new,buffer, CkMyPe()); }
-      else if (arg == "flipflop")  { sprintf (buffer_new,buffer, counter % 2); }
-      else 
-        {
+      if (arg == "cycle") {
+        snprintf (buffer_new, sizeof(buffer_new), buffer, cycle);
+      } else if (arg == "time") {
+        snprintf (buffer_new, sizeof(buffer_new), buffer, time);
+      } else if (arg == "count") {
+        snprintf (buffer_new, sizeof(buffer_new), buffer, counter);
+      } else if (arg == "proc") {
+        snprintf (buffer_new, sizeof(buffer_new), buffer, CkMyPe());
+      } else if (arg == "flipflop") {
+        snprintf (buffer_new, sizeof(buffer_new), buffer, counter % 2);
+      } else {
           ERROR3("cello::expand_name",
                  "Unknown file variable #%d '%s' for file '%s'",
                  int(i),arg.c_str(),name.c_str());
-        }
+      }
 
       right = std::string(buffer_new) + right;
 

--- a/src/Cello/control_adapt.cpp
+++ b/src/Cello/control_adapt.cpp
@@ -318,8 +318,8 @@ void Block::adapt_refine_()
     char buffer [80];
     int v3[3];
     index().values(v3);
-    sprintf (buffer,"Block %s (%x %x %x) is refining",name().c_str(),
-	     v3[0],v3[1],v3[2]);
+    snprintf (buffer,sizeof(buffer),"Block %s (%x %x %x) is refining",
+              name().c_str(),v3[0],v3[1],v3[2]);
     monitor->print("Adapt",buffer);
   }
 
@@ -906,8 +906,8 @@ void Block::adapt_coarsen_()
     char buffer [80];
     int v3[3];
     index().values(v3);
-    sprintf (buffer,"Block %s (%x %x %x) is coarsening",name().c_str(),
-	     v3[0],v3[1],v3[2]);
+    snprintf (buffer,sizeof(buffer),"Block %s (%x %x %x) is coarsening",
+              name().c_str(),v3[0],v3[1],v3[2]);
     monitor->print("Adapt",buffer);
   }
 

--- a/src/Cello/data_FieldData.cpp
+++ b/src/Cello/data_FieldData.cpp
@@ -303,10 +303,8 @@ void FieldData::clear
 	}
 	break;
       default:
-	char buffer[80];
-	sprintf (buffer,"Clear called with unsupported precision %s" ,
-		 cello::precision_name[precision]);
-	ERROR("FieldData::clear", buffer);
+	ERROR1("FieldData::clear", "Clear called with unsupported precision %s",
+               cello::precision_name[precision]);
       }
 
     }
@@ -675,7 +673,7 @@ void FieldData::print
   ip=CkMyPe();
 
   char filename [80];
-  sprintf (filename,"%s-%d.debug",message,ip);
+  snprintf (filename,sizeof(filename),"%s-%d.debug",message,ip);
   printf ("DEBUG message = %s\n",message);
   printf ("DEBUG filename = %s\n",filename);
 

--- a/src/Cello/data_FieldDescr.cpp
+++ b/src/Cello/data_FieldDescr.cpp
@@ -183,7 +183,7 @@ int FieldDescr::insert_(const std::string & field_name,
     for (int i=0; i<id; i++) {
       if (name_[i] == field_name) {
 	char buffer [ ERROR_LENGTH ];
-	sprintf (buffer,
+	snprintf (buffer, ERROR_LENGTH,
 		 "Insert field called multiple times with same field %s",
 		 field_name.c_str());
 	WARNING("FieldDescr::insert_permanent", buffer);
@@ -226,11 +226,8 @@ int FieldDescr::insert_(const std::string & field_name,
 void FieldDescr::set_precision(int id_field, int precision) throw()
 {
   if ( ! cello::is_precision_supported (precision) ) {
-    char buffer[80];
-    sprintf (buffer,"precision \"%s\" is not supported",
-	     cello::precision_name[precision]);
-    WARNING("FieldDescr::set_precision",
-	    buffer);
+    WARNING1("FieldDescr::set_precision","precision \"%s\" is not supported",
+	         cello::precision_name[precision]);
   }
   if (id_field >= 0) {
     precision_.at(id_field) = 

--- a/src/Cello/io_Input.cpp
+++ b/src/Cello/io_Input.cpp
@@ -184,15 +184,17 @@ std::string Input::expand_name_
 
     strncpy (buffer, middle.c_str(),MAX_BUFFER);
     
-    if      (arg == "cycle") { sprintf (buffer_new,buffer, cycle_); }
-    else if (arg == "time")  { sprintf (buffer_new,buffer, time_); }
-    else if (arg == "proc")  { sprintf (buffer_new,buffer, CkMyPe()); }
-    else 
-      {
-	ERROR3("Input::expand_name_",
-	       "Unknown file variable #%d '%s' for file '%s'",
-	       int(i),arg.c_str(),name.c_str());
-      }
+    if (arg == "cycle") {
+      snprintf (buffer_new,sizeof(buffer_new), buffer, cycle_);
+    } else if (arg == "time") {
+      snprintf (buffer_new,sizeof(buffer_new), buffer, time_);
+    } else if (arg == "proc") {
+      snprintf (buffer_new,sizeof(buffer_new), buffer, CkMyPe());
+    } else {
+	  ERROR3("Input::expand_name_",
+	         "Unknown file variable #%d '%s' for file '%s'",
+	         int(i),arg.c_str(),name.c_str());
+    }
 
     right = std::string(buffer_new) + right;
 

--- a/src/Cello/io_Output.cpp
+++ b/src/Cello/io_Output.cpp
@@ -183,18 +183,21 @@ std::string Output::expand_name_
     left  = left.substr(0,pos);
 
     strncpy (buffer, middle.c_str(),MAX_BUFFER);
-    
-    if      (arg == "cycle") { sprintf (buffer_new,buffer, cycle_); }
-    else if (arg == "time")  { sprintf (buffer_new,buffer, time_); }
-    else if (arg == "count") { sprintf (buffer_new,buffer, count_); }
-    else if (arg == "proc")  { sprintf (buffer_new,buffer, CkMyPe()); }
-    else if (arg == "flipflop")  { sprintf (buffer_new,buffer, count_%2); }
-    else 
-      {
-	ERROR3("Output::expand_name_",
-	       "Unknown file variable #%d '%s' for file '%s'",
-	       int(i),arg.c_str(),name.c_str());
-      }
+    if (arg == "cycle") {
+      snprintf (buffer_new, sizeof(buffer_new), buffer, cycle_);
+    } else if (arg == "time") {
+      snprintf (buffer_new, sizeof(buffer_new), buffer, time_);
+    } else if (arg == "count") {
+      snprintf (buffer_new, sizeof(buffer_new), buffer, count_);
+    } else if (arg == "proc") {
+      snprintf (buffer_new, sizeof(buffer_new), buffer, CkMyPe());
+    } else if (arg == "flipflop") {
+      snprintf (buffer_new, sizeof(buffer_new), buffer, count_ % 2);
+    } else {
+	  ERROR3("Output::expand_name_",
+             "Unknown file variable #%d '%s' for file '%s'",
+             int(i),arg.c_str(),name.c_str());
+    }
 
     right = std::string(buffer_new) + right;
 

--- a/src/Cello/io_OutputData.cpp
+++ b/src/Cello/io_OutputData.cpp
@@ -165,10 +165,11 @@ void OutputData::write_block ( const  Block * block ) throw()
     
   count = (text_block_count_ == 0) ? num_blocks : 0;
 
-  sprintf (file,"%s.block_list",name_file.c_str());
-  sprintf (dir, "%s",           name_dir.c_str());
-  sprintf (line,"%s %s\n",      block->name().c_str(),name_out_file.c_str());
-    
+  snprintf (file,sizeof(file),"%s.block_list",name_file.c_str());
+  snprintf (dir, sizeof(dir), "%s",           name_dir.c_str());
+  snprintf (line,sizeof(line),"%s %s\n",      block->name().c_str(),
+            name_out_file.c_str());
+
   proxy_main.p_text_file_write(strlen(dir)+1,  dir,
 			       strlen(file)+1, file,
 			       strlen(line)+1, line,
@@ -181,9 +182,9 @@ void OutputData::write_block ( const  Block * block ) throw()
       
     count = 0;
     
-    sprintf (file,"%s.file_list",name_file.c_str());
-    sprintf (dir, "%s",          name_dir.c_str());
-    sprintf (line,"%s\n",        name_out_file.c_str());
+    snprintf (file,sizeof(file),"%s.file_list",name_file.c_str());
+    snprintf (dir, sizeof(dir), "%s",          name_dir.c_str());
+    snprintf (line,sizeof(line),"%s\n",        name_out_file.c_str());
     
     proxy_main.p_text_file_write(strlen(dir)+1,  dir,
 				 strlen(file)+1, file,

--- a/src/Cello/mesh_Adapt.cpp
+++ b/src/Cello/mesh_Adapt.cpp
@@ -385,12 +385,13 @@ void Adapt::print(std::string message, const Block * block, FILE * fp) const
       info.index_.index_level(il3,max_level_);
       char neighbor_block[80];
       if (block) {
-        sprintf (neighbor_block,"%s",block->name(info.index_).c_str());
+        snprintf (neighbor_block,sizeof(neighbor_block),"%s",
+                  block->name(info.index_).c_str());
       } else {
         int it3[3],ia3[3];
         info.index_.array(ia3,ia3+1,ia3+2);
         info.index_.tree(it3,it3+1,it3+2);
-        sprintf (neighbor_block,"%X:%X %X:%X,%X:%X",
+        snprintf (neighbor_block,sizeof(neighbor_block),"%X:%X %X:%X,%X:%X",
                  ia3[0],it3[0],
                  ia3[1],it3[1],
                  ia3[2],it3[2]);
@@ -412,7 +413,8 @@ void Adapt::write(std::string root, const Block * block, int cycle_start) const
   const int cycle = cello::simulation()->cycle();
   if (cycle >= cycle_start) {
     char filename[80];
-    sprintf (filename,"%d-%s.%s",cycle,root.c_str(),block->name().c_str());
+    snprintf (filename,sizeof(filename),"%d-%s.%s",cycle,root.c_str(),
+              block->name().c_str());
 
     CkPrintf ("%s\n",filename);
 

--- a/src/Cello/mesh_Block.cpp
+++ b/src/Cello/mesh_Block.cpp
@@ -147,8 +147,8 @@ void Block::init_refine_
 
   if ((monitor != NULL) && monitor->is_verbose()) {
     char buffer [80];
-    sprintf (buffer,"Block() %s %d (%x %x %x) created",name().c_str(),
-	     index.level(),index[0],index[1],index[2]);
+    snprintf (buffer,sizeof(buffer),"Block() %s %d (%x %x %x) created",
+              name().c_str(), index.level(),index[0],index[1],index[2]);
     monitor->print("Adapt",buffer);
   }
   int ibx,iby,ibz;
@@ -546,8 +546,8 @@ Block::~Block()
 
   if (monitor && monitor->is_verbose()) {
     char buffer [80];
-    sprintf (buffer,"~Block() %s (%d;%d;%d) destroyed",name().c_str(),
-	     index_[0],index_[1],index_[2]);
+    snprintf (buffer,sizeof(buffer),"~Block() %s (%d;%d;%d) destroyed",
+              name().c_str(),index_[0],index_[1],index_[2]);
     monitor->print("Adapt",buffer);
   }
 

--- a/src/Cello/mesh_Block.hpp
+++ b/src/Cello/mesh_Block.hpp
@@ -859,7 +859,7 @@ protected: // functions
     char buffer[27];
     int v3[3];
     index_.values(v3);
-    sprintf (buffer,"%08X-%08X-%08X",
+    snprintf (buffer, sizeof(buffer), "%08X-%08X-%08X",
 	     v3[0],v3[1],v3[2]);
     return buffer;
   }

--- a/src/Cello/mesh_Index.cpp
+++ b/src/Cello/mesh_Index.cpp
@@ -528,7 +528,7 @@ void Index::write (int ip,
 		   const int nb3[3]) const
 {
   char filename[80];
-  sprintf (filename,"index.%s.%d",msg,ip);
+  snprintf (filename,sizeof(filename),"index.%s.%d",msg,ip);
   FILE * fp = fopen(filename,"a");
 
   print_(fp,msg,max_level,rank,nb3,false);

--- a/src/Cello/monitor_Monitor.cpp
+++ b/src/Cello/monitor_Monitor.cpp
@@ -182,7 +182,7 @@ void Monitor::write_ (FILE * fp, const char * component, const char * message) c
 
   char process[MONITOR_LENGTH] = "";
 
-  sprintf (process,"%0d",CkMyPe());
+  snprintf (process,MONITOR_LENGTH,"%0d",CkMyPe());
 
   // Get time
 
@@ -217,7 +217,7 @@ void Monitor::write_verbatim
 
     char buffer_process[MONITOR_LENGTH] = "";
 
-    sprintf (buffer_process,"%0d",CkMyPe());
+    snprintf (buffer_process,MONITOR_LENGTH,"%0d",CkMyPe());
 
     // Get time
 

--- a/src/Cello/parameters_Param.cpp
+++ b/src/Cello/parameters_Param.cpp
@@ -290,13 +290,13 @@ std::string Param::value_to_string (int type)
     string_buffer = expr_begin + char_buffer + expr_end;
     break;
   case parameter_integer:
-    sprintf (char_buffer,"%d",value_integer_);
+    snprintf (char_buffer,sizeof(char_buffer),"%d",value_integer_);
     string_buffer = char_buffer;
     break;
   case parameter_float:
     // '#' format character forces a decimal point, which is required to
     // differentiate an integer from a float type
-    sprintf (char_buffer,FLOAT_FORMAT,value_float_);
+    snprintf (char_buffer,sizeof(char_buffer),FLOAT_FORMAT,value_float_);
     string_buffer =  char_buffer;
     break;
   case parameter_logical:

--- a/src/Cello/problem_MethodOrderMorton.cpp
+++ b/src/Cello/problem_MethodOrderMorton.cpp
@@ -186,7 +186,7 @@ void MethodOrderMorton::recv_index
 {
   {
     char buffer[80];
-    sprintf (buffer,"recv_index %d %d\n",index,count);
+    snprintf (buffer,sizeof(buffer),"recv_index %d %d\n",index,count);
     TRACE_ORDER_BLOCK(buffer,block);
   }
   if (!self) {
@@ -201,7 +201,7 @@ void MethodOrderMorton::recv_index
   if (psync_index_(block)->next()) {
     {
       char buffer[80];
-      sprintf (buffer,"complete %d %d\n",index,count);
+      snprintf (buffer,sizeof(buffer),"complete %d %d\n",index,count);
       TRACE_ORDER_BLOCK(buffer,block);
     } 
     send_index(block,index, count, false);

--- a/src/Cello/simulation_Simulation.cpp
+++ b/src/Cello/simulation_Simulation.cpp
@@ -77,7 +77,7 @@ Simulation::Simulation
   CkPrintf ("%d DEBUG_SIMULATION Simulation(parameter_file,n)\n",CkMyPe());
   fflush(stdout);
   char name[40];
-  sprintf (name,"parameters-%02d.text",CkMyPe());
+  snprintf (name,sizeof(name),"parameters-%02d.text",CkMyPe());
   parameters_->write(name);
 #endif
   

--- a/src/Cello/simulation_Simulation.hpp
+++ b/src/Cello/simulation_Simulation.hpp
@@ -227,7 +227,7 @@ public: // virtual functions
   void debug_open() {
 #if defined(CELLO_DEBUG) || defined(CELLO_VERBOSE)
     char buffer[40];
-    sprintf(buffer,"out.debug.%03d-%03d",CkMyPe(),cycle_);
+    snprintf(buffer,sizeof(buffer),"out.debug.%03d-%03d",CkMyPe(),cycle_);
     fp_debug_ = fopen (buffer,"w");
 #endif
   }

--- a/src/Cello/test_Error.cpp
+++ b/src/Cello/test_Error.cpp
@@ -23,7 +23,7 @@ PARALLEL_MAIN_BEGIN
   PARALLEL_PRINTF ("Warning message:\n");
 
   char warning_message[ERROR_LENGTH];
-  sprintf (warning_message,"Warning message test");
+  snprintf (warning_message,sizeof(warning_message),"Warning message test");
   WARNING("main",warning_message);
 
   unit_func("WARNING");

--- a/src/Cello/test_Performance.cpp
+++ b/src/Cello/test_Performance.cpp
@@ -15,7 +15,7 @@
 void sleep_flop (int s, int count)
 {
   char sleep_string [10];
-  sprintf (sleep_string,"sleep %d",s);
+  snprintf (sleep_string,sizeof(sleep_string),"sleep %d",s);
   int err = system(sleep_string);
 
   if (err == -1) ERROR("main","system(sleep) failed!!");

--- a/src/Enzo/fluid-props/EnzoEOSIdeal.hpp
+++ b/src/Enzo/fluid-props/EnzoEOSIdeal.hpp
@@ -48,7 +48,7 @@ public: // public interface common to all EOS types
   /// create a string for debugging purposes that represents the EOS's value
   std::string debug_string() const noexcept {
     char buffer[50] = "";
-    sprintf(buffer, "EnzoEOSIdeal{ gamma : %#.16g }", gamma);
+    snprintf(buffer, sizeof(buffer), "EnzoEOSIdeal{ gamma : %#.16g }", gamma);
     return buffer;
   }
 

--- a/src/Enzo/gravity/solvers/EnzoSolverBiCgStab.cpp
+++ b/src/Enzo/gravity/solvers/EnzoSolverBiCgStab.cpp
@@ -890,7 +890,7 @@ void EnzoSolverBiCgStab::loop_2(EnzoBlock* block) throw() {
 
 #ifdef DEBUG_READ
     char buffer[40];
-    sprintf (buffer,"Q.%s",block->name().c_str());
+    snprintf (buffer,sizeof(buffer),"Q.%s",block->name().c_str());
     enzo_float * P = (enzo_float*) field.values(ip_);
     FILE * fp = fopen(buffer,"r");
     for (int i=0; i<m_; i++) fscanf (fp,"%g",P+i);
@@ -1192,7 +1192,7 @@ void EnzoSolverBiCgStab::loop_8(EnzoBlock* block) throw() {
 
 #ifdef DEBUG_WRITE
     char buffer[40];
-    sprintf (buffer,"Q.%s",block->name().c_str());
+    snprintf (buffer,sizeof(buffer),"Q.%s",block->name().c_str());
     FILE * fp = fopen(buffer,"w");
     enzo_float * Q = (enzo_float*) field.values(iq_);
     for (int i=0; i<m_; i++) fprintf (fp,"%g\n",Q[i]);


### PR DESCRIPTION
### Pull request summary

As mentioned in #390, macOS has decided that `sprintf` is deprecated, which produces a lot of annoying compiler warnings. This replaces all occurrences of `sprintf` outside of the parsing code (which is addressed by #390)

### Detailed Description

This is pretty self-explanatory. I would have loved to have consolidated the implementations of `cello::expand_name` and `Output::expand_name_``, but I was a little confused about the differences (and I was trying to get through this relatively quickly).

Aside: In case you're unaware, if you declare a c-style array
```c
char my_arr[14];
```
then calling `sizeof(my_arr)` gives the total size of the array in bytes (in contrast, calling `sizeof` on a pointer just gives the size of the pointer). I take advantage of this a lot throughout this PR.

This PR has no dependencies. (It is totally independent from #390)