### PR TITLE
Introducing pre commit tool

### DIFF
--- a/.git-blame-ignore-revs
+++ b/.git-blame-ignore-revs
@@ -1,0 +1,2 @@
+# remove trailing whitespace from cmake files and rst files
+95497bac8e74844b6e7f36b30dfa42bd89338b8c

--- a/.git-blame-ignore-revs
+++ b/.git-blame-ignore-revs
@@ -1,2 +1,4 @@
 # remove trailing whitespace from cmake files and rst files
 95497bac8e74844b6e7f36b30dfa42bd89338b8c
+# remove trailing whitespace from some newer cmake files and rst files
+84d7c2baf0c655c277d901e6e5f8e2dd00e6fff4

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,7 +1,5 @@
-
-# if we choose to adopt the pre-commit ci, uncomment the following
-#ci:
-#    autofix_prs: false
+ci:
+    autofix_prs: false
 
 
 repos:

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,0 +1,20 @@
+
+# if we choose to adopt the pre-commit ci, uncomment the following
+#ci:
+#    autofix_prs: false
+
+
+repos:
+-   repo: https://github.com/pre-commit/pre-commit-hooks
+    rev: v2.3.0
+    hooks:
+    -   id: check-yaml
+    -   id: check-case-conflict
+    -   id: trailing-whitespace
+        files: |
+            (?x)^(
+                doc/source/.*\.rst|
+                .*\.cmake|
+                .*CMakeLists.txt
+            )$
+

--- a/cmake/CreateStdFilesystemTarget.cmake
+++ b/cmake/CreateStdFilesystemTarget.cmake
@@ -47,11 +47,11 @@ function(_detect_stdlib_impl output_variable)
   # this detection stategy, won't work for libstdc++ older than 6.1
   # (but that's okay, such versions are older than C++17)
   file(WRITE ${test_file}
-" 
+"
 // include headers defining implementation-specific macros (since we include
 // <iostream>, this may not be strictly necessary)
 #if __has_include(<ciso646>)
-  // pre c++20, this header is commonly included for std library implementation 
+  // pre c++20, this header is commonly included for std library implementation
   // macros: https://en.cppreference.com/w/cpp/header/version
   #include <ciso646>
 #else

--- a/cmake/EnableFPOptimizations.cmake
+++ b/cmake/EnableFPOptimizations.cmake
@@ -6,7 +6,7 @@
 #
 # Defines a function that enables value-unsafe floating point optimization
 # flags for the C and C++ compilers.
-# 
+#
 # This can also add the openmp-simd flags to the C and C++ compilers (and any
 # other flags necessary for simd optimizations).
 

--- a/cmake/FindCharm.cmake
+++ b/cmake/FindCharm.cmake
@@ -15,22 +15,22 @@
 # behalf a nonexclusive, paid-up, irrevocable worldwide license in this material
 # to reproduce, prepare derivative works, distribute copies to the public,
 # perform publicly and display publicly, and to permit others to do so.
-# 
+#
 # Additionally, redistribution and use in source and binary forms, with or without
 # modification, are permitted provided that the following conditions are met:
-# 
+#
 # 1. Redistributions of source code must retain the above copyright notice, this
 # list of conditions and the following disclaimer.
-# 
+#
 # 2. Redistributions in binary form must reproduce the above copyright notice,
 # this list of conditions and the following disclaimer in the documentation and/or
 # other materials provided with the distribution.
-# 
+#
 # 3. Neither the name of Triad National Security, LLC, Los Alamos National
 # Laboratory, LANL, the U.S. Government, nor the names of its contributors may be
 # used to endorse or promote products derived from this software without specific
 # prior written permission.
-# 
+#
 # THIS SOFTWARE IS PROVIDED BY TRIAD NATIONAL SECURITY, LLC AND CONTRIBUTORS "AS
 # IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
 # IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
@@ -167,13 +167,13 @@ function(_get_charm_linker_invocation charm_compiler out)
   #      https://discourse.cmake.org/t/avoid-duplicate-linking-to-avoid-xcode-15-warnings/9084
   # -> cmake 3.29 does introduce some mechanisms to deal with this. (Aside: if
   #    this solution worked for us, it would probably be reasonable to require
-  #    users to use 3.29 to suppress the warning - especially since it is SO 
+  #    users to use 3.29 to suppress the warning - especially since it is SO
   #    easy to get modern cmake versions on macOS)
   # -> However, the fact that we force CMake to invoke the charm++ compiler for
   #    linking keeps us from easily using the CMake solution.
   #    -> In a little more detail, CMake assumes that we are using the build's
   #       mainstream c++ compiler to invoke linking. Consequently, it tries to
-  #       escape certain arguments intended to be passed through to the linker 
+  #       escape certain arguments intended to be passed through to the linker
   #       (with -Wl,... for gcc and -Xlinker for clang)
   #    -> charmc itself acts like a compiler frontend (it wraps the
   #       compiler-frontend used to compile it, similar to h5cc or mpicc).
@@ -213,11 +213,11 @@ function(_get_charm_linker_invocation charm_compiler out)
     message(WARNING
       "something went wrong while trying to query apple-clang version")
   endif()
-    
+
   if (suppress)
     # https://discourse.cmake.org/t/avoid-duplicate-linking-to-avoid-xcode-15-warnings/9084/3
     set(linker "${linker} -ld-option -Wl,-no_warn_duplicate_libraries")
- 
+
     # the following could plausibly be unnecessary in newer version of charm++
     if (CMAKE_CXX_COMPILER_ID STREQUAL "AppleClang" OR
         CMAKE_CXX_COMPILER_ID STREQUAL "Clang")

--- a/cmake/GenericOptionCommand.cmake
+++ b/cmake/GenericOptionCommand.cmake
@@ -35,7 +35,7 @@ set(__GenericOptionCommand YES)
 
 
 function(generic_option variable type help_text)
-  
+
   # on the off-chance that the variable-name matches a value used in this
   # function, let's check if it already exists (BEFORE DEFINING ANY VARIABLES)
   if (DEFINED "${variable}")
@@ -90,7 +90,7 @@ somewhere to define the variable.
      instead choose to refactor, keep in mind that it's a little tricky to get
      this \"right\" (it can be tricky to allow users to override the value)")
   endif()
- 
+
   cmake_policy(GET CMP0077 _CMP0077_val)
   if ("${_CMP0077_val}" STREQUAL "OLD")
     message(FATAL_ERROR "${_func_name} needs NEW behavior of CMP0077")

--- a/cmake/RequiredFortranCompileOptions.cmake
+++ b/cmake/RequiredFortranCompileOptions.cmake
@@ -102,7 +102,7 @@ function(get_required_fortran_options outVar)
     set(gnu_precision_flags "-fdefault-real-8;-fdefault-double-8")
   else()
     set(gnu_precision_flags "")
-  endif() 
+  endif()
   set(all_gnu_flags
     "-fno-second-underscore" "-ffixed-line-length-132" ${gnu_precision_flags})
 
@@ -176,7 +176,7 @@ function(target_required_fortran_compile_options target flag_scope)
 
   get_required_fortran_options(_REQ_FC_FLAGS)
 
-  if (NOT ("${_REQ_FC_FLAGS}" STREQUAL "")) 
+  if (NOT ("${_REQ_FC_FLAGS}" STREQUAL ""))
     target_compile_options(${target} ${flag_scope} "${_REQ_FC_FLAGS}")
   endif()
 endfunction()

--- a/cmake/charm.cmake
+++ b/cmake/charm.cmake
@@ -15,22 +15,22 @@
 # behalf a nonexclusive, paid-up, irrevocable worldwide license in this material
 # to reproduce, prepare derivative works, distribute copies to the public,
 # perform publicly and display publicly, and to permit others to do so.
-# 
+#
 # Additionally, redistribution and use in source and binary forms, with or without
 # modification, are permitted provided that the following conditions are met:
-# 
+#
 # 1. Redistributions of source code must retain the above copyright notice, this
 # list of conditions and the following disclaimer.
-# 
+#
 # 2. Redistributions in binary form must reproduce the above copyright notice,
 # this list of conditions and the following disclaimer in the documentation and/or
 # other materials provided with the distribution.
-# 
+#
 # 3. Neither the name of Triad National Security, LLC, Los Alamos National
 # Laboratory, LANL, the U.S. Government, nor the names of its contributors may be
 # used to endorse or promote products derived from this software without specific
 # prior written permission.
-# 
+#
 # THIS SOFTWARE IS PROVIDED BY TRIAD NATIONAL SECURITY, LLC AND CONTRIBUTORS "AS
 # IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
 # IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
@@ -41,7 +41,7 @@
 # HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT
 # LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT
 # OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
-# \brief     Function used to setup a Charm++ module. 
+# \brief     Function used to setup a Charm++ module.
 #
 # 2021/07/05 pgrete: adapted from https://github.com/quinoacomputing/cmake-modules
 # 2023/02/05 mabruzzo: refactored the addCharmModule so that the primary is now an INTERFACE library rather than a custom target. The benefit of doing this is that the include_directory dependencies are now automatically managed

--- a/config/msu_hpcc_gcc.cmake
+++ b/config/msu_hpcc_gcc.cmake
@@ -15,7 +15,7 @@ if(NOT __processedUserDefaults)
 
   # the minimal set of required flags to successfully compile with this Fortran
   # compiler are handled internally (if those flags don't work, please update
-  # the relevant internal logic rather than specifying them here) 
+  # the relevant internal logic rather than specifying them here)
 
   # in principle we should set flags to specify hardware architecture (so that
   # they can be used with openmp-simd optimizations

