### PR TITLE
Adjusting the tolerance for MHD slow magnetosonic wave

### DIFF
--- a/input/vlct/run_MHD_linear_wave_test.py
+++ b/input/vlct/run_MHD_linear_wave_test.py
@@ -182,7 +182,7 @@ def analyze_tests():
     r.append(err_compare(3.005870212811956e-08,  'alfven',  1, 32))
 
     r.append(err_compare(2.2373810027584788e-07, 'slow',    1, 16))
-    r.append(err_compare(4.437026706327692e-08,  'slow',    1, 32))
+    r.append(err_compare(4.43702e-08,            'slow',    1, 32))
 
     r.append(err_compare(1.0021263485338544e-07, 'entropy', 1, 16))
     r.append(err_compare(2.9194839706868883e-08,  'entropy', 1, 32))

--- a/input/vlct/testing_utils.py
+++ b/input/vlct/testing_utils.py
@@ -281,8 +281,12 @@ def isclose(a,b,abs_tol = False):
     # subtracted
     if abs_tol:
         # slow wave requires slightly bigger tolerance (since it includes more
-        # timesteps which allows the floating point errors to grow more)
-        atol = 5.e-14
+        # timesteps which allows the floating point errors to grow more).
+        # -> the variation can be shockingly large between machines. When
+        #    comparing ubuntu 20.04 with a macbook, the difference was nearly
+        #    2e-13 while both used gcc compilers. We choose something in the
+        #    middle...
+        atol = 7.e-14
     else:
         atol = 0
     return np.isclose(a,b,rtol=err,atol=atol)


### PR DESCRIPTION
### Pull request summary

I adjusted the tolerance on MHD slow magnetosonic wave so that the test passes on macOS.


### Detailed Description

In more detail,
- I confirmed that on my older linux machine, the L1 error norms are extremely consistent with the existing value (regardless of whether I use gcc or clang). In other words, I confirmed that nothing has broken the tests. (we pretty much knew that already based on circleci, but it was nice confirmation)
- It turns out that the results are just shockingly different on my MacBook (regardless of whether I use g++ or apple-clang).

My assumption is that some combination of the differences in operating systems and the differences in architectures cause differences in how floating-point values get rounded and those differences compound over the course of the test.

ASIDE: I have confirmed that Issue #328 is still a problem (the stable-gravity wave test fails when compiled with clang). But, that seems to be **entirely** unrelated (I've confirmed that it is compiler-related and not machine-related). That's a problem for a different PR. (I'll add some updates to that issue).