### PR TITLE
minor bugfix - Object's copy-assignment operation is currently wrong -- It doesn't return anything.

### DIFF
--- a/src/Cello/data_Object.hpp
+++ b/src/Cello/data_Object.hpp
@@ -17,8 +17,7 @@ class Object : public PUP::able {
 public: // interface
 
   /// Constructor
-  Object() throw()
-  { }
+  Object() = default;
 
   /// Charm++ PUP::able declarations
   PUPable_abstract(Object);
@@ -28,12 +27,10 @@ public: // interface
   { }
 
   /// Copy constructor
-  Object(const Object & Object) throw()
-  { }
+  Object(const Object & Object) = default;
 
-  /// Assignment operator
-  Object & operator= (const Object & Object) throw()
-  { }
+  /// Copy assignment operator
+  Object & operator= (const Object & Object) = default;
 
   /// Destructor
   virtual ~Object() throw()

--- a/src/Cello/data_Object.hpp
+++ b/src/Cello/data_Object.hpp
@@ -33,8 +33,7 @@ public: // interface
   Object & operator= (const Object & Object) = default;
 
   /// Destructor
-  virtual ~Object() throw()
-  { }
+  virtual ~Object() = default;
 
   /// CHARM++ Pack / Unpack function
   void pup (PUP::er &p)


### PR DESCRIPTION
### Pull request summary

Fixing a minor bug in the ``Object`` class's copy-assignment operation. Currently it doesn't return a reference. I switched the implementation so that it now uses the default implementation.

### Detailed Description

While I was here, I modified the constructor and the copy-constructor to use the default implementation since there is no semantic difference (and it can sometimes produce faster code) 

This is a major change or addition (that needs 2 reviewers): no