--- a/doc/source/design/design-adapt.rst
+++ b/doc/source/design/design-adapt.rst
@@ -89,7 +89,7 @@ Before presenting the algorithm, we define the following notation:
   \bar{L}_{i,s}^{k+1}`: *current lower and upper level bounds (for
   step s), which are dynamically updated*
 * :math:`L_i^{k+1}` *the next level which is decided when* :math:`\underline{L}_{i,s}^{k+1} = \bar{L}_{i,s}^{k+1}`
- 
+
 We can now write the two main conditions that we use to initialize and
 update the level bounds:
 

--- a/doc/source/design/design-flux.rst
+++ b/doc/source/design/design-flux.rst
@@ -1,16 +1,16 @@
 .. include:: ../roles.incl
-  
+
 **********************
 Flux Correction Design
 **********************
 .. toctree::
-     
+
 ============
 Requirements
 ============
 
 Flux correction involves updating field values along faces between
-neighboring blocks to ensure that conserved quantities are 
+neighboring blocks to ensure that conserved quantities are
 conserved across jumps in spacial and temporal resolution.
 The update involves adding correction factors to all coarse
 values that lie along coarse-fine interfaces, where the correction
@@ -23,7 +23,7 @@ MHD, and expansion terms in cosmological problems may also need to be
 considered.
 
 Basic operations involved include the following:
-   
+
 #. allocating and deallocating flux data
 #. setting and accessing flux values
 #. communicating fluxes between neighboring blocks (fine-to-coarse)
@@ -74,7 +74,7 @@ sufficient support for storing fluxes, computing flux correction
 factors, and applying the flux correction to conserved field values.
 
 Specific requirements include the following:
-   
+
 - **RC-1.** Store fluxes of conserved fields that lie along block faces
 - **RC-2.** Store associated fluxes computed on adjacent blocks
 - **RC-3.** Communicate fluxes between adjacent blocks when (and ideally only when) needed
@@ -130,7 +130,7 @@ MethodFluxCorrect class
 The :p:`MethodFluxCorrect` class is a Cello :p:`Method`, whose
 main virtual method is :p:`compute(Block)`.  This operates on some
 subset of data types on a Block.  The :p:`MethodFluxCorrect` method
-initiates communication 
+initiates communication
 between processes, and computes and applies appropriate
 flux-correction operations on required Field values along block
 interfaces.
@@ -149,19 +149,19 @@ required for flux-correction.)
 .. glossary::
 
    ``MethodFluxCorrect::MethodFluxCorrect()``
-   
+
       *Create a new MethodFluxCorrect object, and define its refresh communication requirements*
-  
+
 ----
 
 .. glossary::
 
    ``virtual void MethodFluxCorrect::compute (Block * block)``
-   
+
       *Request Cello to refresh its flux data, then apply flux correction*
 
       * **block**: *Block that flux correction is being applied to*
-   
+
 ----------
 Face class
 ----------
@@ -209,9 +209,9 @@ y=1, z=2), and face (lower=0, upper=1).
    ``int Face::face()``
     *Return whether the normal direction is towards the lower (0) or upper (1) face direction.*
 
-----------------     
+----------------
 FaceFluxes class
-----------------     
+----------------
 
 Face fluxes represent an array of fluxes of a given conserved Field
 through a Block's face or subset of a face.  Operations available for
@@ -226,10 +226,10 @@ finer time step to match a neighboring block's coarser time step.
    comment # [*]
 
 .. glossary::
-   
+
    ``FaceFluxes::FaceFluxes (Face face, int index_field, int nx, int ny, int nz, int cx, int cy, int cz)``
     *Create a FaceFluxes object for the given face, field, and block size. Optionally include centering adjustment (0 <= cx,cy,cz <= 1) for facet-, edge-, or corner-located field values*
-   
+
 ----
 
 .. glossary::
@@ -272,42 +272,42 @@ finer time step to match a neighboring block's coarser time step.
 
   ``void FaceFluxes::get_size (int * mx, int * my, int * mz)``
    *Return the array dimensions of the flux array, including any adjustments for centering.  Indexing is ix + mx\*(iy +my\*iz).*
-   
+
 ----
 
 .. glossary::
 
   ``void FaceFluxes::set_flux_array ( std::vector<double> array, int dx, int dy, int dz)``
    *Copy flux values from an array to the FluxFaces flux array. Array element array[ix\*dx + iy\*dy + iz\*dz] should correspond to flux value (ix,iy,iz), where (0,0,0) <= (ix,iy,iz) < (mx,my,mz).*
-  
+
 ----
 
 .. glossary::
 
   ``std::vector<double> & FaceFluxes::flux_array (int * dx=0, int * dy=0, int * dz=0)``
    *Return the array of fluxes and associated strides (dx,dy,dz) such that the (ix,iy,iz) flux value is fluxes[ix\*dx + iy\*dy + iz\*dz], where (0,0,0) <= (ix,iy,iz) < (mx,my,mz).*
-  
+
 ----
 
 .. glossary::
 
   ``void FaceFluxes::coarsen(int cx, int cy, int cz, int rank)``
    *Used for coarsening fine-level fluxes to match coarse level fluxes. Arguments (cx,cy,cz) specify the child indices of the block within its parent (not to be confused with centering (cx_,cy_,cz_); flux array size is kept the same, with offset determined by child indices.*
-  
+
 ----
 
 .. glossary::
 
   ``void FaceFluxes::accumulate (FaceFluxes & ff, int cx, int cy, int cz, rank)``
    *Add the FaceFluxes object to this one. Used for accumulating fluxes with finer time steps until they match the coarser time step. Assumes spacially-conforming FaceFluxes objects.*
-  
+
 ----
 
 .. glossary::
 
   ``FaceFluxes & FaceFluxes::operator *= (double weight)``
    *Scale the fluxes array by a scalar constant.*
-  
+
 --------------
 FluxData class
 --------------
@@ -324,7 +324,7 @@ differencing fluxes is the responsibility of the :p:`FaceFluxes`
 class; :p:`FluxData` is primarily a container.
 
 
-.. glossary::      
+.. glossary::
 
    ``FluxData::FluxData()``
      *Create an empty FluxData() object*
@@ -359,35 +359,35 @@ class; :p:`FluxData` is primarily a container.
 
 ----
 
-.. glossary::      
+.. glossary::
 
    ``void FluxData::block_fluxes(int axis, int face, int i_f)``
     *Return the face fluxes object associated with the given facet and field. Note 0 <= i_f  < num_fields() is an index into the field_list vector, not the field index itself.*
 
 ----
 
-.. glossary::      
+.. glossary::
 
    ``void FluxData::neighbor_fluxes(int axis, int face, int i_f)``
     *Return the neighboring block's face fluxes associated with the given facet and field. Note 0 <= i_f  < num_fields() is an index into the field_list vector, not the field index itself.*
 
 ----
 
-.. glossary::      
+.. glossary::
 
    ``void FluxData::set_block_fluxes(FaceFluxes * ff, int axis, int face, int i_f)``
     *Set the block's face fluxes associated with the given facet and field. Note 0 <= i_f  < num_fields() is an index into the field_list vector, not the field index itself.*
 
 ----
 
-.. glossary::      
+.. glossary::
 
    ``void FluxData::set_neighbor_fluxes(FaceFluxes * ff, int axis, int face, int i_f)``
     *Set the neighboring block's face fluxes associated with the given facet and field. Note 0 <= i_f  < num_fields() is an index into the field_list vector, not the field index itself.*
 
 ----
 
-.. glossary::      
+.. glossary::
 
    ``void FluxData::sum_neighbor_fluxes(FaceFluxes * ff, int axis, int face, int i_f)``
     *Accumulate (sum) the neighboring block's face fluxes associated with the given facet and field. Note 0 <= i_f  < num_fields() is an index into the field_list vector, not the field index itself.*
@@ -417,7 +417,7 @@ type, which by definition includes
    3. only from finer resolution to coarser resolution (temporal as
       well as spacial)
 
----- 
+----
 
 .. figure:: flux-refresh-1.png
     :width: 500px
@@ -425,9 +425,9 @@ type, which by definition includes
     :alt: figure illustrating that fine block fluxes are coarsened before being communicated
     :figclass: align-center
 
-    Communicating fluxes assuming constant time steps.               
-      
----- 
+    Communicating fluxes assuming constant time steps.
+
+----
 
 .. figure:: flux-refresh-2.png
     :width: 500px
@@ -435,13 +435,13 @@ type, which by definition includes
     :alt:  figure illustrating that fine block fluxes with shorter time steps are accumulated in the receiving coarse grid neighbor fluxes
     :figclass: align-center
 
-    Communicating fluxes assuming adaptive time steps.               
-      
+    Communicating fluxes assuming adaptive time steps.
+
 Testing
 =======
 
 Multiple levels of testing are used, including unit tests for the lower level
-:p:`Face`, :p:`FaceFluxes`, and :p:`FluxData` classes, and 
+:p:`Face`, :p:`FaceFluxes`, and :p:`FluxData` classes, and
 application testing for :p:`MethodFluxCorrect`.
 
 Application tests include varying difficulties of meshes, physics,
@@ -454,7 +454,7 @@ are summarized below:
    * **M1** unigrid
    * **M2** one additional refinement level
    * **M3** two additional refinement levels
-     
+
 * **Physics**
 
   * **PH** hydro
@@ -473,7 +473,7 @@ are summarized below:
   * **F8** double
 
 * **Parallelism**
-  
+
   * **p1**: single processor
   * **pc**: parallel across cores
   * **pn**: parallel across nodes
@@ -481,11 +481,11 @@ are summarized below:
 Documentation
 =============
 
-- **DD-1.** *Design*: add flux correction design to :p:`design/design-flux.rst` 
+- **DD-1.** *Design*: add flux correction design to :p:`design/design-flux.rst`
 - **DD-2.** *Method*: add :p:`MethodFluxCorrect` method documentation to :p:`user/problem_method.rst`
 - **DD-3.** *Testing*: add :p:`testing/testing_flux.rst` test documentation
 - **DD-4.** *Parameters*: update :p:`doc/source/param/`  parameter documentation
-   
+
 ==========
 Milestones
 ==========

--- a/doc/source/design/design-interp.rst
+++ b/doc/source/design/design-interp.rst
@@ -24,7 +24,7 @@ augmented coarse-grid array overlaps multiple additional blocks.
     In ENZO's SecondOrderA interpolation method, multiple additional blocks
     intersect the extended array of coarse values (red) required for
     computing the interpolated ghost zone values (blue) for the fine block (green)
-    that intersects a coarse block.          
+    that intersects a coarse block.
 
 ======
 Design
@@ -35,9 +35,9 @@ Note a given block may participate in multiple roles for different block faces.
 There are three main block roles involved in an interpolation:
 
    1. **Sending block**
-      
+
       a. sends its overlapped cell values to the receiver
-         
+
    2. **Extra block**
 
       a. sends its overlapped cell values to the receiver
@@ -88,7 +88,7 @@ receiver.  This is handled in the
 ``Block::refresh_load_extra_face_()`` method, which can be found in
 the ``control_refresh.cpp`` source file.  Depending on the relative
 mesh refinement level, an extra block may be handled
-          
+
 Receiving Block
 ===============
 

--- a/doc/source/design/index.rst
+++ b/doc/source/design/index.rst
@@ -4,7 +4,7 @@ Design documents
 
 .. role:: raw-html(raw)
              :format: html
-                      
+
 This section describes some of the lower-level designs of Enzo-E and
 Cello, including flux-correction, IO, and ghost zone refresh.
 

--- a/doc/source/devel/array.rst
+++ b/doc/source/devel/array.rst
@@ -68,7 +68,7 @@ the number of dimensionsions of the array.
 
 At a high-level, this class template has semantics like a pointer or
 ``std::shared_ptr`` (there are also similarities to numpy's
-``ndarray``).  These objects serve as a 
+``ndarray``).  These objects serve as a
 smart-pointer with methods for treating the data as a specialized
 array.  These semantics explicitly differ from the C++ standard
 library containers (like ``std::vector``).
@@ -106,10 +106,10 @@ Simplest initialization:
 
 
     * Construct an array of shape ``(5,)`` that holds ints:
-       
+
     .. code-block:: c++
 
-       CelloView<int,1> arr(5); 
+       CelloView<int,1> arr(5);
        CelloView<int,1> arr2 = CelloView<int,1>(5); // yields same result
 
 Wrap a pre-existing pointer:
@@ -130,7 +130,7 @@ We can also forward declare an array and assign values to it later.
 .. code-block:: c++
 
    int data[] = {0,1,2,3,4,5};
-   CelloView<int,2> arr; 
+   CelloView<int,2> arr;
    arr = CelloView<int,2>(data,2,3);
 
 
@@ -189,7 +189,7 @@ To perform a deepcopy, assign the the results of the ``deepcopy`` method.
    int data[] = {0,1,2,3,4,5};
    CelloView<int,2> a(data,2,3);
    CelloView<int,2> e = a.deepcopy(); // e is now a deep copy of a
-   
+
 Modifications to the contents of ``e`` will not be reflected in ``a``
 or ``data`` (and vice-versa)
 
@@ -339,7 +339,7 @@ the generating subarrays of a ``CelloView`` instance. These are
      are passed as the ``start`` argument, they are understood to mean
      that the slice starts at the first element
      (``CSlice(0,NULL)``, ``CSlice(0,nullptr)``, ``CSlice(NULL,NULL)``, &
-     ``CSlice(nullptr,nullptr)`` are all equivalent). 
+     ``CSlice(nullptr,nullptr)`` are all equivalent).
 
 Finally, we note that ``CSlice`` provides a default constructor to
 simplify the construction of arrays of slices. However, to help avoid
@@ -486,16 +486,16 @@ have:
 
   * An ``(mz,my,mx-1)`` array of left reconstructed values, ``wl``
 
-  * An ``(mz,my,mx-1)`` array of right reconstructed values, ``wr`` 
+  * An ``(mz,my,mx-1)`` array of right reconstructed values, ``wr``
 
 First is an the ``CelloView`` version:
-    
+
 .. code-block:: c++
 
    typedef double enzo_float;
    typedef CelloView<enzo_float,3> EFlt3DArray;
 
-   void reconstruct_NN_x(EFlt3DArray &w, EFlt3DArray &wl, 
+   void reconstruct_NN_x(EFlt3DArray &w, EFlt3DArray &wl,
                          EFlt3DArray &wr){
        w.subarray(CSlice(0,w.shape(0)),
                   CSlice(0,w.shape(1)),
@@ -518,7 +518,7 @@ The analogous code using conventional pointer operations is:
        for (int iy=0; iy<my-1; iy++) {
          for(int ix=0; ix<mx-1; ix++) {
            int i = (iz*my + iy)*mx + ix;
-           int i_xf = (iz*my + iy)*(mx-1) + ix; 
+           int i_xf = (iz*my + iy)*(mx-1) + ix;
            wl[i_xf] = w[i];
            Wr[i_xf] = w[i + offset];
          }
@@ -585,9 +585,9 @@ The analogous function using conventional pointer operations is provided below:
    typedef double enzo_float;
    typedef CelloView<enzo_float,3> EFlt3DArray;
 
-   void update_cons(enzo_float *u, enzo_float *out, 
+   void update_cons(enzo_float *u, enzo_float *out,
                     enzo_float *xflux, enzo_float *yflux,
-                    enzo_float *zflux, enzo_float dt, 
+                    enzo_float *zflux, enzo_float dt,
                     enzo_float dx, enzo_float dy, enzo_float dz,
                     int mx, int my, int mz){
      enzo_float dtdx = dt/dx;
@@ -606,7 +606,7 @@ The analogous function using conventional pointer operations is provided below:
            int i_yf = (iz*(my-1) + iy) * mx + ix;
            int i_xf = (iz*my + iy) * (mx-1) + ix;
 
-           out[i] = (u[i] 
+           out[i] = (u[i]
                      - dtdx * (xflux[i_xf] - xflux[i_xf - x_offset])
                      - dtdy * (yflux[i_yf] - yflux[i_yf - y_offset])
                      - dtdz * (zflux[i_zf] - zflux[i_zf - z_offset]));
@@ -651,7 +651,7 @@ This code assumes a mesh with shape ``(mz, my, mx)``. Suppose we have:
    void calc_center_bfield(EFlt3DArray &bc, EFlt3DArray &bi, int dim){
      EFlt3DArray bi_l = bi;
 
-     // The following is a repeating pattern that gets factored out into 
+     // The following is a repeating pattern that gets factored out into
      // a helper function
      EFlt3DArrau bi_r;
      if (dim == 0) {
@@ -709,7 +709,7 @@ map/dictionary of instances of ``CelloView<T,3>``.  The keys of the
 map are always strings.
 
 .. note::
-   
+
     As a historical note, the ``ViewMap`` class template replaces an
     older concrete class known as ``EnzoEFltArrayMap``, which was a
     map/dictionary of instances of ``CelloView<enzo_float,3>`` (or

--- a/doc/source/devel/cmake_primer.rst
+++ b/doc/source/devel/cmake_primer.rst
@@ -115,7 +115,7 @@ Note, the usage of Charm++ introduces some additional complexity to this project
 
    At this time, the conventions for organizing Cello/Enzo-E's header files introduce a lot of transitive dependencies.
    Going forward, we may wish to revisit this.
-   
+
 
 
 ``cmake`` directory
@@ -125,7 +125,7 @@ This directory holds scripts used for optimizations, building charm++ modules, a
 
 ``config`` directory
 ~~~~~~~~~~~~~~~~~~~~
-Following a convention from Enzo, the ``config`` directory holds CMake scripts that each define useful variables for the build that are specific to different platforms. 
+Following a convention from Enzo, the ``config`` directory holds CMake scripts that each define useful variables for the build that are specific to different platforms.
 
 
 =========

--- a/doc/source/devel/coding-guidelines.rst
+++ b/doc/source/devel/coding-guidelines.rst
@@ -8,7 +8,7 @@ Enzo-E Coding Guidelines
 
 
 This page describes current coding guidelines for Enzo-E development.  It is
-a working document and always open to suggestions for changes.  
+a working document and always open to suggestions for changes.
 
 -----------------------
 
@@ -22,7 +22,7 @@ File paths have the form
 ``src/Enzo/``\ *component*\ ``/`` *class*\ ``.[hc]pp``, where
 
 * *component* is the organizing directory from the Enzo-Layer. You can
-  investigate 
+  investigate
 * *class* is the class-name (see below for Enzo-E class naming
   guidelines)
 * and the ``.hpp`` extension is for header (declaration) files while
@@ -103,7 +103,7 @@ discussion about file naming can be found in the previous section)
 +---------------------+---------------------------+------------------+
 | Boundary conditions | ``EnzoBoundary``\ *Name*  | ``Boundary``     |
 +---------------------+---------------------------+------------------+
-| Interpolation       | ``EnzoProlong``\ *Name*   | ``Prolong``      | 
+| Interpolation       | ``EnzoProlong``\ *Name*   | ``Prolong``      |
 +---------------------+---------------------------+------------------+
 | Restriction         | ``EnzoRestrict``\ *Name*  | ``Restrict``     |
 +---------------------+---------------------------+------------------+
@@ -429,7 +429,7 @@ We recommend some of the following coding practices:
   * You explicitly want to allow the argument to be a ``nullptr``.
 
 * When declaring enumerations, prefer to use a `scoped enum <https://en.cppreference.com/w/cpp/language/enum>`_.
