### PR TITLE
Fix to resolve Bug enzo-project/enzo-e#430

### DIFF
--- a/src/Cello/control_compute.cpp
+++ b/src/Cello/control_compute.cpp
@@ -62,8 +62,11 @@ void Block::compute_next_ ()
 
   } else {
 
-    compute_end_();
+    // Barrier before exiting compute to synchronize the updating of
+    // Simulation state variables (time, cycle)
 
+    contribute
+      ( CkCallback (CkIndex_Block::r_compute_end(nullptr), proxy_array()) ) ;
   }
 }
 

--- a/src/Cello/mesh.ci
+++ b/src/Cello/mesh.ci
@@ -129,6 +129,7 @@ module mesh {
 
     entry void p_compute_continue();
     entry void r_compute_continue(CkReductionMsg *);
+    entry void r_compute_end(CkReductionMsg *);
 
     entry void p_compute_exit();
     entry void r_compute_exit(CkReductionMsg *);

--- a/src/Cello/mesh_Block.cpp
+++ b/src/Cello/mesh_Block.cpp
@@ -38,6 +38,7 @@ const char * phase_name[] = {
 
 Block::Block ( process_type ip_source, MsgType msg_type )
   : CBase_Block(),
+    index_(thisIndex),
     data_(NULL),
     child_data_(NULL),
     level_next_(0),
@@ -66,7 +67,8 @@ Block::Block ( process_type ip_source, MsgType msg_type )
     index_method_(-1),
     index_solver_(),
     refresh_(),
-    index_(thisIndex)
+    index_order_(0),
+    count_order_(1)
 {
 #ifdef TRACE_BLOCK
 
@@ -651,6 +653,7 @@ void Block::p_refresh_child
 
 Block::Block ()
   : CBase_Block(),
+    index_(thisIndex),
     data_(NULL),
     child_data_(NULL),
     level_next_(0),
@@ -678,7 +681,9 @@ Block::Block ()
     name_(""),
     index_method_(-1),
     index_solver_(),
-    refresh_()
+    refresh_(),
+    index_order_(0),
+    count_order_(1)
 {
   init_refresh_();
   init_adapt_(nullptr);

--- a/src/Cello/mesh_Block.hpp
+++ b/src/Cello/mesh_Block.hpp
@@ -310,6 +310,11 @@ public: // interface
     delete msg;
     compute_exit_();
   }
+  void r_compute_end(CkReductionMsg * msg)
+  {
+    delete msg;
+    compute_end_();
+  }
 
   /// Return the currently active Method
   int index_method() const throw()


### PR DESCRIPTION
This fixes a synchronization bug in which Simulation time is not updated consistently, such that any methods accessing the current time via the Simulation object (rather than the Block object's copy, which is preferred) will produce small but inconsistent results.

This fix is expected to break some circleci answer tests. A new "gold standard" will need to be generated.

This is a small fix, only one reviewer is needed. I've assigned Matthew since he's adept at updating the gold standard, though if anyone else wants to review that's perfectly fine.