### PR TITLE
remove deprecated `Method:mhd_vlct:{half,full}_dt_reconstruct_method` parameters

### DIFF
--- a/doc/source/param/method_mhd_vlct.incl
+++ b/doc/source/param/method_mhd_vlct.incl
@@ -139,52 +139,6 @@ The Method:mhd_vlct:mhd_choice determines whether the method is used as a pure h
 
 ----
 
-.. par:parameter:: Method:mhd_vlct:half_dt_reconstruct_method
-
-   :Summary: :s:`name of the reconstruction method to use for the full timestep`
-   :Type:   :par:typefmt:`string`
-   :Default: :d:`nn`
-   :Scope:     :z:`Enzo`
-
-   :e:`Name of the interpolation method used to reconstruct face-centered
-   primitives for the first half timestep.` ``"nn"`` :e:`is recommended
-   for this method (problems arise if` ``"plm"`` :e:`or` ``"plm_athena"``
-   :e:`are used). For a list of options, see`
-   :ref:`using-vlct-reconstruction`
-
-   .. warning::
-
-      This parameter is deprecated and will be removed in a future version.
-      It only carried meaning while using the original predictor-corrector
-      time integration scheme.
-
-      Furthermore, this parameter only conveyed the illusion of choice. In
-      reality, the integrator ONLY worked when this was set to ``"nn"``. For
-      that reason, this parameter is not replaced.
-
-----
-
-.. par:parameter:: Method:mhd_vlct:full_dt_reconstruct_method
-
-   :Summary: :s:`name of the reconstruction method to use for the full timestep`
-   :Type:   :par:typefmt:`string`
-   :Default: :d:`plm`
-   :Scope:     :z:`Enzo`
-
-   :e:`Name of the interpolation method used to reconstruct face-centered
-   primitives for the full timestep. For a list of options, see`
-   :ref:`using-vlct-reconstruction`
-
-   
-
-   .. warning::
-
-      This parameter is deprecated and will be removed in a future version.
-      The :par:param:`~Method:mhd_vlct:reconstruct_method` parameter is a
-      direct replacement.
-
-----
-
 Deprecated mhd_vlct parameters
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 The following parameters have all been deprecated and will be removed

--- a/src/Enzo/hydro-mhd/EnzoMethodMHDVlct.cpp
+++ b/src/Enzo/hydro-mhd/EnzoMethodMHDVlct.cpp
@@ -59,40 +59,14 @@ parse_mhdchoice_pack_pair_(ParameterGroup p)
            p.get_group_path().c_str());
   }
 
-  // backwards compatibilty: deprecated half/full_dt_reconstruct_method params
   if (is_defined("half_dt_reconstruct_method") ||
       is_defined("full_dt_reconstruct_method")) {
-
-    if (is_defined("time_scheme") || is_defined("reconstruct_method")) {
-      ERROR1("parse_mhdchoice_pack_pair_",
-             "In the \"%s\" parameter-group, the deprecated parameters, "
-             "\"half_dt_reconstruct_method\" & \"full_dt_reconstruct_method\", "
-             "can't be specified when \"time_scheme\" or "
-             "\"reconstruct_method\" is specified.",
-             p.get_group_path().c_str());
-    }
-
-    if (p.value_string("half_dt_reconstruct_method", "nn") != "nn") {
-      // it never made ANY sense to allow the half timestep of the VL+CT
-      // algorithm to use anything other than the "nn" choice. (The only reason
-      // it was ever an option was due to a misunderstanding early on)
-      ERROR1("parse_mhdchoice_pack_pair_",
-             "The deprecated parameter, \"%s:half_dt_reconstruct_method\", "
-             "can't have any value other than \"nn\"",
-             p.get_group_path().c_str());
-    }
-
-    if (is_defined("full_dt_reconstruct_method")) {
-      recon_names[1] = p.value_string("full_dt_reconstruct_method", "plm");
-    }
-
-    WARNING1("parse_mhdchoice_pack_pair_",
-             "In the \"%s\" parameter-group, \"half_dt_reconstruct_method\" & "
-             "\"full_dt_reconstruct_method\" are deprecated, and they will be "
-             "removed in the future. The former can't have any value other "
-             "than \"nn\"; it won't be replaced. Use \"reconstruct_method\" "
-             "instead of the latter.",
-             p.get_group_path().c_str());
+    ERROR1("parse_mhdchoice_pack_pair_",
+           "In the \"%s\" parameter-group, \"half_dt_reconstruct_method\" & "
+           "\"full_dt_reconstruct_method\" have been removed. The former was "
+           "only allowed to have a value of \"nn\" and the latter was "
+           "replaced with \"reconstruct_method\".",
+           p.get_group_path().c_str());
   }
 
   // allocate and initialize argpack-ptr


### PR DESCRIPTION
### Pull request summary

This is pretty self-explanatory. I removed 2 deprecated parameters from the VL+CT solver.

### Detailed Description

The VL+CT solver still has a few other remaining deprecated parameters but those are a little tricky to remove (since they are now employed by to configure `EnzoPhysicsFluidProps`). The PPM solver has a similar set of deprecated parameters and I think they should both be removed at the same time