### PR TITLE
Make additional use of `ParameterGroup`

### DIFF
--- a/src/Cello/parameters_Config.cpp
+++ b/src/Cello/parameters_Config.cpp
@@ -815,15 +815,13 @@ void Config::read_monitor_ (Parameters * p) throw()
 
 //----------------------------------------------------------------------
 
-void Config::read_output_ (Parameters * p) throw()
+void Config::read_output_ (Parameters * all_p) throw()
 {
   //--------------------------------------------------
   // Output
   //--------------------------------------------------
 
-  p->group_set(0,"Output");
-
-  num_output = p->list_length("list");
+  num_output = all_p->list_length("Output:list");
 
   output_list.resize(num_output);
   output_type.resize(num_output);
@@ -854,48 +852,54 @@ void Config::read_output_ (Parameters * p) throw()
   output_particle_list.resize(num_output);
   output_name.resize(num_output);
 
-  output_dir_global = p->value_string("dir_global",".");
+  output_dir_global = all_p->value_string("Output:dir_global",".");
 
   for (int index_output=0; index_output<num_output; index_output++) {
 
     TRACE1 ("index = %d",index_output);
 
     output_list[index_output] = 
-      p->list_value_string (index_output,"Output:list","unknown");
+      all_p->list_value_string (index_output,"Output:list","");
+    
+    if (output_list[index_output] == "") {
+      ERROR1("Config::read_output_",
+             "there was a problem parsing element %d of Output:list",
+             index_output);
+    }
 
-    p->group_set(1,output_list[index_output]);
+    ParameterGroup p (*all_p, "Output:" + output_list[index_output]);
 
-    output_type[index_output] = p->value_string("type","unknown");
+    output_type[index_output] = p.value_string("type","unknown");
 
     if (output_type[index_output] == "unknown") {
-      ERROR1("Config::read",
+      ERROR1("Config::read_output_",
 	     "Output:%s:type parameter is undefined",
 	     output_list[index_output].c_str());
     }
 
-    output_stride_write[index_output] = p->value_integer("stride_write",0);
+    output_stride_write[index_output] = p.value_integer("stride_write",0);
 
-    output_stride_wait[index_output] = p->value_integer("stride_wait",0);
+    output_stride_wait[index_output] = p.value_integer("stride_wait",0);
 
-    if (p->type("dir") == parameter_string) {
+    if (p.type("dir") == parameter_string) {
       output_dir[index_output].resize(1);
-      output_dir[index_output][0] = p->value_string("dir","");
-    } else if (p->type("dir") == parameter_list) {
-      int size = p->list_length("dir");
+      output_dir[index_output][0] = p.value_string("dir","");
+    } else if (p.type("dir") == parameter_list) {
+      int size = p.list_length("dir");
       if (size > 0) output_dir[index_output].resize(size);
       for (int i=0; i<size; i++) {
-	output_dir[index_output][i] = p->list_value_string(i,"dir","");
+	output_dir[index_output][i] = p.list_value_string(i,"dir","");
       }
     }
 
-    if (p->type("name") == parameter_string) {
+    if (p.type("name") == parameter_string) {
       output_name[index_output].resize(1);
-      output_name[index_output][0] = p->value_string("name","");
-    } else if (p->type("name") == parameter_list) {
-      int size = p->list_length("name");
+      output_name[index_output][0] = p.value_string("name","");
+    } else if (p.type("name") == parameter_list) {
+      int size = p.list_length("name");
       if (size > 0) output_name[index_output].resize(size);
       for (int i=0; i<size; i++) {
-	output_name[index_output][i] = p->list_value_string(i,"name","");
+	output_name[index_output][i] = p.list_value_string(i,"name","");
       }
     }
 
@@ -911,35 +915,34 @@ void Config::read_output_ (Parameters * p) throw()
     //   }
     // }
 
-    if (p->type("field_list") == parameter_list) {
-      int length = p->list_length("field_list");
+    if (p.type("field_list") == parameter_list) {
+      int length = p.list_length("field_list");
       output_field_list[index_output].resize(length);
       for (int i=0; i<length; i++) {
-	output_field_list[index_output][i] = p->list_value_string(i,"field_list","");
+	output_field_list[index_output][i] = p.list_value_string(i,"field_list","");
       }
     }
 
-    if (p->type("particle_list") == parameter_list) {
-      int length = p->list_length("particle_list");
+    if (p.type("particle_list") == parameter_list) {
+      int length = p.list_length("particle_list");
       output_particle_list[index_output].resize(length);
       for (int i=0; i<length; i++) {
-	output_particle_list[index_output][i] = p->list_value_string(i,"particle_list","");
+	output_particle_list[index_output][i] = p.list_value_string(i,"particle_list","");
       }
     }
 
     // Read schedule for the Output object
 
-    ParameterGroup p_group
-      (*p, "Output:" + output_list[index_output] + ":schedule");
-    output_schedule_index[index_output] = read_schedule_(p_group);
+    ParameterGroup p_schedule_group(*all_p, p.get_group_path() + ":schedule");
+    output_schedule_index[index_output] = read_schedule_(p_schedule_group);
 
     // Image 
     
     if (output_type[index_output] == "image") {
 
 
-      if (p->type("axis") != parameter_unknown) {
-	std::string axis = p->value_string("axis");
+      if (p.type("axis") != parameter_unknown) {
+	std::string axis = p.value_string("axis");
 	ASSERT2("Problem::initialize_output",
 		"Output %s axis %s must be \"x\", \"y\", or \"z\"",
 		output_list[index_output].c_str(), axis.c_str(),
@@ -953,54 +956,54 @@ void Config::read_output_ (Parameters * p) throw()
       }
 
 
-      output_image_type[index_output] = p->value_string("image_type","data");
+      output_image_type[index_output] = p.value_string("image_type","data");
 
-      output_image_log[index_output] = p->value_logical("image_log",false);
-      output_image_abs[index_output] = p->value_logical("image_abs",false);
+      output_image_log[index_output] = p.value_logical("image_log",false);
+      output_image_abs[index_output] = p.value_logical("image_abs",false);
 
       output_image_mesh_color[index_output] = 
-	p->value_string("image_mesh_color","level");
+	p.value_string("image_mesh_color","level");
       output_image_mesh_order[index_output] = 
-	p->value_string("image_mesh_order","none");
+	p.value_string("image_mesh_order","none");
 
       output_image_color_particle_attribute[index_output] = 
-	p->value_string("image_color_particle_attribute","");
+	p.value_string("image_color_particle_attribute","");
 
       output_image_size[index_output].resize(2);
       output_image_size[index_output][0] = 
-	p->list_value_integer(0,"image_size",512);
+	p.list_value_integer(0,"image_size",512);
       output_image_size[index_output][1] = 
-	p->list_value_integer(1,"image_size",512);
+	p.list_value_integer(1,"image_size",512);
 
       output_image_reduce_type[index_output] = 
-	p->value_string("image_reduce_type","sum");
+	p.value_string("image_reduce_type","sum");
 
       output_image_face_rank[index_output] = 
-	p->value_integer("image_face_rank",3);
+	p.value_integer("image_face_rank",3);
 
       output_image_ghost[index_output] = 
-	p->value_logical("image_ghost",false);
+	p.value_logical("image_ghost",false);
 
       output_image_min[index_output] =
-	p->value_float("image_min",std::numeric_limits<double>::max());
+	p.value_float("image_min",std::numeric_limits<double>::max());
       output_image_max[index_output] =
-	p->value_float("image_max",-std::numeric_limits<double>::max());
+	p.value_float("image_max",-std::numeric_limits<double>::max());
 
-      output_min_level[index_output] = p->value_integer("min_level",0);
+      output_min_level[index_output] = p.value_integer("min_level",0);
       output_max_level[index_output] =
-	p->value_integer("max_level",std::numeric_limits<int>::max());
-      output_leaf_only[index_output] = p->value_logical("leaf_only",true);
+	p.value_integer("max_level",std::numeric_limits<int>::max());
+      output_leaf_only[index_output] = p.value_logical("leaf_only",true);
 
-      if (p->type("colormap") == parameter_list) {
-	int size = p->list_length("colormap");
+      if (p.type("colormap") == parameter_list) {
+	int size = p.list_length("colormap");
 	output_colormap[index_output].clear();
 	for (int i=0; i<size; i++) {
-          if (p->list_type(i,"colormap") == parameter_float) {
+          if (p.list_type(i,"colormap") == parameter_float) {
             // Assume red, green, blue triad if float
             output_colormap[index_output].push_back
-              (p->list_value_float(i,"colormap",0.0));
-          } else if (p->list_type(i,"colormap") == parameter_string) {
-            std::string name = p->list_value_string(i,"colormap");
+              (p.list_value_float(i,"colormap",0.0));
+          } else if (p.list_type(i,"colormap") == parameter_string) {
+            std::string name = p.list_value_string(i,"colormap");
             // Check for #rrggbb or color name
             int color_rgb;
             if (name[0] == '#') {
@@ -1037,7 +1040,7 @@ void Config::read_output_ (Parameters * p) throw()
           } else {
             ERROR1("Config::read_output()",
                    "Unknown colormap list type %d\n",
-                   p->list_type(i,"colormap"));
+                   p.list_type(i,"colormap"));
           }
 	}
       }
@@ -1046,9 +1049,9 @@ void Config::read_output_ (Parameters * p) throw()
       output_image_upper[index_output].resize(3);
       for (int axis=0; axis<3; axis++) {
 	output_image_lower[index_output][axis] =
-	  p->list_value_float(axis,"image_lower",-std::numeric_limits<double>::max());
+	  p.list_value_float(axis,"image_lower",-std::numeric_limits<double>::max());
 	output_image_upper[index_output][axis] =
-	  p->list_value_float(axis,"image_upper",std::numeric_limits<double>::max());
+	  p.list_value_float(axis,"image_upper",std::numeric_limits<double>::max());
       }
 
     }

--- a/src/Cello/parameters_Config.hpp
+++ b/src/Cello/parameters_Config.hpp
@@ -11,6 +11,7 @@
 #define PARAMETERS_CONFIG_HPP
 
 class Parameters;
+class ParameterGroup;
 
 class Config : public PUP::able {
 
@@ -571,8 +572,7 @@ protected: // functions
   void read_testing_     ( Parameters * ) throw();
   void read_units_       ( Parameters * ) throw();
 
-  int read_schedule_( Parameters * ,
-		      const std::string group   );
+  int read_schedule_( ParameterGroup p);
 
 };
 

--- a/src/Cello/parameters_ParameterGroup.cpp
+++ b/src/Cello/parameters_ParameterGroup.cpp
@@ -31,6 +31,16 @@ parameter_type ParameterGroup::type(std::string param) noexcept
 
 //----------------------------------------------------------------------
 
+parameter_type ParameterGroup::list_type(int index, std::string param) noexcept
+{
+  std::vector<std::string> init_groups(pop_wrapped_p_groups_());
+  parameter_type out = wrapped_p_.list_type(index, full_name(param));
+  restore_wrapped_p_groups_(init_groups);
+  return out;
+}
+
+//----------------------------------------------------------------------
+
 int ParameterGroup::value_integer (std::string s, int deflt) noexcept
 {
   std::vector<std::string> init_groups(pop_wrapped_p_groups_());

--- a/src/Cello/parameters_ParameterGroup.hpp
+++ b/src/Cello/parameters_ParameterGroup.hpp
@@ -122,6 +122,9 @@ public:
   /// Return the type of the given parameter
   parameter_type type(std::string param) noexcept;
 
+  /// Return the type of the given element in a parameter list
+  parameter_type list_type(int, std::string) throw();
+
   /// Return the Param pointer for the specified parameter
   Param * param (std::string parameter);
 

--- a/src/Cello/parameters_Parameters.cpp
+++ b/src/Cello/parameters_Parameters.cpp
@@ -979,19 +979,6 @@ std::vector<std::string> Parameters::leaf_parameter_names
 
 //----------------------------------------------------------------------
 
-std::vector<std::string> Parameters::leaf_parameter_names() const throw()
-{
-  std::string full_group_name = full_name("");
-  ASSERT("Parameters::leaf_parameter_names",
-         "the version of this method that returns the leaf parameter names in "
-         "the current parameter-group can't be called when the current "
-         "parameter-group is empty",
-         full_group_name != ":");
-  return leaf_parameter_names(full_group_name);
-}
-
-//----------------------------------------------------------------------
-
 std::string Parameters::full_name(std::string parameter) const throw()
 {
   int n = current_group_.size();

--- a/src/Cello/parameters_Parameters.hpp
+++ b/src/Cello/parameters_Parameters.hpp
@@ -239,13 +239,6 @@ public: // interface
   std::vector<std::string> leaf_parameter_names
   (const std::string& full_group_name) const throw();
 
-  /// Returns a vector holding the names of all leaf parameters in the current
-  /// group
-  ///
-  /// this overload of the function is deprecated, but exists to maintain
-  /// backwards compatibility
-  std::vector<std::string> leaf_parameter_names() const throw();
-
   /// Return the full name of the parameter including group
   std::string full_name (std::string parameter) const throw();
 

--- a/src/Cello/problem_InitialValue.cpp
+++ b/src/Cello/problem_InitialValue.cpp
@@ -68,11 +68,6 @@ void InitialValue::enforce_block ( Block * block,
   ASSERT("InitialValue::enforce_block",
 	 "Block does not exist",
 	 block != NULL);
-  
-  //--------------------------------------------------
-  parameters_->group_set(0,"Initial");
-  parameters_->group_set(1,"value");
-  //--------------------------------------------------
 
   Data *data = block->data();
 
@@ -94,7 +89,8 @@ void InitialValue::enforce_block ( Block * block,
        index_field++) {
     
     std::string field_name = field_descr->field_name(index_field);
-    parameter_type parameter_type = parameters_->type(field_name);
+    std::string parameter_path = "Initial:value:" + field_name;
+    parameter_type parameter_type = parameters_->type(parameter_path);
 
     if ((index_field>=num_fields_) && (parameter_type != parameter_unknown)){
       // It is possiblefor a permanent field to be initialized after
@@ -109,7 +105,7 @@ void InitialValue::enforce_block ( Block * block,
 
       if (parameter_type == parameter_float) {
 	field_data->clear(field_descr,
-			  parameters_->value_float(field_name,0.0), 
+			  parameters_->value_float(parameter_path, 0.0),
 			  index_field);
       } else if (parameter_type != parameter_unknown){
 	int cx,cy,cz;
@@ -256,19 +252,17 @@ void InitialValue::initialize_values_()
   // skip, if values_ has already been initialized
   if (initialized_values_){return;}
 
-  parameters_->group_set(0,"Initial");
-  parameters_->group_set(1,"value");
-
   values_ = new Value*[num_fields_];
 
   // Initialize Value objects
   for (int index_field = 0; index_field < num_fields_; index_field++) {
     std::string field_name = cello::field_descr()->field_name(index_field);
-    parameter_type parameter_type = parameters_->type(field_name);
+    std::string parameter_path = "Initial:value:" + field_name;
+    parameter_type parameter_type = parameters_->type(parameter_path);
 
     if ((parameter_type != parameter_unknown) &&
 	(parameter_type != parameter_float)){
-      values_[index_field] = new Value(parameters_, field_name);
+      values_[index_field] = new Value(parameters_, parameter_path);
     } else {
       values_[index_field] = NULL;
     }

--- a/src/Enzo/enzo-core/EnzoConfig.cpp
+++ b/src/Enzo/enzo-core/EnzoConfig.cpp
@@ -920,28 +920,27 @@ void EnzoConfig::read_initial_bb_test_(Parameters * p)
 
 //----------------------------------------------------------------------
 
-void EnzoConfig::read_method_check_(Parameters * p)
+void EnzoConfig::read_method_check_(Parameters * all_p)
 {
-  p->group_set(0,"Method");
-  p->group_push("check");
+  ParameterGroup p(*all_p, "Method:check");
 
-  method_check_num_files = p->value_integer
+  method_check_num_files = p.value_integer
     ("num_files",1);
-  method_check_ordering = p->value_string
+  method_check_ordering = p.value_string
     ("ordering","order_morton");
 
-  if (p->type("dir") == parameter_string) {
+  if (p.type("dir") == parameter_string) {
     method_check_dir.resize(1);
-    method_check_dir[0] = p->value_string("dir","");
-  } else if (p->type("dir") == parameter_list) {
-    int size = p->list_length("dir");
+    method_check_dir[0] = p.value_string("dir","");
+  } else if (p.type("dir") == parameter_list) {
+    int size = p.list_length("dir");
     if (size > 0) method_check_dir.resize(size);
     for (int i=0; i<size; i++) {
-      method_check_dir[i] = p->list_value_string(i,"dir","");
+      method_check_dir[i] = p.list_value_string(i,"dir","");
     }
   }
-  method_check_monitor_iter   = p->value_integer("monitor_iter",0);
-  method_check_include_ghosts = p->value_logical("include_ghosts",false);
+  method_check_monitor_iter   = p.value_integer("monitor_iter",0);
+  method_check_include_ghosts = p.value_logical("include_ghosts",false);
 }
 
 //----------------------------------------------------------------------

--- a/src/Enzo/enzo-core/EnzoConfig.cpp
+++ b/src/Enzo/enzo-core/EnzoConfig.cpp
@@ -1047,10 +1047,8 @@ namespace{
     EnzoDualEnergyConfig out = EnzoDualEnergyConfig::build_disabled();
 
     // fetch names of parameters in Physics:fluid_props:dual_energy
-    p->group_set(0, "Physics");
-    p->group_set(1, "fluid_props");
-    p->group_set(2, "dual_energy");
-    std::vector<std::string> names = p->leaf_parameter_names();
+    std::vector<std::string> names = p->leaf_parameter_names
+      ("Physics:fluid_props:dual_energy");
 
     const bool missing_de_config = names.size() == 0;
     if (!missing_de_config){ // parse Physics:fluid_props:dual_energy
@@ -1157,10 +1155,8 @@ namespace{
     const bool legacy_gamma_specified = p->param("Field:gamma") != nullptr;
 
     // fetch names of parameters in Physics:fluid_props:eos
-    p->group_set(0, "Physics");
-    p->group_set(1, "fluid_props");
-    p->group_set(2, "eos");
-    std::vector<std::string> names = p->leaf_parameter_names();
+    std::vector<std::string> names = p->leaf_parameter_names
+      ("Physics:fluid_props:eos");
 
     const bool missing_eos_config = names.size() == 0;
 
@@ -1291,10 +1287,8 @@ namespace{
 
     // fetch names of parameters in Physics:fluid_props:floors. If any of them
     // exist, let's parse them
-    p->group_set(0, "Physics");
-    p->group_set(1, "fluid_props");
-    p->group_set(2, "floors");
-    std::vector<std::string> floor_l = p->leaf_parameter_names();
+    std::vector<std::string> floor_l = p->leaf_parameter_names
+      ("Physics:fluid_props:floors");
 
     const bool no_legacy = (floor_l.size() > 0);
     if (no_legacy){

--- a/src/Enzo/initial/EnzoInitialBCenter.cpp
+++ b/src/Enzo/initial/EnzoInitialBCenter.cpp
@@ -231,16 +231,15 @@ void EnzoInitialBCenter::enforce_block( Block * block,
 
 void EnzoInitialBCenter::initialize_values_()
 {
-  parameters_->group_set(0,"Initial");
-  parameters_->group_set(1,"vlct_bfield");
-
 
   // Check if values are specified for any component of the vector potential
   //    - If only a subset of values are specified, than the unspecified
   //      components are assumed to be constant.
   //    - If none of the components are specified, then bfields are assumed to
   //      be pre-calculated and only the cell-centered values are computed
-  std::string names[3] = {"Ax","Ay","Az"};
+  std::string names[3] = {"Initial:vlct_bfield:Ax",
+                          "Initial:vlct_bfield:Ay",
+                          "Initial:vlct_bfield:Az"};
   for (int i = 0; i < 3; i++){
     if (parameters_->type(names[i]) == parameter_unknown){
       values_[i] = nullptr;


### PR DESCRIPTION
### Pull request summary

Modify some existing parsing logic to make use of `ParameterGroup`.

### Detailed Description

The  `ParameterGroup` class was introduced back in #341 (the main body of that PR calls the class `ParameterAccessor` -- the name was changed based on feedback). It is a class whose sole-purpose is to provide access to parameters within a specific parameter-group (without specifying the full path to a parameter).

This functionality was duplicated in the pre-existing `Parameters` class. However, the `Parameters` class already provided a LOT of other functionality and this particular functionality is achieved by managing a bunch of internal state.

Part of the intention when introducing `ParameterGroup` was to eventually replace existing code that already made use of this functionality provided by the `Parameters` class so that it now makes use of the `ParametersGroup` class instead (in other words, the underlying logic is not changing). **This is what this PR does.**

The benefits are twofold:
- the code making use of this functionality is now a little more explicit
- it will allow us to remove this duplicated functionality from the `Parameters` class (this will actually be somewhat helpful for simplifying code in SMP-mode). 


**I plan to remove the duplicated functionality in a future, separate PR** since it will involve a number of modifications to existing unit-tests & it would be helpful to get the current changes into the main codebase. (Plus these changes have been kicking around on my computer for 3 months and I want to get them off my plate)