-  The concept of a scoped enums was introduced in C++11. 
+  The concept of a scoped enums was introduced in C++11.
   An example of a scoped enum from the codebase is the :cpp:enum:`!ghost_choice` enumeration.
   The declaration of this type looks something like the following snippet:
 
@@ -446,7 +446,7 @@ We recommend some of the following coding practices:
        This is much more explicit (and consequently better) than the alternative.
        If :cpp:enum:`!ghost_choice` were instead defined as an unscoped enum, :cpp:enumerator:`!exclude`, :cpp:enumerator:`!include`, and :cpp:enumerator:`!permit` would be introduced as symbols in the global namespace. [#f2]_
 
-    2. Because :cpp:enum:`!ghost_choice` is a scoped enum, ``ghost_choice`` is directly recognized as a type of a variable. If it were an unscoped enum, you must 
+    2. Because :cpp:enum:`!ghost_choice` is a scoped enum, ``ghost_choice`` is directly recognized as a type of a variable. If it were an unscoped enum, you must
        If it were an unscoped enum, you could instead declare a variable of type ``enum ghost_choice``.
 
     3. Perhaps most importantly, scoped enums have better type safety.

--- a/doc/source/devel/eos-fluidprops.rst
+++ b/doc/source/devel/eos-fluidprops.rst
@@ -81,7 +81,7 @@ As an aside, the signatures of these methods actually use :cpp:type:`!EnzoEFltAr
    If :cpp:class:`!EnzoPhysicsFluidProps` holds a barotropic EOS, this method should do nothing.
 
    .. note::
-      In the future, it may make sense to directly pass the pressure floor. 
+      In the future, it may make sense to directly pass the pressure floor.
 
 
     .. _EOS-Developer-Guide:
@@ -183,7 +183,7 @@ The :cpp:class:`!EnzoEOSIdeal` class implements methods that, given the density 
 
     4. no base classes or virtual methods
 
-  Invariants that might be enforced in a constuctor are instead enforced by a factory method (e.g. :cpp:func:`!EnzoEOSIdealt::construct`). 
+  Invariants that might be enforced in a constuctor are instead enforced by a factory method (e.g. :cpp:func:`!EnzoEOSIdealt::construct`).
 
   In reality, it would probably simplify the code quite a bit, without sacrificing much/any performance, if we just required that the class was trivially copyable (that's possible without it being an aggregate)
 
@@ -341,7 +341,7 @@ This means that any time you perform a copy on an instance of :cpp:class:`!EnzoE
   // make a copy of eos_variant
   EnzoEOSVariant my_eos_variant = eos_variant;
 
-  
+
 Any mutations to the contents of ``my_eos_variant`` will not affect the contents of ``enzo::fluid_props()->eos_variant()``.
 Examples might include:
 
@@ -415,7 +415,7 @@ This snippet will abort with an error if each Processing Element's global :cpp:c
 Using ``EnzoEOSVariant`` (visitor pattern)
 ------------------------------------------
 
-The :cpp:func:`EOSVariant::visit` method can be used to dispatch code based on the type of the EOS that is stored within the EOSVariant. 
+The :cpp:func:`EOSVariant::visit` method can be used to dispatch code based on the type of the EOS that is stored within the EOSVariant.
 This method effectively implements the `visitor design pattern <https://en.m.wikipedia.org/wiki/Visitor_pattern>`_.
 While this is generally most helpful when you have a collection of objects, it may be helpful in simplifying some code in Enzo-E.
 

--- a/doc/source/devel/hydro_infrastructure.rst
+++ b/doc/source/devel/hydro_infrastructure.rst
@@ -111,7 +111,7 @@ The introduction of this formalism has 2 key benefits:
      determination of which indices to iterate over. The
      ``EnzoFieldArrayFactory`` can take the stale depth as an argument
      in its constructor and then all arrays that an instance builds
-     will have the stale values clipped off.  This allows the bounds of 
+     will have the stale values clipped off.  This allows the bounds of
      for-loops to be written as though the only reconstruction algorithm
      is nearest-neighbor interpolation and as though there never any
      preceeding partial timesteps.
@@ -765,7 +765,7 @@ reproduced below:
 .. note::
    In the near-future, the above snippet will be replaced with nicer looking
    documentation that will be auto-generated using doxygen and breathe
-   
+
 More details will be given below about internal energy calculations.
 
     .. _KernelReq-section:

--- a/doc/source/devel/index.rst
+++ b/doc/source/devel/index.rst
@@ -10,7 +10,7 @@ including adding new computational methods, initial conditions,
 refinement criteria, etc.
 
 .. toctree::
-      
+
    coding-guidelines
    initial
    adapt

--- a/doc/source/devel/method.rst
+++ b/doc/source/devel/method.rst
@@ -50,7 +50,7 @@ Be mindful, that the following snippet doesn't actually exist anywhere in the co
       Method* cur_method = method_l[method_ind];
 
       for (std::size_t j = 0; j < num_local_blocks; j++){
-        /* do some fancy stuff related to refreshing fields with data from 
+        /* do some fancy stuff related to refreshing fields with data from
            neighboring blocks */
 
         // call compute on the method
@@ -66,7 +66,7 @@ Be mindful, that the following snippet doesn't actually exist anywhere in the co
     }
 
   }
