### PR TITLE
Fix ReadTheDocs doc CI build

### DIFF
--- a/.readthedocs.yaml
+++ b/.readthedocs.yaml
@@ -16,6 +16,10 @@ python:
    install:
    - requirements: doc/source/requirements.txt
 
+sphinx:
+  # Path to your Sphinx configuration file.
+  configuration: doc/source/conf.py
+
 # Build PDF & ePub
 formats:
   - epub


### PR DESCRIPTION
ReadTheDocs has broken CI builds builds unless you explicitly specify that we are building sphinx docs