### PR TITLE
Fix-failing-CI tests: No longer using removed numpy function

### DIFF
--- a/tools/l1_error_norm.py
+++ b/tools/l1_error_norm.py
@@ -444,7 +444,7 @@ def load_reference_table(fname, coerce_pos_key = False):
                 break
 
     # load the actual data
-    rec = np.recfromtxt(fname, skip_header = header_line_count, comments = "#",
+    rec = np.genfromtxt(fname, skip_header = header_line_count, comments = "#",
                         dtype = None, delimiter = ',', names = True,
                         encoding='utf-8')
     # reformat the actual data


### PR DESCRIPTION
### Pull request summary

Our CI tests have now started using a numpy 2.0 (since we don't pin python versions). That release removed `numpy.recfromtxt`, which caused some of our tests to fail.

This PR simply replaces `np.recfromtxt` with `np.genfromtxt`.

This is a major change or addition (that needs 2 reviewers): no
