### PR TITLE
Remove last Enzo layer cmake-`GLOB`s

### DIFF
--- a/doc/source/devel/cmake_primer.rst
+++ b/doc/source/devel/cmake_primer.rst
@@ -186,12 +186,21 @@ At the time of writing this page, this should now be less of an issue.
 What do I need to change when I add a new file to the source code?
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
-The answer to this question is: "usually nothing".
-The CMake system for Enzo-E is configured to use globbing expressions to locate source files that are included in the build.
-As long your new files are added to one of the main source directories and follows standard naming conventions, the build system should automatically find it.
+The answer depends on whether you are adding a file to the Cello layer or the Enzo layer.
+Here, we assume that you're adding a file to an existing directory.
 
-As an aside, our usage of globbing expressions to locate sources needed by CMake is considered a bad practice by the CMake developers.
-Their recommendation is that all files used in the build are explicitly listed.
+ * If you're adding a file to the Cello layer, you usually don't need to do anything.
+   In more detail, the CMake system for this layer is currently configured to use globbing expressions to locate source files that are included in the build.
+   As long your new files are added to the main source directory and follows standard naming conventions, the build system should automatically find it.
+
+ * If you're adding a file to the Enzo layer, you need to open the ``CMakeLists.txt`` file in the directory where your new file is located.
+   You then need to find the location within the ``CMakeLists.txt`` file where the other files in the directory are currently listed and insert the name of your new file into that list.
+
+
+Originally, we used globbing expressions everywhere, but we have fully phased them out of the Enzo layer (we may consider phasing them out of the Cello layer in the future).
+
+In more detail, the usage of globbing expressions to locate sources needed by CMake is considered a bad practice by the CMake developers.
+Their recommendation is that all files used in the build are explicitly listed (as is now done in the Enzo layer).
 This is because CMake generally only adjusts the build system if a ``CMakeLists.txt`` file has been updated (e.g. if you append a new entry to the list of source files).
 Historically, if you globbed for source files, CMake wouldn't know that it needed to rebuild the list of source files when you added a new one (since the ``CMakeLists.txt`` file wasn't touched).
 
@@ -204,7 +213,7 @@ The CMake developers generally view this unfavorably because:
 
  * "[t]he ``CONFIGURE_DEPENDS`` flag may not work reliably on all generators"
 
-For that reason, we may want to reconsider our approach in the future.
+Furthermore, incremental-rebuilds generally perform, after changing branches, when the required sources are explicitly listed.
 
 .. note:
    In the interval of time between Enzo-E's transition to using CMake and the patch introducing this documentation, the command to locate source files with globbing expressions did not include the ``CONFIGURE_DEPENDS`` Flag.

--- a/doc/source/devel/coding-guidelines.rst
+++ b/doc/source/devel/coding-guidelines.rst
@@ -361,7 +361,6 @@ Usually you will introduce a header (``.hpp``) and source (``.cpp``) file at the
    If it doesn't exist, check the parent directory.
    Repeat the process until you find it.
 5. Add the paths to your new header and source file to the existing list of other files that are located in the same subdirectory as your new files.
-   (If no such list exists, but you see something about ``GLOB``, you may not need to do anything).
 
 **How do I delete a file from the Enzo Layer?**
 

--- a/src/Enzo/CMakeLists.txt
+++ b/src/Enzo/CMakeLists.txt
@@ -26,17 +26,6 @@ target_link_libraries(main_enzoCharmModule INTERFACE enzoCharmModule)
 #    target_include_directories(<MY-TARGET> PUBLIC ${ROOT_INCLUDE_DIR})
 set(ROOT_INCLUDE_DIR ${CMAKE_CURRENT_SOURCE_DIR}/../)
 
-# Get the list of source files
-# - we do this using GLOB patterns. This approach is not recommended by the
-#   authors of CMake (their recommendation is to explicitly list all files that
-#   must be installed).
-# - Some of the disadvantages of this approach are mitigated by inclusion of
-#   the CONFIGURE_DEPENDS flag.
-# - See the CMake Primer section of the developer documentation for more details
-file(GLOB SRC_FILES CONFIGURE_DEPENDS
-  *.cpp *.F *.hpp fortran.h fortran_types.h
-)
-
 set(Cello_LIBS "cello_component;charm_component;control;disk;error;data;io;memory;mesh;monitor;parameters;parallel;performance;problem;compute;simulation;test_Unit")
 
 set(External_LIBS "")