-  
+
 Pitfalls
 ========
 The previous section should have made it clear that a given ``Method`` instance generally has its ``timestep`` and ``compute`` method invoked on one or more ``Block`` per cycle.

--- a/doc/source/devel/param.rst
+++ b/doc/source/devel/param.rst
@@ -15,7 +15,7 @@ We are currently in the process of migrating between approaches for accessing th
 Given the large scope of this transition, we decided to gradually migrate between the approaches, rather than try to do it one shot.
 
 * At the time of writing, we have migrated a large number of :cpp:class:`!Method` classes.
-  
+
 * Our intention is to eventually migrate as much as possible to this new approach (e.g. all :cpp:class:`!Method` classes, all :cpp:class:`!Physics` classes, all :cpp:class:`!Initial` classes, etc.).
   Ultimately we would like to remove the :cpp:class:`!Config` and :cpp:class:`!EnzoConfig` classes.
 
@@ -77,7 +77,7 @@ Values associated with parameters can be queried by invoking methods directly pr
 
 Basic API for Accessing Parameters
 ----------------------------------
-   
+
 Both classes define a common set of methods for querying the values associated with the parameters.
 We'll now describe some of the most commonly used methods.
 Consider a reference to a :cpp:class:`!Parameters` instance or a :cpp:class:`!ParametersGroup` instance called ``p``.
@@ -162,7 +162,7 @@ Here's we present (an edited) example of what the class's constructor might look
     : Method(),
       alpha_(p.value_float("alpha",0.7)) // access alpha param & use it to initialize
                                          // this->alpha_ (for the sake of example,
-                                         // it defaults to 0.7 if not specified) 
+                                         // it defaults to 0.7 if not specified)
    {
      // parse the courant value
      double parsed_courant_val = p.value_float("courant", 1.0);
@@ -190,7 +190,7 @@ How to add a new parameter
 ==========================
 
 
-Let’s walk through an example where we want to introduce a new parameter to :cpp:class:`!EnzoMethodHeat`. 
+Let’s walk through an example where we want to introduce a new parameter to :cpp:class:`!EnzoMethodHeat`.
 Suppose we want to add a new parameter called :par:param:`!my_param`.
 The full name of this parameter would be :par:param:`!Method:heat:my_param`.
 
@@ -209,7 +209,7 @@ The steps are as follows:
 2. Modify the pup routine of :cpp:class:`!EnzoMethodHeat` and the ``PUP::able`` migration constructor to properly handle the newly added member-variable
 
 3. Modify the main constructor of :cpp:class:`!EnzoMethodHeat` to initialize ``my_param_`` based on the value parsed from the parameter file.
-   
+
    - The constructor of :cpp:class:`!EnzoMethodHeat` is passed a copy of an instance of :cpp:class:`!ParameterGroup`, in an argument ``p``.
 
    - In the simplest case, you might use one of the methods described :ref:`here <basic-parameter-access-api>` to access the value specified in the parameter-file, and store the result in ``my_param_``.
@@ -369,7 +369,7 @@ A code snippet using our new approach is shown below:
    However, this is mostly unavoidable if we want to gracefully accomodate initialization of multiple instances of the same :cpp:class:`!Method` subclass.
    Hopefully, this page of documentation will help to offset this disadvantage.
 
-   The *only* other alternative is have :cpp:class:`!ParameterGroup` instances "auto-magically" redirect absolute parameter-paths, but I think that will generally be more confusing. 
+   The *only* other alternative is have :cpp:class:`!ParameterGroup` instances "auto-magically" redirect absolute parameter-paths, but I think that will generally be more confusing.
 
 Hypothetical Question: How do I used :cpp:class:`!ParameterGroup` to query the parameter specified to configure some other :cpp:class:`!Method` subclass?
 ---------------------------------------------------------------------------------------------------------------------------------------------------------

--- a/doc/source/devel/physics.rst
+++ b/doc/source/devel/physics.rst
@@ -85,7 +85,7 @@ The general advice is to implement a :cpp:class:`!Physics` class so that it is i
 This makes the behavior of :cpp:class:`!Physics` classes much easier to reason about because a single PE (processing element)
 
   - only has one instance of a given :cpp:class:`!Physics` class
-  
+
   - AND is responsible for evolving one or more instances of :cpp:class:`EnzoBlock`.
 
 

--- a/doc/source/index.rst
+++ b/doc/source/index.rst
@@ -46,15 +46,15 @@ highly scalable multigrid-based linear solver.
 
 .. toctree::
    :maxdepth: 1
-	   
+
    tutorial/index
-   user/index      
+   user/index
    reference/index
    devel/index
    design/index
    project/index
    tests/index
-   
+
 Getting started
 ---------------
 
@@ -121,7 +121,7 @@ below.  They are more up-to-date, but are also still rather large.
    :download:`Enzo-E / Cello Status and What's New? <http://client64-71.sdsc.edu/Tutorial/1805-1-status.pdf>`
 
    :download:`Introduction to Enzo-E <http://client64-71.sdsc.edu/Tutorial/1805-2-intro.pdf>`
-	     
+
    :download:`First Steps with Enzo-E <http://client64-71.sdsc.edu/Tutorial/1805-3-using.pdf>`
 
 Indices and tables

--- a/doc/source/param/index.rst
+++ b/doc/source/param/index.rst
@@ -1,5 +1,5 @@
 .. include:: ../roles.incl
-	     
+
 *************************
 Enzo-E / Cello Parameters
 *************************
@@ -44,7 +44,7 @@ available, which is used to control how frequently load balancing
 is performed.
 
 .. include:: balance.incl
-	     
+
 --------
 Boundary
 --------
@@ -96,18 +96,18 @@ different types of Field's and Particles.  For example, field groups
 may include "color" and "temporary", and particle groups may include
 "dark_matter" and "star".
 
-:: 
+::
 
     Group {
 
        list = ["color", "temporary"];
 
        color {
-          field_list = ["species_HI", "species_HII" ]; 
-       } 
+          field_list = ["species_HI", "species_HII" ];
+       }
 
        temporary {
-          field_list = ["pressure", "temperature"]; 
+          field_list = ["pressure", "temperature"];
        }
 
     }
@@ -115,7 +115,7 @@ may include "color" and "temporary", and particle groups may include
 Field and Particle groups can analogously be defined in the respective
 Field and Particle parameter groups:
 
