### PR TITLE
Suppress inconsistent ``override`` warnings.

### DIFF
--- a/src/Enzo/enzo-core/EnzoUnits.hpp
+++ b/src/Enzo/enzo-core/EnzoUnits.hpp
@@ -37,7 +37,7 @@ public: // interface
   { }
   
   /// CHARM++ Pack / Unpack function
-  void pup (PUP::er &p);
+  void pup (PUP::er &p) override;
 
   /// Update current units for cosmological problems
   void set_current_time (double time);

--- a/src/Enzo/gravity/EnzoPhysicsGravity.hpp
+++ b/src/Enzo/gravity/EnzoPhysicsGravity.hpp
@@ -65,7 +65,7 @@ public: // interface
   { }
 
   /// CHARM++ Pack / Unpack function
-  void pup (PUP::er &p)
+  void pup (PUP::er &p) override
   {
     TRACEPUP;
     Physics::pup(p);

--- a/src/Enzo/particle/formation/EnzoMethodStarMakerSTARSS.hpp
+++ b/src/Enzo/particle/formation/EnzoMethodStarMakerSTARSS.hpp
@@ -28,16 +28,16 @@ public:
    {  }
 
   /// Charm++ Pack / Unpack function
-  void pup (PUP::er &p);
+  void pup (PUP::er &p) override;
 
   /// Apply method
-  virtual void compute ( Block * block) throw();
+  void compute ( Block * block) throw() override;
 
-  virtual std::string particle_type () throw()
+  std::string particle_type () throw() override
   { return "star";}
 
   /// Name
-  virtual std::string name () throw()
+  std::string name () throw() override
    { return "star_maker";}
 
   virtual ~EnzoMethodStarMakerSTARSS() throw() {};


### PR DESCRIPTION
### Pull request summary

There are a few spots in the codebase where we have started to make use of the ``override`` keyword (it tells the compiler to make sure that you are actually overriding an existing virtual function - this is an extremely useful feature).

The clang compiler provides warnings if some virtual methods within a given class are annotated with ``override`` while other methods are not annotated. (It dislikes the inconsistency -- and I think it's a fair complaint)

This change addresses that warning by using ``override`` more consistently throughout the class (where we had already used it once it in the past)

### Detailed Description

<!--
Please provide at least 1-2 sentences describing the pull request in detail.  Why is this change required?  What problem does it solve?

If it fixes an open issue, please mention the issue that it addresses here and provide a link to the issue. GitHub will automatically link any number prefixed with a hash, e.g. #42, to the appropiate issue.

If your PR depends on another PR, please link to the PR here. For example, you might say "This PR depends upon #84." (again, GitHub automatically makes links any number prefixed with a hash)
-->


<!-- Please replace yes/no/unknown on the following line with one of those three options based on whether you expect that this PR is a major change that will require two reviewers -->
This is a major change or addition (that needs 2 reviewers): no