@@ -56,7 +45,7 @@ endif()
 
 # Step 1: forward-declare the enzo library. This holds most of the files that
 #         are turned into the enzo binary. (We will return to this shortly)
-add_library(enzo STATIC ${SRC_FILES})
+add_library(enzo STATIC charm_enzo.cpp)
 
 # Step 2: define main_enzo
 # -> this includes a machinery for driving the simulation (it's directly

--- a/src/Enzo/enzo-core/CMakeLists.txt
+++ b/src/Enzo/enzo-core/CMakeLists.txt
@@ -10,25 +10,33 @@
 #         rm complains that it can't remove a directory.
 #       - We choose to avoid that name in order to avoid worrying users
 
-# Get the list of source files in this directory
-# - we do this using GLOB patterns. This approach is not recommended by the
-#   authors of CMake (their recommendation is to explicitly list all files that
-#   must be installed).
-# - Some of the disadvantages of this approach are mitigated by inclusion of
-#   the CONFIGURE_DEPENDS flag.
-# - See the CMake Primer section of the developer documentation for more details
-file(GLOB LOCAL_SRC_FILES CONFIGURE_DEPENDS
-  *.cpp *.hpp
+
+target_sources(enzo PRIVATE
+  EnzoBlock.cpp
+  EnzoBlock.hpp
+  EnzoBoundary.cpp
+  EnzoBoundary.hpp
+  EnzoConfig.cpp
+  EnzoConfig.hpp
+  EnzoFactory.cpp
+  EnzoFactory.hpp
+  EnzoMethodBalance.cpp
+  EnzoMethodBalance.hpp
+  EnzoMsgCheck.cpp
+  EnzoMsgCheck.hpp
+  EnzoProblem.cpp
+  EnzoProblem.hpp
+  EnzoSimulation.cpp
+  EnzoSimulation.hpp
+  EnzoStopping.cpp
+  EnzoStopping.hpp
+  EnzoUnits.hpp
+  enzo.cpp
 )
-
-# remove the unit-test file from this search
-list(FILTER LOCAL_SRC_FILES EXCLUDE REGEX "test_EnzoUnits")
-
-target_sources(enzo PRIVATE ${LOCAL_SRC_FILES})
 
 if (BUILD_TESTING)
   # Add a unit test
-  add_executable(test_enzo_units "test_EnzoUnits.cpp")
+  add_executable(test_enzo_units test_EnzoUnits.cpp)
   target_link_libraries(test_enzo_units PRIVATE enzo main_enzo)
   target_link_options(test_enzo_units PRIVATE ${Cello_TARGET_LINK_OPTIONS})
 endif()


### PR DESCRIPTION
<!--
Thank you so much for your PR! To help us review, fill out the form to the best of your ability.  Please make use of the development guide at https://enzo-e.readthedocs.io/en/main/devel/index.html

(For context, all of this text enclosed by these fancy brackets are comments that won't be rendered by GitHub)
-->


### Pull request summary

This modifies `src/Enzo/CMakeLists.txt` and `src/Enzo/enzo-core/CMakeLists.txt` so that the source files are no longer fetched with globbing expressions.


### Detailed Description

After this PR is merged and #386 is merged, there will no longer be any globbing expressions in the Enzo layer. Other PRs that made similar changes include https://github.com/enzo-project/enzo-e/pull/332 - https://github.com/enzo-project/enzo-e/pull/336 as well as #367. 

The other aforementioned PRs also converted the other subdirectories into separate "subcomponents." Essentially the source files were grouped together into distinct CMake targets (they're usually compiled into a distinct static-library) and their headers were removed from `src/Enzo/_enzo.hpp`, and inserted into a single separate header (for this scenario the analogous header-file name is `src/Enzo/enzo-core/enzo-core.hpp`. We did not do that here.

That is in fact something I still really want to do. But that's going to take some time. Plus I think achieving conformity in terms of the build system is very valuable in it's own right. (As I've mentioned elsewhere, shifting from glob-expressions to directly listing source files will generally help with rebuilds when switching between branches).

This also reflects the documentation to reflect that no `CMakeLists.txt` file in the Enzo layer involves globbing expressions.

This PR has 0 dependencies.