### PR TITLE
Remove usage of VLA -- it breaks default macOS builds (and use of clang in general)

### DIFF
--- a/src/Enzo/io/EnzoInitialHdf5.cpp
+++ b/src/Enzo/io/EnzoInitialHdf5.cpp
@@ -10,6 +10,7 @@
 
 #include <chrono>
 #include <thread>
+#include <vector>
 
 #define CHECK_COSMO_PARAMS true
 
@@ -119,7 +120,7 @@ void EnzoInitialHdf5::enforce_block
   int min_level = cello::hierarchy()->min_level();
 
   // Maintain running count of messages sent
-  int count_messages[max_level_ + 1] = {};
+  std::vector<int> count_messages(max_level_ + 1, 0);
 
   // Read in Field files
   for (size_t index=0; index<field_files_.size(); index++) {


### PR DESCRIPTION

<!--
Thank you so much for your Pull Request! To help us review it, please fill out this template to the best of your ability. Please make use of the development guide at https://enzo-e.readthedocs.io/en/main/devel/index.html

If you're unfamiliar with this process, here are some formatting basics:
  * any text enclosed by fancy brackets (<!~~ and ~~>, but you need to replace "~~" with "--"), is considered a comment that won't be rendered by GitHub after you post your pull request

  * GitHub will render all other text will be rendered. It respects markdown escape sequences to control formatting (e.g. lines starting with `###` specify a section-heading)
-->


<!--Provide a general summary of your changes in the title above, for
example "Fixes crash in gravity solver in super-cycling".  Please avoid
non-descriptive titles such as "Addresses issue #42".-->

<!-- If you are able to do so, please do not create the PR out of main, but out of a separate branch. -->


### Pull request summary

Fixed a spot in `EnzoInitialHdf5` where we were using variable length arrays.

### Detailed Description

In more detail, VLAs (variable length arrays) are a feature of C99 and are not supported in C++. g++ happens to support the feature, but other compilers (like clang++) don't. Thus builds on macOS were broken.

This fixes #407.

This is a major change or addition (that needs 2 reviewers): no