-:: 
+::
 
     Field {
 
@@ -123,7 +123,7 @@ Field and Particle parameter groups:
 
        species_HI {
 
-          group_list = ["temporary"]; 
+          group_list = ["temporary"];
 
        }
 
@@ -134,7 +134,7 @@ different types of fields and particles using the ``Grouping`` class
 (see ``src/Cello/data_Grouping.?pp``).
 
 .. include:: group.incl
-	     
+
 -------
 Initial
 -------
@@ -142,7 +142,7 @@ Initial
 The :p:`Initial` group is used to specify initial conditions.  :p:`cycle` specifies the initial cycle number (usually 0), :p:`list` specifies a list of initial conditions, which may include ``"value"`` for initializing fields directly, or other problem-specific initial condition generators.
 
 .. include:: initial.incl
-	     
+
 ------
 Memory
 ------
@@ -225,7 +225,7 @@ Just as with fields, particle types can be assigned to groups_.
 
 .. include:: particle.incl
 
--------   
+-------
 Physics
 -------
 
@@ -255,13 +255,13 @@ Note that when simulation "time" is specified, then the simulation's
 time step may be reduced so that the corresponding output occurs
 exactly at the specified time.
 
-:: 
+::
 
     Output {
 
 
        list = ["check", "dump", "image"];
-    
+
        check {
 
           # **** write a checkpoint every 100.0 seconds ****
@@ -297,7 +297,7 @@ exactly at the specified time.
             ...
        }
     }
-            
+
 .. include:: schedule.incl
 
 ------
@@ -318,8 +318,8 @@ Testing
 
 .. include:: testing.incl
 
------   
+-----
 Units
------   
+-----
 
 .. include:: units.incl

--- a/doc/source/project/gravity_solver_optimization/index.rst
+++ b/doc/source/project/gravity_solver_optimization/index.rst
@@ -2,24 +2,24 @@
 Gravity Solver Optimisation
 ===========================
 
-This document will outline the results of optimisations on the gravity solver 
-performed by a team of scientists consisting of Dr. John Regan and Dr. Stefan 
-Arridge from Maynooth University and Sophie Wenzel-Teuber and Dr. Buket Benek 
-Gursoy from the Irish Centre for High End Computing (ICHEC, part of NUI Galway). 
+This document will outline the results of optimisations on the gravity solver
+performed by a team of scientists consisting of Dr. John Regan and Dr. Stefan
+Arridge from Maynooth University and Sophie Wenzel-Teuber and Dr. Buket Benek
+Gursoy from the Irish Centre for High End Computing (ICHEC, part of NUI Galway).
 
 
 Summary
 -------
 
 We investigated test problems with 16^3, 32^3, 64^3, 256^3 root grid, varying
-number of blocks and number of PEs, with/without AMR, for around 200 cycles. 
+number of blocks and number of PEs, with/without AMR, for around 200 cycles.
 Furthermore, we analysed the bottleneck of the simulations with a
 profiler and present a runtime analysis. Specifically, for dark-matter-only
 cosmology runs, and 256^3 unigrid, the optimal setup was found to be 8^3
-blocks, each of size 32^3. The effects of changing parameters such as 
+blocks, each of size 32^3. The effects of changing parameters such as
 ``min_level`` and the number of V-cycles on code performance were also analysed.
 It was observed that it is unlikely to achieve much speed-up just from changing
-some parameters in the configuration file. 
+some parameters in the configuration file.
 A new feature was implemented in the code to allow refresh operations to have
 different values for ``min_face_rank`` and by using a smaller ``ghost_depth`` a
 decrease in runtime of 30% could be achieved for a unigrid simulation.
@@ -28,62 +28,62 @@ decrease in runtime of 30% could be achieved for a unigrid simulation.
 Profiling with Projections
 --------------------------
 
-Charm++ has the possibility to gather tracing data of all entry functions and a 
-visualisation tool called Projections. 
+Charm++ has the possibility to gather tracing data of all entry functions and a
+visualisation tool called Projections.
 
-The tracing data logs which processes executes which entry function at which 
+The tracing data logs which processes executes which entry function at which
 point in time and for how long. This creates one log file per PE. The size of
-these log files can be set with the ``+logsize`` parameter. 
-Whenever this size is exceeded the logs are flushed to disk. This I/O can 
-heavily influence the tracing results as it will appear as a long execution of 
+these log files can be set with the ``+logsize`` parameter.
+Whenever this size is exceeded the logs are flushed to disk. This I/O can
+heavily influence the tracing results as it will appear as a long execution of
 an entry function in the data.
 
-The Projections visualisation tool provides many possibilities to view this 
-tracing data. The following image is a screenshot from a gravity simulation 
+The Projections visualisation tool provides many possibilities to view this
+tracing data. The following image is a screenshot from a gravity simulation
 with 30 PEs on a grid of 64x64x64 cells, divided into 4 blocks per dimension.
 
-All tracing and runtime measurements have been performed on ICHEC's 
+All tracing and runtime measurements have been performed on ICHEC's
 supercomputer on one or two nodes consisting of 40 Intel Skylake processors each
 and 192GiB (1.5TiB) RAM.
 
 .. image:: 64_overview.png
 
 The X axis shows the time of 3 cycles (203-205) and the Y axis has one line
-per PE of colour codes for the entry functions this PE executed. White signals 
+per PE of colour codes for the entry functions this PE executed. White signals
 idle time.
 
-The purple coloured lines are the refresh routine (functions 
-``p_dot_recv_children`` in the brighter and ``p_new_refresh_recv`` in the 
+The purple coloured lines are the refresh routine (functions
+``p_dot_recv_children`` in the brighter and ``p_new_refresh_recv`` in the
 darker shade).
 
 The blue columns represent the ``r_stopping_compute_timestep`` function and
-signal the end of one and beginning of a new timestep. The equal length of this 
-function for almost all PEs suggest that the log data was flushed during the 
-execution of this function. Therefore, the execution time shown in the image is 
+signal the end of one and beginning of a new timestep. The equal length of this
+function for almost all PEs suggest that the log data was flushed during the
+execution of this function. Therefore, the execution time shown in the image is
 not representable for the real runtime. The same is true for equally sized
 time spans in other functions throughout the plot.
 
-Especially the black blocks that represent "overhead" probably have to be 
-neglected as well as this overhead almost never appears in plots without the 
+Especially the black blocks that represent "overhead" probably have to be
+neglected as well as this overhead almost never appears in plots without the
 problem of flushing log files to disk.
 
-However, what can safely be said is that the refresh routine plays a vital role 
+However, what can safely be said is that the refresh routine plays a vital role
 for the performance of this Enzo-E simulation.
 
 Other plots of Projections show that the refresh routine alone accounts for more
 than 24 million messages in the 3 cycles above of which most result in an entry
-function execution time of less than 0.02s. 
+function execution time of less than 0.02s.
 
 .. image:: 64_msg_number_histo.png
 
-This image shows a histogram of the execution times of the messages for the 
+This image shows a histogram of the execution times of the messages for the
 entry functions.
 
 Purple coloured are the refresh functions as above. Red represents
-``p_control_sync_count``, which is also called in this routine to query the 
-refresh state of a blocks neighbours. 
+``p_control_sync_count``, which is also called in this routine to query the
+refresh state of a blocks neighbours.
 
-When disabling the adaptive mesh refinement and running in a unigrid mode the 
+When disabling the adaptive mesh refinement and running in a unigrid mode the
 effect of the refresh routine is much smaller and the stages of the simulation
 can be identified in the overview.
 
@@ -92,7 +92,7 @@ can be identified in the overview.
 This simulation was run on a grid of 256 cells cubed, divided into 8 blocks per
 direction and parallelised over 32 PEs.
 
-The five cycles of the Multigrid solver are clearly distinguishable because all 
+The five cycles of the Multigrid solver are clearly distinguishable because all
 PEs except one are idle. The number of V-cycles can be adjusted in the parameter
 file and will automatically reduce due to a smaller residual later in the
 simulation.
@@ -101,7 +101,7 @@ the problem and therefore reducing the idle time of the other processors is
 possible by adjusting the ``min_level`` parameter but results in longer
 runtimes (presumably due to communication).
 
-The function ``p_compute_continue`` also has a large 
+The function ``p_compute_continue`` also has a large
 impact on the simulation time and is accountable for starting all solvers that
 are linked to the simulation.
 
@@ -109,55 +109,55 @@ are linked to the simulation.
 Runtime analysis for unigrid on a single node
 ---------------------------------------------
 
-To compare parameters and runtime settings in future analysis a good setup has 
+To compare parameters and runtime settings in future analysis a good setup has
 to be found first that can yield the baseline for performance observations.
 
 All combinations of the grid sizes 32, 64 and 256 cubed, the number of blocks of
-2, 4, 8, 16, 32 and 64 per direction (where applicable) and the number of PEs 
-of 2, 4, 8, 16, 32 and 64 (also where applicable) were run for a simulation 
+2, 4, 8, 16, 32 and 64 per direction (where applicable) and the number of PEs
+of 2, 4, 8, 16, 32 and 64 (also where applicable) were run for a simulation
 without adaptive mesh refinement for clarity.
 
-This provides a lot of numbers that are difficult to compare. The goal is to 
+This provides a lot of numbers that are difficult to compare. The goal is to
 find metrics that cover a beneficial balance between a good workload per PE and
 therefore a performance utilisation of the resources, and a high
 parallelisation.
 
-What was used is a mixture of weak and strong scaling: 
-The following plot shows the runtime per cycle (``total runtime / number of 
-cycles``) for a simulation size of 256 cubed for four constant numbers of 
-blocks per PE. 
+What was used is a mixture of weak and strong scaling:
+The following plot shows the runtime per cycle (``total runtime / number of
+cycles``) for a simulation size of 256 cubed for four constant numbers of
+blocks per PE.
 
 .. image:: graph_time-p-cycle.png
 
 For example for a number of 64 blocks per PE the runtimes were calculated for
 
 * 16^3 blocks on 64PEs
-* 8^3 blocks on 8 PEs 
+* 8^3 blocks on 8 PEs
 * 4^3 blocks on 1 PE.
 
 This means in the graph above from left to right the blocks become larger but
 with less parallelisation. Therefore, each PE has more to calculate on the right
 side of the graph than on the left, but less to communicate.
 
-A similar plot can be created for the accumulated time of all PEs to perform 
+A similar plot can be created for the accumulated time of all PEs to perform
 one cycle - this is the value from above multiplied by the number of PEs. This
 relates to the CPU time needed to complete one step of the simulation.
 
 .. image:: graph_time-p-cycle_all-PE.png
 
-From this graph it is clear that it is more efficient to compute larger blocks 
+From this graph it is clear that it is more efficient to compute larger blocks
 on fewer PEs.
 
 Clearly, both representations have to be combined as each one is insufficient
 for an educated guess of a balanced setup.
 From this combination we concluded that a good initial setup of the simulation
-for further tests is using 32PEs and 8 blocks on a grid of 256 cubed cells 
+for further tests is using 32PEs and 8 blocks on a grid of 256 cubed cells
 (which relates to the mid point of the green line in the two plots above).
 
-These metrics fail at smaller simluation sizes for two reasons: The amount of 
+These metrics fail at smaller simluation sizes for two reasons: The amount of
 computational work can be viewed as too small compared to the overhead and the
 parameter space is not sufficient to produce enough results for meaningful
-graphs of the metrics mentioned above. 
+graphs of the metrics mentioned above.
 It is still the case however that fewer but larger blocks and fewer PEs result
 in less CPU time per cycle (again, due to the reduced overhead for
 communication).
@@ -172,32 +172,32 @@ node AMR run.
 How large the ghost zones are that are copied and how many neighbours take part
 in the exchange is parameterised by two variables.
 
-The ``ghost_depth`` that determines the number of cells that are copied in a 
+The ``ghost_depth`` that determines the number of cells that are copied in a
 direction was set to 4 in the runs above which is a necessity at the moment.
 Significant code changes would be required to adapt this value for the
 distinctive refresh routines started by the different parts of Enzo-E.
 
 Only in a simulation on a uniform grid this value can be decreased. Comparing
-the runtime of simulations with a ghost depth of 2 and 4 resulted in a 
-decrease from 2.7872s to 2.1578s (speedup of 1.292) for a simulation with the 
-setting determined in the method above (256^3 cells in 8^3 blocks and 32 
+the runtime of simulations with a ghost depth of 2 and 4 resulted in a
+decrease from 2.7872s to 2.1578s (speedup of 1.292) for a simulation with the
+setting determined in the method above (256^3 cells in 8^3 blocks and 32
 PEs).
 
 Another parameter are the number of neighbours that exchange their ghost zones.
-In a three dimensional grid a cell has 26 neighbours. 6 of them share a face, 
+In a three dimensional grid a cell has 26 neighbours. 6 of them share a face,
 12 share an edge and 8 only a corner.
 
-Depending on the algorithm only the data from neighbouring faces is used. 
-Therefore, it is enough for the refresh routine to only exchange data from 
-these neighbour blocks. 
+Depending on the algorithm only the data from neighbouring faces is used.
+Therefore, it is enough for the refresh routine to only exchange data from
+these neighbour blocks.
 
 The variable to determine how many neighbours are used for the refresh is called
 ``min_face_rank``. A small code change allowed for this to be set when
-constructing refresh objects. For the same simulation parameters as above this 
+constructing refresh objects. For the same simulation parameters as above this
 resulted in a difference of from 2.0589s to 1.9297s (speedup of 1.067) per cycle
-for a unigrid and from  89.0964s to 89.5893s per cycle for an AMR run. 
-The runtime of the AMR simulation has been averaged over all 160 cycles even 
-though the simulation the mesh is not refined in the first ~100 cycles. 
+for a unigrid and from  89.0964s to 89.5893s per cycle for an AMR run.
+The runtime of the AMR simulation has been averaged over all 160 cycles even
+though the simulation the mesh is not refined in the first ~100 cycles.
 Therefore, these numbers have to be treated with caution.
 
 Combining both approaches is as mentioned only possible in a unigrid simulation
@@ -213,6 +213,6 @@ optimisation there is still further work that could potentially be carried out.
 However, further optimisations are likely to be challenging and would require
 extensive code changes like implementing a more effective smoother such as
 red-black Gauss-Seidel, doing multiple Jacobi smoothings per refresh, or
-implementing full-multigrid method instead of V-cycles. 
+implementing full-multigrid method instead of V-cycles.
 Another potential work would be to investigate an alternative strategy for
 computing gravitational forces e.g. through the use of 3D parallel FFT.

--- a/doc/source/project/index.rst
+++ b/doc/source/project/index.rst
@@ -5,7 +5,7 @@ Project documents
 .. toctree::
    :maxdepth: 1
 
-   project-plan	        
+   project-plan
    principles
    components
    gravity_solver_optimization/index

--- a/doc/source/project/principles.rst
+++ b/doc/source/project/principles.rst
@@ -72,7 +72,7 @@ Usability
 .. table:: A simple hydrodynamics problem
 
    ===========  ===========
-     |NSF000|      |NSF300| 
+     |NSF000|      |NSF300|
    ===========  ===========
 
 Cello is designed to be both *user-friendly* and *developer-friendly*.
@@ -92,7 +92,7 @@ field:
 
 .. role:: config(code)
    :language: python
- 
+
 This reads naturally as "initialize density with the value 1.0
 wherever the input image mask is set (i.e. not black), and 0.125
 elsewhere."

--- a/doc/source/reference/index.rst
+++ b/doc/source/reference/index.rst
@@ -1,10 +1,10 @@
-	     
+
 ***************
 Reference Guide
 ***************
 
 .. toctree::
    :maxdepth: 1
-	   
+
    ../param/index
 

--- a/doc/source/tests/adapt-cmake.rst
+++ b/doc/source/tests/adapt-cmake.rst
@@ -3,7 +3,7 @@
 Adapt Tests
 -----------
 
-Tests run 2D implosion problem on a slope mesh refinement with square initial values at different ``max_level``. This specifies the most highly defined block in the mesh hierarchy. 
+Tests run 2D implosion problem on a slope mesh refinement with square initial values at different ``max_level``. This specifies the most highly defined block in the mesh hierarchy.
 
 
 adapt-L5-P1

--- a/doc/source/tests/adapt.rst
+++ b/doc/source/tests/adapt.rst
@@ -3,7 +3,7 @@
 Adapt Tests
 -----------
 
-Tests run 2D implosion problem on a slope mesh refinement with square initial values at different ``max_level``. This specifies the most highly defined block in the mesh hierarchy. 
+Tests run 2D implosion problem on a slope mesh refinement with square initial values at different ``max_level``. This specifies the most highly defined block in the mesh hierarchy.
 
 adapt-L0-P1
 ===========

--- a/doc/source/tests/boundary-cmake.rst
+++ b/doc/source/tests/boundary-cmake.rst
@@ -2,7 +2,7 @@
 Boundary Condition Tests
 ------------------------
 
-Runs an implosion problem on various boundary conditions in 2D and 3D. 
+Runs an implosion problem on various boundary conditions in 2D and 3D.
 
 
 boundary_outflow-2d

--- a/doc/source/tests/boundary.rst
+++ b/doc/source/tests/boundary.rst
@@ -2,7 +2,7 @@
 Boundary Condition Tests
 ------------------------
 
-Runs an implosion problem on various boundary conditions in 2D and 3D. 
+Runs an implosion problem on various boundary conditions in 2D and 3D.
 
 
 boundary_mixed-2d

--- a/doc/source/tests/checkpoint.rst
+++ b/doc/source/tests/checkpoint.rst
@@ -2,7 +2,7 @@
 Checkpoint Tests
 ----------------
 
-Tests for restart checkpoints. Runs 2D implosion using PPM method with slope mesh refinement. 
+Tests for restart checkpoints. Runs 2D implosion using PPM method with slope mesh refinement.
 
 
 checkpoint_ppm-1

--- a/doc/source/tests/helloworld.rst
+++ b/doc/source/tests/helloworld.rst
@@ -7,9 +7,9 @@ Tests of full code to demonstrate functionality. These are done as a demostratio
 HelloWorld
 ==========
 
-Demonstration test of Enzo-E, generates high pressure region in shape of Hello World 
+Demonstration test of Enzo-E, generates high pressure region in shape of Hello World
 
-Hi 
+Hi
 ===
 
 Shorter version of HelloWorld. Takes few minutes as opposed to several hours

--- a/doc/source/tests/hydro.rst
+++ b/doc/source/tests/hydro.rst
@@ -20,7 +20,7 @@ From `broken link <https://ww.astro.virginia.edu/VITA/ATHENA/dmr.html>_`
 test_implosion
 ==============
 
-Runs a 2D implosion problem. Tests Initial:<field>:value. Test outputs density image file and mesh image file. 
+Runs a 2D implosion problem. Tests Initial:<field>:value. Test outputs density image file and mesh image file.
 
 test_implosion-code
 ===================

--- a/doc/source/tests/mergesinks-cmake.rst
+++ b/doc/source/tests/mergesinks-cmake.rst
@@ -7,11 +7,11 @@ Four tests of the enzo-e "merge sinks" method.
 - the stationary serial test
 
 - the stationary parallel test
-    
+
 - the drifting serial test
 
 - the stationary parallel test
-    
+
 All the files necessary for running the tests can be found in input/merge_sinks.
 
 Each test involves setting up initial conditions with 1000 sink particles randomly

--- a/doc/source/tests/mergesinks.rst
+++ b/doc/source/tests/mergesinks.rst
@@ -7,11 +7,11 @@ Four tests of the enzo-e "merge sinks" method.
 - the stationary serial test
 
 - the stationary parallel test
-    
+
 - the drifting serial test
 
 - the stationary parallel test
-    
+
 All the files necessary for running the tests can be found in input/merge_sinks.
 
 Each test involves setting up initial conditions with 1000 sink particles randomly

--- a/doc/source/tests/pytest_framework.rst
+++ b/doc/source/tests/pytest_framework.rst
@@ -235,7 +235,7 @@ For all classes annotated with this decorator:
 
  * the framework knows that it must make symbolic links to all files in the directory run by ``GRACKLE_INPUT_DATA_DIR`` before it runs the simulation associated with this class.
  * the testing framwork also knows to skip the associated test(s) if the ``GRACKLE_INPUT_DATA_DIR`` environment variable is unset.
- 
+
 If you forget to add this label, ``Enzo-E`` will not be able to locate the data file needed for Grackle (in a portable way).
 Thus, the associated simulation and test will fail.
 

--- a/doc/source/tutorial/getting_started.rst
+++ b/doc/source/tutorial/getting_started.rst
@@ -15,7 +15,7 @@ architectures, including the "Frontera" supercomputer at TACC and the
 
 .. toctree::
    :maxdepth: 1
-	   
+
    getting_started_pleiades
    getting_started_frontera
 
@@ -302,7 +302,7 @@ Debugging Options
 ^^^^^^^^^^^^^^^^^
 
 The following options are useful for debugging.
-       
+
 .. list-table:: Debug Options
    :widths: 10 30 5
    :header-rows: 1
@@ -366,7 +366,7 @@ For example, a configure line may look like
   cmake -DCHARM_ROOT=$(pwd)/../../charm/build-gcc-mpi-proj -DEnzo-E_CONFIG=msu_hpcc_gcc -DGrackle_ROOT=${HOME}/src/grackle/build-gcc -Duse_projections=ON -Duse_jemalloc=ON -Dbalance=ON  ..
 
 To see all available (and selected) options you can also run ``ccmake .`` in the
-build directory (after running ``cmake`` in first place), or use the ``ccmake`` GUI 
+build directory (after running ``cmake`` in first place), or use the ``ccmake`` GUI
 directly to interactively configure Enzo-E by calling ``ccmake ..`` in an empty build
 directory.
 
@@ -497,7 +497,7 @@ Time = 0.05
 Time = 0.10
 
 .. image:: hello-de-0165.png
-   :scale: 40 %                   
+   :scale: 40 %
 
 .. image:: hello-mesh-level-0165.png
    :scale: 40 %

--- a/doc/source/tutorial/getting_started.rst
+++ b/doc/source/tutorial/getting_started.rst
@@ -371,7 +371,7 @@ Here are 2 illustrative examples:
    If you stored ``"-Wall;-Wpedantic;-funroll-loops"`` within the ``ENZOE_CXX_FLIST`` variable, then all C++ files used to build Cello and Enzo-E would be passed those flags.
 
  * Next we show that to properly pass "options groups" you may need to make use of shell-like quoting with the ``SHELL:`` prefix (this is required because of option de-duplication performed by cmake).
-   Thus storing ``"SHELL:-option1 A;-Wall;SHELL:-option2 B"`` within ``ENZOE_Fortran_FLIST`` would cause all Fortran files used in Enzo-E and Cello to be passed ``-option1 A -Wall -option2 B``. 
+   Thus storing ``"SHELL:-option1 A;-Wall;SHELL:-option2 B"`` within ``ENZOE_Fortran_FLIST`` would cause all Fortran files used in Enzo-E and Cello to be passed ``-option1 A -Wall -option2 B``.
 
 
 CMake offers a similar set of standard variables named ``CMAKE_<LANG>_FLAGS`` that serve a similar purpose, but they behave slightly differently.

--- a/doc/source/tutorial/index.rst
+++ b/doc/source/tutorial/index.rst
@@ -4,5 +4,5 @@ Tutorial
 
 .. toctree::
    :maxdepth: 2
-	   
+
    getting_started

--- a/doc/source/user/data_field.rst
+++ b/doc/source/user/data_field.rst
@@ -28,12 +28,12 @@ Field API
 FieldData (field data) object.`
 
 ----
-   
+
 :Method:  :p:`Field::Field(FieldDescr \*, FieldData \*)`
-:Method:  Field(const Field & field) 
+:Method:  Field(const Field & field)
 :Summary:   :s:`Copy constructor`
 :Return:   :t:`none`
-		       
+
 ----
 
 :Method:  :p:`Field::operator= (const Field & field)`
@@ -51,7 +51,7 @@ FieldData (field data) object.`
 :Method:  :p:`Field::pup (PUP::er &p)`
 :Summary:   :s:`CHARM++ Pack / Unpack function`
 :Return:   :t:`void`
-  
+
 ----
 
 :Method:  :p:`Field::field_descr()`
@@ -76,7 +76,7 @@ FieldData (field data) object.`
 :Summary:  :s:`Set the field data object for the Field object`
 :Return:   :t:`void`
 
-  
+
 Field Descriptor
 ----------------
 
@@ -101,13 +101,13 @@ Field Descriptor
 :Method:   :p:`Field::set_ghost_depth(int id, int gx, int gy=0, int gz=0)`
 :Summary:   :s:`Set ghost_depth for a field`
 :Return:   :t:`void`
-    
+
 ----
 
 :Method:   :p:`Field::set_precision(int id, int precision)`
 :Summary:   :s:`Set precision for a field`
 :Return:   :t:`void`
-    
+
 ----
 
 :Method:   :p:`Field::insert_permanent(const std::string & name)`
@@ -168,7 +168,7 @@ Properties
 :Method:   :p:`centering(int id, int \* cx, int \* cy = 0, int \* cz = 0) const`
 :Summary:   :s:`centering of given field`
 :Return:   :t:`void`
-    
+
 ----
 
 :Method:   :p:`is_centered(int id) const`
@@ -180,7 +180,7 @@ Properties
 :Method:   :p:`ghost_depth(int id, int \* gx, int \* gy = 0, int \* gz = 0) const`
 :Summary:   :s:`depth of ghost zones of given field`
 :Return:   :t:`void`
-    
+
 ----
 
 :Method:   :p:`precision(int id) const`
@@ -220,14 +220,14 @@ History
 :Return:   :t:`int`
 
 ----
-  
+
 :Method:   :p:`save_history (double time)`
 :Summary:   :s:`Copy "current" fields to history`
 :Return:   :t:`void`
 
 :e:`Copy "current" fields to history = 1 fields (saving time), and
 push back older generations up to num_history()`
-  
+
 ----
 
 :Method:   :p:`history_time (int ih) const`
@@ -244,7 +244,7 @@ Units
 :e:`if it's already in cgs, then leave as-is
 except if it's in cgs but the scaling factor has changed (e.g. due to
 expansion) then adjust for the new scaling factor`
-    
+
 ----
 
 :Method:   :p:`units_scale_code (int id, double amount)`
@@ -252,7 +252,7 @@ expansion) then adjust for the new scaling factor`
 :Return:   :t:`void`
 
 :e:`if it's already in code units, leave it as-is warning if scaling factor has changed.`
-	  
+
 ----
 
 :Method:   :p:`units_scaling (const FieldDescr \*, int id)`
@@ -291,7 +291,7 @@ FieldData
 :Return:   :t:`char \*`
 
 :e:`Return array for the corresponding field, which does not contain ghosts whether they're allocated or not`
-	     
+
 ----
 
 :Method:   :p:`permanent ()  const`
@@ -311,7 +311,7 @@ FieldData
 :Method:   :p:`clear (float value = 0.0, int id_first = -1, int id_last  = -1)`
 :Summary:   :s:`Clear specified array(s) to specified value`
 :Return:   :t:`void`
- 
+
 ----
 
 :Method:   :p:`permanent_allocated() const`
@@ -371,7 +371,7 @@ FieldData
 :e:`Return the number of elements (nx,ny,nz) along each axis, and total number of bytes n`
 
 Debugging
----------  
+---------
 
 :Method:   :p:`print (const char \* message, bool use_file = false) const`
 :Summary:   :s:`Print basic field characteristics for debugging`

--- a/doc/source/user/parameters-example.rst
+++ b/doc/source/user/parameters-example.rst
@@ -27,31 +27,31 @@ Domain Group
 
   ::
 
-    Domain { 
+    Domain {
        lower = [ 0.0, 0.0 ];
        upper = [ 1.0, 1.0 ];
-    } 
+    }
 
 Mesh Group
 ----------
 
   ::
 
-   Mesh { 
+   Mesh {
       root_size      = [160, 160];
       root_blocks    = [  1,   1 ];
    }
-    
+
 Field Group
 -----------
 
   ::
 
     Field {
-    
+
        ghost_depth  = 3;
-    
-       fields = [ 
+
+       fields = [
           "density",
           "velocity_x",
           "velocity_y",
@@ -66,7 +66,7 @@ Method Group
   ::
 
     Method {
-    
+
        list = [ "ppm" ];
 
        ppm {
@@ -101,7 +101,7 @@ Initial Group
   ::
 
    Initial {
-       density       { value = [ 1.0, 
+       density       { value = [ 1.0,
        (0.35 < x && x < 0.40 && 0.25 < y && y < 0.70) ||
        (0.35 < x && x < 0.60 && 0.25 < y && y < 0.30) ||
        (0.35 < x && x < 0.60 && 0.45 < y && y < 0.50) ||
@@ -139,7 +139,7 @@ Output Group
 
   ::
 
-   Output { 
+   Output {
 
       file_groups = ["cycle_step"];
 

--- a/doc/source/user/parameters-file.rst
+++ b/doc/source/user/parameters-file.rst
@@ -34,12 +34,12 @@ and ``root_size`` are parameters contained in the respective groups.
 
   ::
 
-     Domain { 
+     Domain {
        lower = [0.0, 0.0, 0.0];
        upper = [1.0, 1.0, 1.0];
-     } 
+     }
 
-     Mesh { 
+     Mesh {
        root_size = [128,128,128];
      }
 
@@ -51,17 +51,17 @@ be "``reflecting``".
 
   ::
 
-     Boundary { 
+     Boundary {
        type = "periodic";
-     } 
+     }
 
-     Mesh { 
+     Mesh {
        root_size = [128,128,128];
      }
 
-     Boundary { 
+     Boundary {
        type = "reflecting";
-     } 
+     }
 
 Subgroups
 *********
@@ -140,16 +140,16 @@ A parameter value is one of several different basic data types:
     ==================	=============================
 
 **Integer types** are integers, and must be representable using a
-32-bit integer.    
+32-bit integer.
 
-    
-**Scalar types** are any floating point or integral numerical values.  
+
+**Scalar types** are any floating point or integral numerical values.
 The constant 'pi' is also recognized as a scalar.
 
    *Note that floating-point and integers are not interchangeable: if a
    floating point type is expected, one cannot use an integer.*
 
-**String types** are enclosed in double-quotes. 
+**String types** are enclosed in double-quotes.
 
 **Variables** represent the position coordinates in space (x, y, and z) and time
 (t).
@@ -238,7 +238,7 @@ underlying grammar and syntax are relatively fixed.
            total_energy = [ 2.8, ( x  +  y ) <  0.1517 , 2.5 ];
            velocity_x = 0.0;
            velocity_y = 0.0;
-        }     
+        }
      }
 
      Adapt {
@@ -326,4 +326,4 @@ underlying grammar and syntax are relatively fixed.
 ----
 
 2020-04-10: Updated with corrections from Joshua Smith.
-     
+

--- a/doc/source/user/problem_initial.rst
+++ b/doc/source/user/problem_initial.rst
@@ -85,7 +85,7 @@ a 3D array of Sedov blast waves.
    Federrath et al 2010, ApJ, 713, 269.
 
 ``"soup"``
-   
+
    Similar to the ``"sedov"`` problem, but with letters instead of spheres.
 
 ``"trace"``
@@ -95,7 +95,7 @@ a 3D array of Sedov blast waves.
    ``"density"`` field distribution.
 
 ``"turbulence"``
-   
+
    Initialize fields for driving turbulence, including ``"driving_[xyz]"``
    fields.
 

--- a/doc/source/user/problem_method.rst
+++ b/doc/source/user/problem_method.rst
@@ -149,7 +149,7 @@ For example, to load balance a simulation with a 4^3 root-level blocking
 ===============================
 
 Adds the comoving expansion terms to the physical variables.
-   
+
 ``"grackle"`` method
 ====================
 
@@ -234,8 +234,8 @@ acceleration fields.
 ``"heat"`` method
 =================
 
-A sample Method for implementing forward-euler to solve the heat equation.   
-   
+A sample Method for implementing forward-euler to solve the heat equation.
+
 ``"merge_sinks"`` method
 ========================
 
@@ -352,7 +352,7 @@ parameter) should be less than 0.5.
 .. list-table:: Method ``mhd_vlct`` parameters
    :widths: 10 5 1 30
    :header-rows: 1
-   
+
    * - Parameter
      - Type
      - Default
@@ -390,11 +390,11 @@ fields
    * - Field
      - Type
      - Read/Write
-     - Description   
+     - Description
    * - ``"density"``
      - ``enzo_float``
      - [rw]
-     -    
+     -
    * - ``"velocity_x"``
      - ``enzo_float``
      - [rw]
@@ -446,7 +446,7 @@ fields
 
 In hydro-mode, none of the 6 fields used to store the magnetic field should
 be defined.
-       
+
 At initialization the face-centered magnetic field should be
 divergence free. Trivial configurations (e.g. a constant magnetic
 field everywhere) can be provided with the ``"value"``
@@ -500,7 +500,7 @@ the associated staling depth, and a brief description.
 		limiters)
    :widths: 3 1 30
    :header-rows: 1
-   
+
    * - Name
      - Staling Depth
      - Description
@@ -556,7 +556,7 @@ We provide a few notes about the choice of interpolator for this algorithm:
       * the second term is the staling depth of the reconstructor specified by
         the :par:param:`~Method:mhd_vlct:reconstruct_method` parameter; this
         is used for computing fluxes for the second stage (for the full
-        timestep). 
+        timestep).
 
 .. _using-vlct-riemann-solver:
 
@@ -595,7 +595,7 @@ them:
     hydrodynamical problems that models contact and shear waves. The
     wavespeed bounds are estimated according to the Einfeldt approach.
     This can only be used in hydro mode.
-    
+
   * ``"hlld"`` The HLLD approximate Riemann solver described in
     Miyoshi & Kusano, 2005. JCP, 315, 344. The wavespeed bounds are
     estimated according to eqn 67 from the paper. This reduces to an
@@ -615,77 +615,77 @@ them:
       assumes constant total pressure. It is unclear whether this causes any
       problems.
 
-``"m1_closure"``: multigroup radiative transfer   
+``"m1_closure"``: multigroup radiative transfer
 ===============================================
 
-Enzo-E's multigroup M1 Closure radiative transfer solver. The M1 Closure solver is implemented following 
+Enzo-E's multigroup M1 Closure radiative transfer solver. The M1 Closure solver is implemented following
 `Rosdahl et al. (2013) <https://ui.adsabs.harvard.edu/abs/2013MNRAS.436.2188R/abstract>`_.
 
 This method adds the following capabilities:
 
-1. **Photon injection:** Photons are sourced from star particles and CiC-deposited 
-   onto the mesh using a cloud radius of one cell width. Depositions occuring at 
-   block boundaries are communicated to neighboring blocks via ghost zone refresh with 
-   ``set_accumulate = true``. This method accesses the ``"luminosity`` attribute 
-   for ``"star"`` particles, where luminosity is in units of :math:`\mathrm{s}^{-1}`. 
-   One can provide an SED using the ``SED`` parameter and specifying ``m1_closure:radiation_spectrum="SED"``. 
-   Alternatively, one can specify ``m1_closure:radiation_spectrum="blackbody"``, in which case 
-   a blackbody spectrum will be integrated. Radiation from recombination is also 
-   optionally included by setting the ``recombination_radiation`` parameter. 
+1. **Photon injection:** Photons are sourced from star particles and CiC-deposited
+   onto the mesh using a cloud radius of one cell width. Depositions occuring at
+   block boundaries are communicated to neighboring blocks via ghost zone refresh with
+   ``set_accumulate = true``. This method accesses the ``"luminosity`` attribute
+   for ``"star"`` particles, where luminosity is in units of :math:`\mathrm{s}^{-1}`.
+   One can provide an SED using the ``SED`` parameter and specifying ``m1_closure:radiation_spectrum="SED"``.
+   Alternatively, one can specify ``m1_closure:radiation_spectrum="blackbody"``, in which case
+   a blackbody spectrum will be integrated. Radiation from recombination is also
+   optionally included by setting the ``recombination_radiation`` parameter.
 
-2. **Photon transport:** The transport equation is solved to update the radiation fields. 
+2. **Photon transport:** The transport equation is solved to update the radiation fields.
    Attenuation is optionally included with the ``attenuation`` parameter.
 
-3. **Photoionization and heating:** This method calculates photoionization and heating rates, 
+3. **Photoionization and heating:** This method calculates photoionization and heating rates,
    which can then be accessed by the ``"grackle"`` method with ``Method:grackle:with_radiative_transfer=true``.
-   Photoionization cross sections can either be provided in the parameter file or calculated inline. 
+   Photoionization cross sections can either be provided in the parameter file or calculated inline.
    This is controlled using the ``m1_closure:cross_section_calculator`` parameter.
 
 This is a reduced speed-of-light (RSOL) method, meaning that the value of the speed of light can be varied
-by setting the ``m1_closure:clight_fraction`` parameter. The radiation timescale is generally set by 
-the speed of light, so a smaller speed of light will allow the simulation to progress faster. 
+by setting the ``m1_closure:clight_fraction`` parameter. The radiation timescale is generally set by
+the speed of light, so a smaller speed of light will allow the simulation to progress faster.
 Some care must be taken when choosing the value for the RSOL, as the approximation is more valid in dense gas.
 The general rule of thumb is the the chosen RSOL must be much less than the typical I-front propagation
-speed in the medium.  For densities typical for the interstellar medium 
-:math:`\left(10^{-2}\,\,\mathrm{cm}^{-3} - 10^{1}\,\,\mathrm{cm}^{-3}\right)`, fractions as low as 
+speed in the medium.  For densities typical for the interstellar medium
+:math:`\left(10^{-2}\,\,\mathrm{cm}^{-3} - 10^{1}\,\,\mathrm{cm}^{-3}\right)`, fractions as low as
 :math:`10^{-2}\,\,\mathrm{cm}^{-3}` are valid. For simulations that seek to resolve
-the reionization of the intergalactic medium, however, the true value of speed of light must be taken in order for reionization to occur at the correct time. 
+the reionization of the intergalactic medium, however, the true value of speed of light must be taken in order for reionization to occur at the correct time.
 See Section 4 of `Rosdahl et al. (2013) <https://ui.adsabs.harvard.edu/abs/2013MNRAS.436.2188R/abstract>`_ for a more detailed discussion.
 
-This method **must** be used in tandem with the ``"m1_closure"`` initializer by appending ``"m1_closure"`` to 
+This method **must** be used in tandem with the ``"m1_closure"`` initializer by appending ``"m1_closure"`` to
 ``Initial:list``.
 
-.. note:: 
+.. note::
 
    Additional term in the radiative transfer equation corresponding to cosmological redshift not yet included. As such, redshifting of radiation into and out of groups is not captured.
 
-   The radiation timescale is set by the courant condition :math:`\Delta t\leq\frac{\Delta x}{3 c_r}`. 
+   The radiation timescale is set by the courant condition :math:`\Delta t\leq\frac{\Delta x}{3 c_r}`.
    For :math:`c_r=c`, this will result in a timestep that is **very** small. Subcycling of radiative transfer
    with respect to hydrodynamics will be implemented soon!
 
    Photochemistry is only supported for six-species: HI, HII, HeI, HeII, HeIII, and :math:`e^-`.
 
-Required Fields 
+Required Fields
 ---------------
 
-The evolved fields are ``"photon_density_i"``, ``"flux_x_i"``, ``"flux_y_i"``, and ``"flux_z_i"``, 
-where photon densities and fluxes are in units of :math:`[L]^{-3}` and :math:`[L]^2[T]^{-1}`, 
+The evolved fields are ``"photon_density_i"``, ``"flux_x_i"``, ``"flux_y_i"``, and ``"flux_z_i"``,
+where photon densities and fluxes are in units of :math:`[L]^{-3}` and :math:`[L]^2[T]^{-1}`,
 respectively, and :math:`i` denotes the group number. A set of fields must be defined for each group, and
 fluxes must be defined in the x, y, and z directions regardless of the dimensionality of the simulation.
 For technical reasons, an additional field called ``"photon_density_i_deposit"`` must be defined for each group.
 
-For example, a simulation that evolves three groups must define these fifteen fields: 
-``"photon_density_0"``, ``"photon_density_0_deposit"``, ``"flux_x_0"``, ``"flux_y_0"``, ``"flux_z_1"``, 
-``"photon_density_1"``, ``"photon_density_1_deposit"``, ``"flux_x_1"``, ``"flux_y_1"``, ``"flux_z_1"``, 
+For example, a simulation that evolves three groups must define these fifteen fields:
+``"photon_density_0"``, ``"photon_density_0_deposit"``, ``"flux_x_0"``, ``"flux_y_0"``, ``"flux_z_1"``,
+``"photon_density_1"``, ``"photon_density_1_deposit"``, ``"flux_x_1"``, ``"flux_y_1"``, ``"flux_z_1"``,
 ``"photon_density_2"``, ``"photon_density_2_deposit"``, ``"flux_x_2"``, ``"flux_y_2"``, ``"flux_z_2"``.
 
 Nine additional fields must be defined corresponding to the elements of the 3D radiation pressure tensor:
-``"P00"``, ``"P01"``, ``"P02"``, 
-``"P10"``, ``"P11"``, ``"P12"``, 
-``"P20"``, ``"P21"``, ``"P22"`` 
+``"P00"``, ``"P01"``, ``"P02"``,
+``"P10"``, ``"P11"``, ``"P12"``,
+``"P20"``, ``"P21"``, ``"P22"``
 Note that only these nine fields are required, regardless of the number of radiation groups specified.
 
-Photionization and heating rates are calculated and stored in the following fields: 
+Photionization and heating rates are calculated and stored in the following fields:
 ``"RT_HI_ionization_rate"``, ``"RT_HeI_ionization_rate"``, ``"RT_HeII_ionization_rate"``, and ``"RT_heating_rate"``.
 
 ``"order_morton"`` method
@@ -729,7 +729,7 @@ parameters
 .. list-table:: Method ``ppm`` parameters
    :widths: 10 5 1 30
    :header-rows: 1
-   
+
    * - Parameter
      - Type
      - Default
@@ -775,7 +775,7 @@ parameters
 .. list-table:: Method ``ppm`` parameters
    :widths: 10 5 1 30
    :header-rows: 1
-   
+
    * - Parameter
      - Type
      - Default
@@ -815,11 +815,11 @@ fields
    * - Field
      - Type
      - Read/Write
-     - Description   
+     - Description
    * - ``"density"``
      - ``enzo_float``
      - [rw]
-     -    
+     -
    * - ``"velocity_x"``
      - ``enzo_float``
      - [rw]

--- a/src/Enzo/particle/CMakeLists.txt
+++ b/src/Enzo/particle/CMakeLists.txt
@@ -1,6 +1,6 @@
 # See LICENSE_CELLO file for license and copyright information
 
-# add source files for 
+# add source files for
 
 # create Enzo::particle, which includes code involving feedback-related
 # particles (e.g. star particles) to the enzo target

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -2,7 +2,7 @@
 function(setup_test_dir TESTDIR)
   # make test directory within build tree (will be used for test output/current working directory)
   file(MAKE_DIRECTORY ${PROJECT_BINARY_DIR}/test/${TESTDIR})
-  # link in input directory because of fixed input file hierarchy 
+  # link in input directory because of fixed input file hierarchy
   file(CREATE_LINK ${PROJECT_SOURCE_DIR}/input ${PROJECT_BINARY_DIR}/test/${TESTDIR}/input SYMBOLIC)
 endfunction()
 


### PR DESCRIPTION
### Pull request summary
 
This introduced a basic configuration file for the [pre-commit](https://pre-commit.com/) software in order to enforce some linters and code-formatting rules.

In general, the pre-commit software was written in python and was originally designed to be use locally (any user of Enzo-E is free to do that). In the original design, it was intended to be used to easily attach varying "lints" to git's "commit-hooks" (specifically the "pre-commit hook", hence the software's name). More recently, pre-commit has become popular for continuous integration. In principle, pre-commit can be used with any arbitrary continuous integration provider (whether it's Jenkins, GitHub Actions, CircleCI, etc.).

We are interested in using [pre-commit.ci](https://pre-commit.ci/), which is a continuous integration service designed around the pre-commit software (the service simply executes the pre-commit software). 
- pre-commit.ci is free for all open-source software. 
- After we set up pre-commit.ci, a check will appear at the bottom of every PR that specifies whether the configured lints passed or failed. 
- The main reason to use it is a powerful feature it provides. If you where add a comment that says "pre-commit.ci autofix" to a PR (where the pre-commit.ci check has failed), the pre-commit.ci service will add a commit to that PR that fixes the formatting.
  - ``yt`` actually makes use of pre-commit.ci. [Here's an example of a comment](https://github.com/yt-project/yt/pull/4099#issuecomment-1229978321) in a pull request that I made to `yt` a while back, where one of the maintainers used pre-commit.ci to reformat my python-code
  - I recently introduced pre-commit.ci to cholla to let us easily call clang-format in this way. It has been extremely useful.

### What does this PR do?

Specifically, this PR adds the configuration file for pre-commit.

For the sake of testing, the primary "lints" are somewhat limited. They include:
- identifying the lines with trailing whitespace. For now, this is limited to the documentation files and the CMake files to be minimally invasive.
- checking whether we have multiple files with names that may produce collisions on file-systems where filenames are not case-sensitive (this was a pain-point for me a little while back on macOS)
- checking that all yaml files in the repository are properly formatted.

### What we need to do after this PR is merged

We will need to go to the [pre-commit.ci](https://pre-commit.ci/) and enable it for the Enzo-E repository. (I'm happy to do that)

### Future Plans

I plan to submit a subsequent PR to have pre-commit drive clang-format for formatting C/C++ code.