### PR TITLE
CMake tweak to support newer charm++ versions -- fix gh-#201

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -185,10 +185,10 @@ set(balancer_default "TreeLB" CACHE STRING "Charm++ load balancer to use by defa
 #TODO we should figure our reasonale defaults and/or provide instructions in the docs
 if (balance)
   foreach(BALANCER IN LISTS balancer_included)
-    string(APPEND Cello_TARGET_LINK_OPTIONS " -module ${BALANCER}")
+    list(APPEND Cello_TARGET_LINK_OPTIONS "SHELL:-module ${BALANCER}")
   endforeach()
   foreach(BALANCER IN LISTS balancer_default)
-    string(APPEND Cello_TARGET_LINK_OPTIONS " -balancer ${BALANCER}")
+    list(APPEND Cello_TARGET_LINK_OPTIONS "SHELL:-balancer ${BALANCER}")
   endforeach()
 endif()
 


### PR DESCRIPTION
### Pull request summary

This commit introduces a minor tweak to the way in which charm++'s linker-flags (related to balancers and modules) are specified in order to let us use newer versions of charm++.

This fixes GitHub Issue #201.

### Detailed Description

I only tested that Enzo-E could compile with charm++ version 8.0 (I didn't actually run any tests -- that will take a little more effort)

This is a major change or addition (that needs 2 reviewers): no
