### PR TITLE
Fixes issue #426, ensuring that Grackle is compiled with the correct precision (BUG FIX)

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -43,6 +43,21 @@ include("CreateStdFilesystemTarget")
 create_StdFilesystem_target()
 
 #----------------------------------------------------------------------------------------
+# Define precision settings
+
+option(USE_DOUBLE_PREC "Use double precision. Turn off for single precision." ON)
+if (USE_DOUBLE_PREC)
+  add_compile_definitions(CONFIG_PRECISION_DOUBLE)
+  # PREC_STRING is used during test setup
+  set(PREC_STRING "double")
+else()
+  add_compile_definitions(CONFIG_PRECISION_SINGLE)
+  # PREC_STRING is used during test setup
+  set(PREC_STRING "single")
+endif()
+add_compile_definitions(SMALL_INTS)
+
+#----------------------------------------------------------------------------------------
 # External libs
 
 # If the user doesn't specify a build type, prefer Release
@@ -62,18 +77,6 @@ set(Cello_TARGET_LINK_OPTIONS "")
 
 #----------------------------------------------------------------------------------------
 # Define preprocessor definitions/user configuration options
-
-option(USE_DOUBLE_PREC "Use double precision. Turn off for single precision." ON)
-if (USE_DOUBLE_PREC)
-  add_compile_definitions(CONFIG_PRECISION_DOUBLE)
-  # PREC_STRING is used during test setup
-  set(PREC_STRING "double")
-else()
-  add_compile_definitions(CONFIG_PRECISION_SINGLE)
-  # PREC_STRING is used during test setup
-  set(PREC_STRING "single")
-endif()
-add_compile_definitions(SMALL_INTS)
 
 add_compile_definitions(CELLO_VERSION="${CMAKE_PROJECT_VERSION}")
 


### PR DESCRIPTION
### Pull request summary

Fixes issue #426, ensuring that Grackle is compiled with the correct precision

### Detailed Description

I moved the CMake precision setting code to after the external dependencies. It is possible this is not the optimal position, but it should at least resolve the issue.

This is a major change or addition (that needs 2 reviewers): no
